### PR TITLE
rename directory_client to scheme_client

### DIFF
--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -1,5 +1,5 @@
 use crate::client_common::DBCredentials;
-use crate::client_directory::DirectoryClient;
+use crate::client_directory::SchemeClient;
 use crate::client_table::TableClient;
 use crate::discovery::Discovery;
 use crate::errors::YdbResult;
@@ -47,8 +47,8 @@ impl Client {
     }
 
     /// Create instance of client for directory service
-    pub fn directory_client(&self) -> DirectoryClient {
-        DirectoryClient::new(
+    pub fn scheme_client(&self) -> SchemeClient {
+        SchemeClient::new(
             self.credentials.clone(),
             self.discovery.clone(),
             self.timeouts,

--- a/ydb/src/client_directory.rs
+++ b/ydb/src/client_directory.rs
@@ -1,25 +1,26 @@
 use std::sync::Arc;
 
-use ydb_grpc::ydb_proto::scheme::{Entry, ListDirectoryRequest, ListDirectoryResult, MakeDirectoryRequest, RemoveDirectoryRequest};
 use ydb_grpc::ydb_proto::scheme::v1::scheme_service_client::SchemeServiceClient;
+use ydb_grpc::ydb_proto::scheme::{
+    Entry, ListDirectoryRequest, ListDirectoryResult, MakeDirectoryRequest, RemoveDirectoryRequest,
+};
 
-use crate::{Discovery, YdbResult};
 use crate::channel_pool::{ChannelPool, ChannelPoolImpl};
 use crate::client::{Middleware, TimeoutSettings};
 use crate::client_common::DBCredentials;
 use crate::discovery::Service;
 use crate::grpc::{grpc_read_operation_result, grpc_read_void_operation_result, operation_params};
+use crate::{Discovery, YdbResult};
 
 pub(crate) type DirectoryServiceClientType = SchemeServiceClient<Middleware>;
 pub(crate) type DirectoryServiceChannelPool = Arc<Box<dyn ChannelPool<DirectoryServiceClientType>>>;
 
-
-pub struct DirectoryClient {
+pub struct SchemeClient {
     timeouts: TimeoutSettings,
     channel_pool: DirectoryServiceChannelPool,
 }
 
-impl DirectoryClient {
+impl SchemeClient {
     pub(crate) fn new(
         credentials: DBCredentials,
         discovery: Arc<Box<dyn Discovery>>,
@@ -46,7 +47,8 @@ impl DirectoryClient {
             .make_directory(MakeDirectoryRequest {
                 operation_params: operation_params(self.timeouts.operation_timeout),
                 path,
-            }).await?;
+            })
+            .await?;
 
         grpc_read_void_operation_result(resp)
     }
@@ -59,7 +61,8 @@ impl DirectoryClient {
             .list_directory(ListDirectoryRequest {
                 operation_params: operation_params(self.timeouts.operation_timeout),
                 path,
-            }).await?;
+            })
+            .await?;
 
         let result: ListDirectoryResult = grpc_read_operation_result(resp)?;
         Ok(result.children)
@@ -73,7 +76,8 @@ impl DirectoryClient {
             .remove_directory(RemoveDirectoryRequest {
                 operation_params: operation_params(self.timeouts.operation_timeout),
                 path,
-            }).await?;
+            })
+            .await?;
 
         grpc_read_void_operation_result(resp)
     }

--- a/ydb/src/client_directory_test_integration.rs
+++ b/ydb/src/client_directory_test_integration.rs
@@ -11,7 +11,7 @@ use crate::test_integration_helper::create_client;
 #[ignore] // need YDB access
 async fn create_list_remove_directory() -> YdbResult<()> {
     let client = create_client().await?;
-    let mut scheme_client = client.directory_client();
+    let mut scheme_client = client.scheme_client();
     let time_now = time::SystemTime::now().duration_since(UNIX_EPOCH)?;
     let directory_name = format!("directory_{}", time_now.as_millis());
     let directory_path = format!("local/{}", directory_name.clone());
@@ -26,4 +26,3 @@ async fn create_list_remove_directory() -> YdbResult<()> {
 
     Ok(())
 }
-

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -48,14 +48,12 @@ mod channel_pool;
 pub(crate) mod client;
 mod client_builder;
 pub(crate) mod client_common;
-pub(crate) mod client_table;
 pub(crate) mod client_directory;
 #[cfg(test)]
-mod client_table_test_integration;
-#[cfg(test)]
 mod client_directory_test_integration;
+pub(crate) mod client_table;
 #[cfg(test)]
-mod test_integration_helper;
+mod client_table_test_integration;
 mod credentials;
 pub(crate) mod discovery;
 mod errors;
@@ -69,6 +67,8 @@ mod session;
 mod session_pool;
 mod sugar;
 mod test_helpers;
+#[cfg(test)]
+mod test_integration_helper;
 mod trait_operation;
 pub(crate) mod transaction;
 mod types;
@@ -82,7 +82,7 @@ pub use client_builder::ClientBuilder;
 // full enum pub types
 pub use client_table::{RetryOptions, TableClient, TransactionOptions};
 // full enum pub types
-pub use client_directory::{DirectoryClient};
+pub use client_directory::SchemeClient;
 // full enum pub types
 pub use discovery::{Discovery, DiscoveryState, StaticDiscovery};
 // full enum pub types


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

client.DirectoryClient renamed to client SchemeClient similar to other sdks