### PR TITLE
remove cache from publish crate. Publish process doesn't use the cache.

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -44,19 +44,4 @@ jobs:
         with:
           token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
 
-      - name: Cache
-        uses: actions/cache@v3
-        with:
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-            ~/.cargo/.crates2.json
-            ~/.cargo/.package-cache
-            ~/.cargo/registry/
-            ~/.cargo/git/db/
-            target/
-
       - run: ./.github/scripts/version-up.sh "${{ github.event.inputs.crate }}" "${{ github.event.inputs.version-part }}" "$GIT_EMAIL"

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -38,9 +38,7 @@ jobs:
     - name: Cache
       uses: actions/cache@v3
       with:
-        key: ${{ runner.os }}-${{env.RUST_VERSION}}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{env.RUST_VERSION}}-cargo-
+        key: ${{ runner.os }}-${{env.RUST_VERSION}}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
         path: |
           ~/.cargo/bin/
           ~/.cargo/.crates.toml


### PR DESCRIPTION
Remove fallback cache to old versions: it increase cache size with every new version.

Better to once full rebuild cache after publish new version. It did while run tests after publish tag.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
fallback to old cache when can't file cache to current lock file.

## New behavior
No fallback to old cache state for prevent cache size increase
