### PR TITLE
Add determined by environment variables credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "ydb"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "async_once",

--- a/ydb/examples/auth-env-connection-string.rs
+++ b/ydb/examples/auth-env-connection-string.rs
@@ -1,10 +1,10 @@
-use ydb::{ClientBuilder, Query, YandexMetadata, YdbResult};
+use ydb::{ClientBuilder, MetadataUrlCredentials, Query, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
     let client =
         ClientBuilder::new_from_connection_string(std::env::var("YDB_CONNECTION_STRING")?)?
-            .with_credentials(YandexMetadata::new())
+            .with_credentials(MetadataUrlCredentials::new())
             .client()?;
     client.wait().await?;
     let sum: i32 = client

--- a/ydb/examples/auth-static-credentials.rs
+++ b/ydb/examples/auth-static-credentials.rs
@@ -1,17 +1,18 @@
-use ydb::{ClientBuilder, Query, StaticCredentialsAuth, YdbResult};
+use ydb::{ClientBuilder, Query, StaticCredentials, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
     println!("create client...");
-    let client = ClientBuilder::new_from_connection_string("grpc://localhost:2136/local".to_string())
-        .unwrap()
-        .with_credentials(StaticCredentialsAuth::new(
-            "root".to_string(),
-            "1234".to_string(),
-            http::uri::Uri::from_static("grpc://localhost:2136/local"),
-            "local".to_string(),
-        ))
-        .client()?;
+    let client =
+        ClientBuilder::new_from_connection_string("grpc://localhost:2136/local".to_string())
+            .unwrap()
+            .with_credentials(StaticCredentials::new(
+                "root".to_string(),
+                "1234".to_string(),
+                http::uri::Uri::from_static("grpc://localhost:2136/local"),
+                "local".to_string(),
+            ))
+            .client()?;
     client.wait().await?;
 
     println!("created\nmake a query...");

--- a/ydb/examples/auth-token.rs
+++ b/ydb/examples/auth-token.rs
@@ -1,9 +1,9 @@
-use ydb::{ClientBuilder, Query, StaticToken, YdbResult};
+use ydb::{AccessTokenCredentials, ClientBuilder, Query, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
     let client = ClientBuilder::new_from_connection_string("grpc://localhost:2136?database=local")?
-        .with_credentials(StaticToken::from("asd"))
+        .with_credentials(AccessTokenCredentials::from("asd"))
         .client()?;
     client.wait().await?;
     let sum: i32 = client

--- a/ydb/examples/auth-yc-cmdline.rs
+++ b/ydb/examples/auth-yc-cmdline.rs
@@ -1,9 +1,9 @@
-use ydb::{ClientBuilder, CommandLineYcToken, Query, YdbResult};
+use ydb::{ClientBuilder, CommandLineCredentials, Query, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
     let client = ClientBuilder::new_from_connection_string("grpc://localhost:2136?database=local")?
-        .with_credentials(CommandLineYcToken::from_cmd("yc iam create-token")?)
+        .with_credentials(CommandLineCredentials::from_cmd("yc iam create-token")?)
         .client()?;
     client.wait().await?;
     let sum: i32 = client

--- a/ydb/examples/auth-ycloud-metadata.rs
+++ b/ydb/examples/auth-ycloud-metadata.rs
@@ -1,9 +1,9 @@
-use ydb::{ClientBuilder, Query, YandexMetadata, YdbResult};
+use ydb::{ClientBuilder, MetadataUrlCredentials, Query, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
     let client = ClientBuilder::new_from_connection_string("grpc://localhost:2136?database=local")?
-        .with_credentials(YandexMetadata::new())
+        .with_credentials(MetadataUrlCredentials::new())
         .client()?;
     client.wait().await?;
     let sum: i32 = client

--- a/ydb/examples/auth-ycloud-serviceaccount.rs
+++ b/ydb/examples/auth-ycloud-serviceaccount.rs
@@ -14,7 +14,7 @@ async fn main() -> YdbResult<()> {
     let client = ClientBuilder::new_from_connection_string(connection_string)?
         // get credentials from file located at path specified in YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS
         .with_credentials(ServiceAccountCredentials::from_env()?)
-        //  or for yandex cloud credentials from env:
+        //  or with credentials from env:
         // .with_credentials(FromEnvCredentials::new()?)
         // or you can use custom url
         // .with_credentials(ServiceAccountCredentials::from_env()?.with_url("https://iam.api.cloud.yandex.net/iam/v1/tokens"))

--- a/ydb/examples/auth-ycloud-serviceaccount.rs
+++ b/ydb/examples/auth-ycloud-serviceaccount.rs
@@ -14,6 +14,8 @@ async fn main() -> YdbResult<()> {
     let client = ClientBuilder::new_from_connection_string(connection_string)?
         // get credentials from file located at path specified in YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS
         .with_credentials(ServiceAccountCredentials::from_env()?)
+        //  or for yandex cloud credentials from env:
+        // .with_credentials(FromEnvCredentials::new()?)
         // or you can use custom url
         // .with_credentials(ServiceAccountCredentials::from_env()?.with_url("https://iam.api.cloud.yandex.net/iam/v1/tokens"))
         .client()?;

--- a/ydb/src/auth_test.rs
+++ b/ydb/src/auth_test.rs
@@ -3,7 +3,7 @@ use tracing::trace;
 use tracing_test::traced_test;
 
 use crate::{
-    credentials::StaticCredentialsAuth, pub_traits::Credentials, test_helpers::CONNECTION_STRING,
+    credentials::StaticCredentials, pub_traits::Credentials, test_helpers::CONNECTION_STRING,
     test_integration_helper::create_password_client, Query, Transaction, YdbResult,
 };
 
@@ -14,7 +14,7 @@ fn auth_success_test() -> YdbResult<()> {
     let uri = http::uri::Uri::from_static(&(CONNECTION_STRING));
 
     let database = uri.path().to_string();
-    let up_auth = StaticCredentialsAuth::new("root".to_string(), "1234".to_string(), uri, database);
+    let up_auth = StaticCredentials::new("root".to_string(), "1234".to_string(), uri, database);
 
     let token_sec = up_auth.create_token()?.token;
     let raw_token = token_sec.expose_secret();
@@ -34,7 +34,7 @@ async fn auth_async_success_test() -> YdbResult<()> {
     let uri = http::uri::Uri::from_static(&(CONNECTION_STRING));
 
     let database = uri.path().to_string();
-    let up_auth = StaticCredentialsAuth::new("root".to_string(), "1234".to_string(), uri, database);
+    let up_auth = StaticCredentials::new("root".to_string(), "1234".to_string(), uri, database);
 
     let token_sec = std::thread::spawn(move || up_auth.create_token())
         .join()
@@ -58,7 +58,7 @@ async fn auth_async_success_test() -> YdbResult<()> {
 async fn wrong_username_test() {
     let uri = http::uri::Uri::from_static(&(CONNECTION_STRING));
     let database = uri.path().to_string();
-    let up_auth = StaticCredentialsAuth::new(
+    let up_auth = StaticCredentials::new(
         "wr0n9_u$ern@me".to_string(),
         "1234".to_string(),
         uri,
@@ -75,7 +75,7 @@ async fn wrong_username_test() {
 async fn wrong_password_test() {
     let uri = http::uri::Uri::from_static(&(CONNECTION_STRING));
     let database = uri.path().to_string();
-    let up_auth = StaticCredentialsAuth::new(
+    let up_auth = StaticCredentials::new(
         "root".to_string(),
         "wr0n9_p@$$w0rd".to_string(),
         uri,

--- a/ydb/src/client_builder.rs
+++ b/ydb/src/client_builder.rs
@@ -1,6 +1,6 @@
 use crate::client_common::{DBCredentials, TokenCache};
 use crate::credentials::{
-    credencials_ref, CredentialsRef, GCEMetadata, StaticCredentialsAuth, StaticToken,
+    credencials_ref, AccessTokenCredentials, CredentialsRef, GCEMetadata, StaticCredentials,
 };
 use crate::dicovery_pessimization_interceptor::DiscoveryPessimizationInterceptor;
 use crate::discovery::{Discovery, TimerDiscovery};
@@ -64,8 +64,9 @@ fn token(uri: &str, mut client_builder: ClientBuilder) -> YdbResult<ClientBuilde
             continue;
         };
 
-        client_builder.credentials =
-            credencials_ref(crate::credentials::StaticToken::from(value.as_ref()));
+        client_builder.credentials = credencials_ref(
+            crate::credentials::AccessTokenCredentials::from(value.as_ref()),
+        );
     }
     Ok(client_builder)
 }
@@ -77,7 +78,7 @@ fn token_cmd(uri: &str, mut client_builder: ClientBuilder) -> YdbResult<ClientBu
         };
 
         client_builder.credentials = credencials_ref(
-            crate::credentials::CommandLineYcToken::from_cmd(value.as_ref())?,
+            crate::credentials::CommandLineCredentials::from_cmd(value.as_ref())?,
         );
     }
     Ok(client_builder)
@@ -140,7 +141,7 @@ fn token_static_password(uri: &str, mut client_builder: ClientBuilder) -> YdbRes
 
     let endpoint: Uri = Uri::from_str(client_builder.endpoint.as_str())?;
 
-    client_builder.credentials = credencials_ref(StaticCredentialsAuth::new(
+    client_builder.credentials = credencials_ref(StaticCredentials::new(
         username,
         password,
         endpoint,
@@ -249,7 +250,7 @@ impl ClientBuilder {
 
     fn new() -> Self {
         Self {
-            credentials: credencials_ref(StaticToken::from("")),
+            credentials: credencials_ref(AccessTokenCredentials::from("")),
             database: "/local".to_string(),
             discovery_interval: Duration::from_secs(60),
             endpoint: "grpc://localhost:2135".to_string(),

--- a/ydb/src/credentials.rs
+++ b/ydb/src/credentials.rs
@@ -65,6 +65,23 @@ impl MetadataUrlCredentials {
             inner: GCEMetadata::from_url(YC_METADATA_URL).unwrap(),
         }
     }
+
+    /// Create GCEMetadata with custom url (may need for debug or spec infrastructure with non standard metadata)
+    ///
+    /// Example:
+    /// ```
+    /// # use ydb::YdbResult;
+    /// # fn main()->YdbResult<()>{
+    /// use ydb::MetadataUrlCredentials;
+    /// let cred = MetadataUrlCredentials::from_url("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")?;
+    /// # return Ok(());
+    /// # }
+    /// ```
+    pub fn from_url<T: Into<String>>(url: T) -> YdbResult<Self> {
+        Ok(Self {
+            inner: GCEMetadata::from_url(url)?,
+        })
+    }
 }
 
 impl Credentials for MetadataUrlCredentials {

--- a/ydb/src/credentials.rs
+++ b/ydb/src/credentials.rs
@@ -76,9 +76,27 @@ impl Credentials for AnonymousCredentials {
     }
 }
 
+pub struct FromEnvCredentials {
+    inner: Box<dyn Credentials>,
+}
+
 /// Select credentials from environment
 /// reference: https://ydb.tech/docs/en/reference/ydb-sdk/auth
-pub fn get_credentials_from_env() -> YdbResult<Box<dyn Credentials>> {
+impl FromEnvCredentials {
+    pub fn new() -> YdbResult<Self> {
+        Ok(Self {
+            inner: get_credentials_from_env()?,
+        })
+    }
+}
+
+impl Credentials for FromEnvCredentials {
+    fn create_token(&self) -> YdbResult<TokenInfo> {
+        self.inner.create_token()
+    }
+}
+
+fn get_credentials_from_env() -> YdbResult<Box<dyn Credentials>> {
     if let Ok(file_creds) = env::var(YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS) {
         return Ok(Box::new(ServiceAccountCredentials::from_file(file_creds)?));
     }

--- a/ydb/src/credentials.rs
+++ b/ydb/src/credentials.rs
@@ -144,7 +144,7 @@ impl AccessTokenCredentials {
     ///
     /// Example:
     /// ```
-    /// # use ydb::StaticToken;
+    /// # use ydb::AccessTokenCredentials;
     /// AccessTokenCredentials::from("asd");
     /// ```
     pub fn from<T: Into<String>>(token: T) -> Self {

--- a/ydb/src/credentials.rs
+++ b/ydb/src/credentials.rs
@@ -25,7 +25,7 @@ const YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS: &str = "YDB_SERVICE_ACCOUNT_KEY_
 const YDB_METADATA_CREDENTIALS: &str = "YDB_METADATA_CREDENTIALS";
 const YDB_ACCESS_TOKEN_CREDENTIALS: &str = "YDB_ACCESS_TOKEN_CREDENTIALS";
 
-const YDB_METADATA_URL: &str =
+pub const YDB_METADATA_URL: &str =
     "http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token";
 
 const EMPTY_TOKEN: &str = "";
@@ -450,7 +450,7 @@ impl GCEMetadata {
     /// # use ydb::YdbResult;
     /// # fn main()->YdbResult<()>{
     /// use ydb::GCEMetadata;
-    /// let cred = GCEMetadata::from_url(YDB_METADATA_URL)?;
+    /// let cred = GCEMetadata::from_url("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token")?;
     /// # return Ok(());
     /// # }
     /// ```

--- a/ydb/src/credentials.rs
+++ b/ydb/src/credentials.rs
@@ -32,6 +32,8 @@ const EMPTY_TOKEN: &str = "";
 
 pub type MetadataUrlCredentials = GCEMetadata;
 pub type AccessTokenCredentials = StaticToken;
+pub type CommandLineCredentials = CommandLineYcToken;
+pub type StaticCredentials = StaticCredentialsAuth;
 
 pub(crate) type CredentialsRef = Arc<Box<dyn Credentials>>;
 

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -143,9 +143,8 @@ pub use waiter::Waiter;
 // full enum pub types
 pub use crate::{
     credentials::{
-        get_credentials_from_env, AccessTokenCredentials, AnonymousCredentials,
-        CommandLineCredentials, GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials,
-        StaticCredentials,
+        AccessTokenCredentials, AnonymousCredentials, CommandLineCredentials, FromEnvCredentials,
+        GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials, StaticCredentials,
     },
     errors::{
         YdbError, YdbIssue, YdbIssueSeverity, YdbOrCustomerError, YdbResult,
@@ -157,6 +156,7 @@ pub use crate::{
 
 // deprecated types
 
+#[allow(deprecated)]
 pub use crate::credentials::{
     CommandLineYcToken, StaticCredentialsAuth, StaticToken, YandexMetadata,
 };

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -143,9 +143,9 @@ pub use waiter::Waiter;
 // full enum pub types
 pub use crate::{
     credentials::{
-        AccessTokenCredentials, AnonymousCredentials, CommandLineYcToken, FromEnvCredentials,
-        GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials, StaticCredentialsAuth,
-        StaticToken, YandexMetadata,
+        AccessTokenCredentials, AnonymousCredentials, CommandLineCredentials, CommandLineYcToken,
+        FromEnvCredentials, GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials,
+        StaticCredentials, StaticCredentialsAuth, StaticToken, YandexMetadata,
     },
     errors::{
         YdbError, YdbIssue, YdbIssueSeverity, YdbOrCustomerError, YdbResult,

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -143,8 +143,9 @@ pub use waiter::Waiter;
 // full enum pub types
 pub use crate::{
     credentials::{
-        CommandLineYcToken, FromEnvCredentials, GCEMetadata, ServiceAccountCredentials,
-        StaticCredentialsAuth, StaticToken, YandexMetadata,
+        AccessTokenCredentials, AnonymousCredentials, CommandLineYcToken, FromEnvCredentials,
+        GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials, StaticCredentialsAuth,
+        StaticToken, YandexMetadata,
     },
     errors::{
         YdbError, YdbIssue, YdbIssueSeverity, YdbOrCustomerError, YdbResult,

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -143,8 +143,8 @@ pub use waiter::Waiter;
 // full enum pub types
 pub use crate::{
     credentials::{
-        CommandLineYcToken, GCEMetadata, ServiceAccountCredentials, StaticCredentialsAuth,
-        StaticToken, YandexMetadata,
+        CommandLineYcToken, FromEnvCredentials, GCEMetadata, ServiceAccountCredentials,
+        StaticCredentialsAuth, StaticToken, YandexMetadata,
     },
     errors::{
         YdbError, YdbIssue, YdbIssueSeverity, YdbOrCustomerError, YdbResult,

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -143,9 +143,9 @@ pub use waiter::Waiter;
 // full enum pub types
 pub use crate::{
     credentials::{
-        AccessTokenCredentials, AnonymousCredentials, CommandLineCredentials, CommandLineYcToken,
-        FromEnvCredentials, GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials,
-        StaticCredentials, StaticCredentialsAuth, StaticToken, YandexMetadata,
+        get_credentials_from_env, AccessTokenCredentials, AnonymousCredentials,
+        CommandLineCredentials, GCEMetadata, MetadataUrlCredentials, ServiceAccountCredentials,
+        StaticCredentials,
     },
     errors::{
         YdbError, YdbIssue, YdbIssueSeverity, YdbOrCustomerError, YdbResult,
@@ -153,4 +153,10 @@ pub use crate::{
     },
     pub_traits::{Credentials, TokenInfo},
     types::{Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueStruct},
+};
+
+// deprecated types
+
+pub use crate::credentials::{
+    CommandLineYcToken, StaticCredentialsAuth, StaticToken, YandexMetadata,
 };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en


## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
There is no automatic determination mechanism for credentials by environment as described in docs
![изображение](https://github.com/ydb-platform/ydb-rs-sdk/assets/1934951/81b462b2-7f04-4696-b8a3-1a98a71762e5)

Credentials types has incostistent  names.

Issue Number: #186 

## What is the new behavior?

- Implemented FromEnvCredentials with descibed algorithm. 
- Added wrapper for StaticToken named AnonimousCredentials for more intuitive name user can search for
- Added type aliases for consistent naming: AccessTokenCredentials, MetadataUrlCredentials, StaticCredentials and CommandLineCredentials


