### PR TITLE
update crate to rust 1.67

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,7 +1,7 @@
 name: Publish rust crate to crates.io
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.66.0
+  RUST_VERSION: 1.67.0
 
 on:
   workflow_dispatch:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [ "1.56.0", "1.66.0" ]
+        rust_version: [ "1.56.0", "1.67.0" ]
 
     services:
       ydb:
@@ -64,7 +64,7 @@ jobs:
     - name: Linter
       if: matrix.rust_version != '1.56.0'
       run: |
-        cargo clippy --workspace --all-targets -- -D warnings
+        cargo clippy --workspace --all-targets -- -D warnings -A clippy::uninlined_format_args
 
     - name: Run tests
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "ydb"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "async_once",

--- a/ydb-grpc/build.rs
+++ b/ydb-grpc/build.rs
@@ -1,5 +1,5 @@
 use std::fs::OpenOptions;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, Write};
 use std::path::PathBuf;
 use std::{fs, io};
 use walkdir::WalkDir;
@@ -118,7 +118,7 @@ fn fix_generated_file(fpath: &std::path::Path) -> io::Result<()> {
         .collect();
 
     let contents = lines.join("\n");
-    f.seek(SeekFrom::Start(0))?;
+    f.rewind()?;
     f.set_len(0)?;
     f.write_all(contents.as_bytes())?;
     Ok(())

--- a/ydb/src/transaction.rs
+++ b/ydb/src/transaction.rs
@@ -154,7 +154,7 @@ impl Drop for SerializableReadWriteTx {
         if !self.finished {
             if let (Some(tx_id), Some(mut session)) = (self.id.take(), self.session.take()) {
                 tokio::spawn(async move {
-                    let _ = session.rollback_transaction(tx_id);
+                    let _ = session.rollback_transaction(tx_id).await;
                 });
             };
         };


### PR DESCRIPTION
fix bug about rollback unfinished transaction

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Check sdk for rust 1.66
Forgot about await for rollback transaction if it drop unfinished

## What is the new behavior?
check sdk fro rust 1.67
await the rollback
