### PR TITLE
set minimum rust version in cargo.toml and remove manual ignore warning in clippy command

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Linter
       if: matrix.rust_version != '1.56.0'
       run: |
-        cargo clippy --workspace --all-targets -- -D warnings -A clippy::uninlined_format_args
+        cargo clippy --workspace --all-targets -- -D warnings
 
     - name: Run tests
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "ydb"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "async_once",

--- a/ydb-example-urlshortener/Cargo.toml
+++ b/ydb-example-urlshortener/Cargo.toml
@@ -3,6 +3,7 @@ publish=false
 name = "ydb-example-urlshortener"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ydb-grpc-helpers/Cargo.toml
+++ b/ydb-grpc-helpers/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 description = "Deprecated, not used now. Crate contain helpers for generate grpc imports in ydb-grpc crate."
 repository = "https://github.com/ydb-platform/ydb-rs-sdk/tree/ydb-grpc-helpers-0.0.11/ydb-grpc-helpers"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/ydb-grpc/Cargo.toml
+++ b/ydb-grpc/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Crate contains generated low-level grpc code from YDB API protobuf, used as base for ydb crate"
 repository = "https://github.com/ydb-platform/ydb-rs-sdk/tree/master/ydb-grpc"
+rust-version = "1.56"
 
 [dependencies]
 prost = "0.11.2"

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Crate contains generated low-level grpc code from YDB API protobuf, used as base for ydb crate"
 repository = "https://github.com/ydb-platform/ydb-rs-sdk/tree/master/ydb"
+rust-version = "1.56"
 
 [dependencies]
 async-trait="0.1"


### PR DESCRIPTION
…lippy.

for future it will use for better show error about unsupported rust version.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):
