### PR TITLE
update rust to 1.69

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,7 +1,7 @@
 name: Publish rust crate to crates.io
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.68.0
+  RUST_VERSION: 1.69.0
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 on:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [ "1.56.0", "1.68.0" ]
+        rust_version: [ "1.56.0", "1.69.0" ]
 
     services:
       ydb:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "ydb"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "async_once",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Test rust 1.69 as newest + linter

