### PR TITLE
fix submodule path from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ydb-api-protos"]
 	path = ydb-grpc/ydb-api-protos
-	url = git@github.com:ydb-platform/ydb-api-protos.git
+	url = https://github.com/ydb-platform/ydb-api-protos.git


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?
Link to submodule by ssh scheme

## What is the new behavior?
Link to submodule by https

It allow anonymous clone.
