### PR TITLE
Prevent a minute wait for wait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "ydb"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "async_once",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "ydb-grpc"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "pbjson",
  "pbjson-build",

--- a/ydb/src/client_builder.rs
+++ b/ydb/src/client_builder.rs
@@ -150,6 +150,7 @@ impl ClientBuilder {
                 discovery_connection_manager,
                 self.endpoint.as_str(),
                 self.discovery_interval,
+                Box::new(db_cred.token_cache.clone()),
             )?),
         };
 


### PR DESCRIPTION
…irst discovery.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

Start discovery immediately. Often discovery started before auth token ready and got auth error. Then wait a minute before retry.

## What is the new behavior?

Wait first get token get result before start first discovery. It allow to do first discovery with good token.
