### PR TITLE
Fixed data representation for Uint8 and Uint16

### DIFF
--- a/ydb/src/client_table_test_integration.rs
+++ b/ydb/src/client_table_test_integration.rs
@@ -656,6 +656,66 @@ SELECT CAST(NULL AS Optional<Int64>)
 #[tokio::test]
 #[traced_test]
 #[ignore] // need YDB access
+async fn select_with_u8_param() -> YdbResult<()> {
+    let client = create_client().await?;
+    let mut transaction = client
+        .table_client()
+        .create_autocommit_transaction(Mode::OnlineReadonly);
+    let res = transaction.query(
+        Query::from(r#"
+            DECLARE $val AS Uint8;
+            SELECT $val as s
+        "#).with_params(ydb_params!(
+            "$val" => 99u8
+        )))
+        .await?;
+    trace!("result: {:?}", &res);
+    assert_eq!(
+        Value::Uint8(99u8),
+        res.into_only_result()
+            .unwrap()
+            .rows()
+            .next()
+            .unwrap()
+            .remove_field_by_name("s")
+            .unwrap()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn select_with_u16_param() -> YdbResult<()> {
+    let client = create_client().await?;
+    let mut transaction = client
+        .table_client()
+        .create_autocommit_transaction(Mode::OnlineReadonly);
+    let res = transaction.query(
+        Query::from(r#"
+            DECLARE $val AS Uint16;
+            SELECT $val as s
+        "#).with_params(ydb_params!(
+            "$val" => 34111u16
+        )))
+        .await?;
+    trace!("result: {:?}", &res);
+    assert_eq!(
+        Value::Uint16(34111u16),
+        res.into_only_result()
+            .unwrap()
+            .rows()
+            .next()
+            .unwrap()
+            .remove_field_by_name("s")
+            .unwrap()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
 async fn select_void_null() -> YdbResult<()> {
     let client = create_client().await?;
     let mut transaction = client

--- a/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
@@ -35,7 +35,7 @@ impl TryFrom<crate::Value> for RawTypedValue {
             },
             Value::Uint8(v) => RawTypedValue {
                 r#type: RawType::Uint8,
-                value: RawValue::Int32(v as i32),
+                value: RawValue::UInt32(v as u32),
             },
             Value::Int16(v) => RawTypedValue {
                 r#type: RawType::Int16,
@@ -43,7 +43,7 @@ impl TryFrom<crate::Value> for RawTypedValue {
             },
             Value::Uint16(v) => RawTypedValue {
                 r#type: RawType::Uint16,
-                value: RawValue::Int32(v as i32),
+                value: RawValue::UInt32(v as u32),
             },
             Value::Int32(v) => RawTypedValue {
                 r#type: RawType::Int32,
@@ -201,11 +201,11 @@ impl TryFrom<RawTypedValue> for Value {
             (t @ RawType::Bool, v) => return types_mismatch(t, v),
             (RawType::Int8, RawValue::Int32(v)) => Value::Int8(v.try_into()?),
             (t @ RawType::Int8, v) => return types_mismatch(t, v),
-            (RawType::Uint8, RawValue::Int32(v)) => Value::Uint8(v.try_into()?),
+            (RawType::Uint8, RawValue::UInt32(v)) => Value::Uint8(v.try_into()?),
             (t @ RawType::Uint8, v) => return types_mismatch(t, v),
             (RawType::Int16, RawValue::Int32(v)) => Value::Int16(v.try_into()?),
             (t @ RawType::Int16, v) => return types_mismatch(t, v),
-            (RawType::Uint16, RawValue::Int32(v)) => Value::Uint16(v.try_into()?),
+            (RawType::Uint16, RawValue::UInt32(v)) => Value::Uint16(v.try_into()?),
             (t @ RawType::Uint16, v) => return types_mismatch(t, v),
             (RawType::Int32, RawValue::Int32(v)) => Value::Int32(v),
             (t @ RawType::Int32, v) => return types_mismatch(t, v),


### PR DESCRIPTION
Fixed Uint8 and Uint16 representation from Int32 to UInt32 according to source code of YDB:

```
case NUdf::TDataType<ui8>::Id: {
    CheckTypeId(value.value_case(), Ydb::Value::kUint32Value, "Uint8");
    return NUdf::TUnboxedValuePod(ui8(value.uint32_value()));
}
case NUdf::TDataType<ui16>::Id: {
    CheckTypeId(value.value_case(), Ydb::Value::kUint32Value, "Uint16");
    return NUdf::TUnboxedValuePod(ui16(value.uint32_value()));
}
```

## Pull request type

Please check the type of change your PR introduces:

- [ x] Bugfix


## What is the current behavior?

Error occuired:
```
ERROR ydb::client_table: error=YdbStatusError(YdbStatusError { message: "Operation { id: \"\", ready: true, status: BadRequest, issues: [IssueMessage { position: None, message: \"contrib/ydb/core/kqp/session_actor/kqp_session_actor.cpp:902: Invalid value representation for type: Uint8, expected value case: 3, but current: 2\", end_position: None, issue_code: 0, severity: 1, issues: [] }], result: Some(Any { type_url: \"type.googleapis.com/Ydb.Table.ExecuteQueryResult\", value: [18, 28, 10, 26, 48, 49, 106, 56, 122, 107, 52, 102, 98, 107, 102, 110, 48, 53, 52, 51, 115, 57, 54, 122, 54, 56, 115, 122, 102, 97] }), metadata: None, cost_info: None }", operation_status: 400010, issues: [YdbIssue { issue_code: 0, message: "contrib/ydb/core/kqp/session_actor/kqp_session_actor.cpp:902: Invalid value representation for type: Uint8, expected value case: 3, but current: 2", issues: [], severity: Error }] })
Error: YdbStatusError(YdbStatusError { message: "Operation { id: \"\", ready: true, status: BadRequest, issues: [IssueMessage { position: None, message: \"contrib/ydb/core/kqp/session_actor/kqp_session_actor.cpp:902: Invalid value representation for type: Uint8, expected value case: 3, but current: 2\", end_position: None, issue_code: 0, severity: 1, issues: [] }], result: Some(Any { type_url: \"type.googleapis.com/Ydb.Table.ExecuteQueryResult\", value: [18, 28, 10, 26, 48, 49, 106, 56, 122, 107, 52, 102, 98, 107, 102, 110, 48, 53, 52, 51, 115, 57, 54, 122, 54, 56, 115, 122, 102, 97] }), metadata: None, cost_info: None }", operation_status: 400010, issues: [YdbIssue { issue_code: 0, message: "contrib/ydb/core/kqp/session_actor/kqp_session_actor.cpp:902: Invalid value representation for type: Uint8, expected value case: 3, but current: 2", issues: [], severity: Error }] })
```

Issue Number: #210

## What is the new behavior?

Queries executed without errors
