### PR TITLE
optimize and simplify publish script

### DIFF
--- a/.github/scripts/version-up.sh
+++ b/.github/scripts/version-up.sh
@@ -25,21 +25,7 @@ function publish_crate() {
     local CRATE_NAME="$1"
     (
       cd "$CRATE_NAME"
-
-      local SUCCESS=0
-      for TRY_COUNTER in $(seq 0 10); do
-        [ "$TRY_COUNTER" != "0" ] && echo "retry count: $TRY_COUNTER" && sleep 60
-
-        if cargo publish; then
-          SUCCESS=1
-          break
-        fi
-      done
-
-      if [ "$SUCCESS" == "0" ]; then
-        echo "Publish crate '$CRATE_NAME' failed."
-        return 1
-      fi
+      cargo publish
     )
 }
 
@@ -123,9 +109,6 @@ function bump_version() {
 }
 
 bump_version "$CRATE_NAME" "$VERSION_PART"
-
-# Force update Cargo.toml for new versions
-cargo check
 
 git diff
 


### PR DESCRIPTION
new cargo wait of previous package published before exit, no need real reason for retry publish now. It was need only for wait of previous package available.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
cargo check before publish
retry cargo publish few times

## What is the new behavior?
do cargo publish once, without check.

compile much faster and no need explicit check for optimize speed.
no publish few packages same time and cargo already can wait about published package available, unavailable of previous package was only reason of retry was added.
