### PR TITLE
use new rust version for publish crate

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,7 +1,7 @@
 name: Publish rust crate to crates.io
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.56.1
+  RUST_VERSION: 1.65.0
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Publish crate with oldest rust

## What is the new behavior?
Publish crate with newest rust
