### PR TITLE
fix sent rust sdk version in headers

### DIFF
--- a/ydb/src/grpc_wrapper/auth.rs
+++ b/ydb/src/grpc_wrapper/auth.rs
@@ -4,6 +4,8 @@ use tonic::metadata::AsciiMetadataValue;
 use tonic::service::Interceptor;
 use tonic::{Code, Status};
 
+const VERSION_LABEL: &str = concat!("ydb-rust-sdk/", env!("CARGO_PKG_VERSION"));
+
 pub(crate) type ServiceWithAuth<S> = InterceptedService<S, AuthInterceptor>;
 
 pub(crate) fn create_service_with_auth<S>(service: S, cred: DBCredentials) -> ServiceWithAuth<S> {
@@ -39,7 +41,7 @@ impl Interceptor for AuthInterceptor {
         request.metadata_mut().insert("x-ydb-auth-ticket", token);
         request.metadata_mut().insert(
             "x-ydb-sdk-build-info",
-            AsciiMetadataValue::from_str("ydb-go-sdk/0.0.0").unwrap(),
+            AsciiMetadataValue::from_str(VERSION_LABEL).unwrap(),
         );
         Ok(request)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Sent const version: ydb-go-sdk/0.0.0

## What is the new behavior?

Sent "ydb-rust-sdk/" + current crate version.
