### PR TITLE
fix directory client test - use database from credentials instead of hardcoded /local

### DIFF
--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -37,6 +37,10 @@ impl Client {
         });
     }
 
+    pub(crate) fn database(&self) -> String {
+        return self.credentials.database.clone();
+    }
+
     /// Create instance of client for table service
     pub fn table_client(&self) -> TableClient {
         return TableClient::new(

--- a/ydb/src/client_directory.rs
+++ b/ydb/src/client_directory.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use tracing::trace;
 
 use ydb_grpc::ydb_proto::scheme::v1::scheme_service_client::SchemeServiceClient;
 use ydb_grpc::ydb_proto::scheme::{
@@ -40,28 +41,38 @@ impl SchemeClient {
     }
 
     pub async fn make_directory(&mut self, path: String) -> YdbResult<()> {
+        let req = MakeDirectoryRequest {
+            operation_params: operation_params(self.timeouts.operation_timeout),
+            path,
+        };
+        trace!(
+            "make directory request: {}",
+            serde_json::to_string(&req).unwrap_or("bad json".into())
+        );
         let resp = self
             .channel_pool
             .create_channel()
             .await?
-            .make_directory(MakeDirectoryRequest {
-                operation_params: operation_params(self.timeouts.operation_timeout),
-                path,
-            })
+            .make_directory(req)
             .await?;
 
         grpc_read_void_operation_result(resp)
     }
 
     pub async fn list_directory(&mut self, path: String) -> YdbResult<Vec<Entry>> {
+        let req = ListDirectoryRequest {
+            operation_params: operation_params(self.timeouts.operation_timeout),
+            path,
+        };
+        trace!(
+            "list directory request: {}",
+            serde_json::to_string(&req).unwrap_or("bad json".into())
+        );
         let resp = self
             .channel_pool
             .create_channel()
             .await?
-            .list_directory(ListDirectoryRequest {
-                operation_params: operation_params(self.timeouts.operation_timeout),
-                path,
-            })
+            .list_directory(req)
             .await?;
 
         let result: ListDirectoryResult = grpc_read_operation_result(resp)?;
@@ -69,14 +80,19 @@ impl SchemeClient {
     }
 
     pub async fn remove_directory(&mut self, path: String) -> YdbResult<()> {
+        let req = RemoveDirectoryRequest {
+            operation_params: operation_params(self.timeouts.operation_timeout),
+            path,
+        };
+        trace!(
+            "remove directory request: {}",
+            serde_json::to_string(&req).unwrap_or("bad json".into())
+        );
         let resp = self
             .channel_pool
             .create_channel()
             .await?
-            .remove_directory(RemoveDirectoryRequest {
-                operation_params: operation_params(self.timeouts.operation_timeout),
-                path,
-            })
+            .remove_directory(req)
             .await?;
 
         grpc_read_void_operation_result(resp)

--- a/ydb/src/client_directory_test_integration.rs
+++ b/ydb/src/client_directory_test_integration.rs
@@ -11,17 +11,18 @@ use crate::test_integration_helper::create_client;
 #[ignore] // need YDB access
 async fn create_list_remove_directory() -> YdbResult<()> {
     let client = create_client().await?;
+    let database_path = client.database();
     let mut scheme_client = client.scheme_client();
     let time_now = time::SystemTime::now().duration_since(UNIX_EPOCH)?;
     let directory_name = format!("directory_{}", time_now.as_millis());
-    let directory_path = format!("local/{}", directory_name.clone());
+    let directory_path = format!("{}/{}", database_path, directory_name.clone());
 
     scheme_client.make_directory(directory_path.clone()).await?;
-    let directories = scheme_client.list_directory("local/".to_owned()).await?;
+    let directories = scheme_client.list_directory(database_path.clone()).await?;
     assert!(directories.iter().any(|d| d.name == directory_name));
 
     scheme_client.remove_directory(directory_path).await?;
-    let directories = scheme_client.list_directory("local/".to_owned()).await?;
+    let directories = scheme_client.list_directory(database_path).await?;
     assert!(!directories.iter().any(|d| d.name == directory_name));
 
     Ok(())


### PR DESCRIPTION


I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

use hardcoded /local database path for directory client tests

## What is the new behavior?
Use database from credentials