### PR TITLE
no bump new version for dependencies

### DIFF
--- a/.github/scripts/version-up.sh
+++ b/.github/scripts/version-up.sh
@@ -110,11 +110,9 @@ function bump_version() {
       ;;
     ydb-grpc)
       version_dep_set "ydb" "ydb-grpc" "$VERSION"
-      bump_version "ydb" patch
       ;;
     ydb-grpc-helpers)
       version_dep_set "ydb-grpc" "ydb-grpc-helpers" "$VERSION"
-      bump_version "ydb-grpc" patch
       ;;
     *)
       echo "Unexpected crate name '$CRATE_NAME'"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "ydb-grpc"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "pbjson",
  "pbjson-build",

--- a/ydb-grpc/Cargo.toml
+++ b/ydb-grpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = true
 name = "ydb-grpc"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["rekby <timofey.koolin@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = "0.3"
 tonic = {version="0.7", features=["tls"]}
 tower = "0.4"
 url="2.2"
-ydb-grpc = { version = "0.0.7", path="../ydb-grpc"}
+ydb-grpc = { version = "0.0.8", path="../ydb-grpc"}
 
 [dev-dependencies]
 async_once="0.2"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

while publish any crate - auto bump and publish new version for higher-level crate

## What is the new behavior?

change version and publish only selected crate