### PR TITLE
change YdbIssue.severity type from u32 to YdbIssueSeverity, remove YdbIssue.severity() func

### DIFF
--- a/ydb/src/grpc_wrapper/grpc.rs
+++ b/ydb/src/grpc_wrapper/grpc.rs
@@ -53,7 +53,7 @@ pub(crate) fn proto_issues_to_ydb_issues(proto_issues: Vec<IssueMessage>) -> Vec
             issue_code: proto_issue.issue_code,
             message: proto_issue.message,
             issues: proto_issues_to_ydb_issues(proto_issue.issues),
-            severity: proto_issue.severity,
+            severity: proto_issue.severity.into(),
         })
         .collect()
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?
