### PR TITLE
use latest v2 cache version

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -43,7 +43,7 @@ jobs:
         echo "::set-output name=version::$(rustc --version | cut -d ' ' -f 2)"
 
     - name: Rust cache
-      uses: Swatinem/rust-cache@v2.0.0
+      uses: Swatinem/rust-cache@v2
 
     - name: Build
       run: cargo build --verbose --workspace --all-targets


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Use latest rust-cache from v2 line.