### PR TITLE
Avoid unnecessary rebuilds

### DIFF
--- a/ydb-grpc/build.rs
+++ b/ydb-grpc/build.rs
@@ -19,12 +19,12 @@ const INCLUDE_DIRS: &[&str] = &[
 ];
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=ydb-api-protos");
-
     if std::env::var("CARGO_FEATURE_REGENERATE_SOURCES").unwrap_or("0".into()) != "1" {
         println!("skip regenerate sources");
         return Ok(());
     }
+    
+    println!("cargo:rerun-if-changed=ydb-api-protos");
 
     for (src, dst) in COMPILE_DIRS {
         clean_dst_dir(dst)?;


### PR DESCRIPTION
Crate published on crates.io does not contain ydb-api-protos directory. Hence, `rerun-if-chaned` directive makes cargo rebuild this crate every time. I think (but haven't tested yet) that proposed patch should address this issue.