### PR TITLE
add support null type in response

### DIFF
--- a/ydb/src/client_table_test_integration.rs
+++ b/ydb/src/client_table_test_integration.rs
@@ -476,10 +476,7 @@ SELECT NULL
     let res = res.results.into_iter().next().unwrap();
     assert_eq!(1, res.columns().len());
 
-    assert_eq!(
-        Value::optional_from(Value::Void, None)?,
-        res.rows().next().unwrap().remove_field(0)?
-    );
+    assert_eq!(Value::Null, res.rows().next().unwrap().remove_field(0)?);
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

panic for null type in response

## What is the new behavior?
allow to parse null type and return Value::Null (new variant).
