### PR TITLE
Add UUID support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,10 +940,11 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1523,6 +1536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,7 +1568,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -1707,6 +1726,12 @@ checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
  "base64 0.13.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2497,11 +2522,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.0.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2581,27 +2608,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.79"
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -2619,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2629,22 +2676,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2916,6 +2966,12 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "ydb"

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = "0.3"
 tonic = { version = "0.8.1", features = ["tls"] }
 tower = "0.4"
 url = "2.2"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1.17.0", features = ["v4", "v7"] }
 ydb-grpc = { version = "0.1.0", path = "../ydb-grpc" }
 
 [dev-dependencies]

--- a/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
@@ -164,7 +164,7 @@ impl RawType {
             RawType::UTF8 => Value::Text(String::default()),
             RawType::Yson => Value::Yson(Bytes::default()),
             RawType::Json => Value::Json(String::default()),
-            t @ RawType::Uuid => return unimplemented_type(t),
+            RawType::Uuid => Value::Uuid(uuid::Uuid::nil()),
             RawType::JSONDocument => Value::JsonDocument(String::default()),
             t @ RawType::DyNumber => return unimplemented_type(t),
             RawType::Decimal(_) => Value::Decimal(decimal_rs::Decimal::default()),

--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -1,6 +1,5 @@
 use crate::errors::{YdbError, YdbResult};
 use std::collections::HashMap;
-use std::hint;
 
 use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
 use crate::grpc_wrapper::raw_table_service::value::RawColumn;

--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -1,5 +1,6 @@
 use crate::errors::{YdbError, YdbResult};
 use std::collections::HashMap;
+use std::hint;
 
 use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
 use crate::grpc_wrapper::raw_table_service::value::RawColumn;
@@ -93,6 +94,7 @@ pub enum Value {
     Struct(ValueStruct),
 
     Decimal(decimal_rs::Decimal),
+    Uuid(uuid::Uuid),
 }
 
 impl Value {
@@ -402,6 +404,7 @@ impl Value {
             Self::List(items) => Self::to_typed_value_list(*items)?,
             Value::Struct(s) => { Self::to_typed_struct(s) }?,
             Self::Decimal(val) => Self::to_typed_decimal(val)?,
+            Self::Uuid(val) => Self::to_typed_uuid(val)?,
         };
         Ok(res)
     }
@@ -418,6 +421,27 @@ impl Value {
             }),
             value: Some(ydb_proto::Value {
                 value: Some(ydb_proto::value::Value::TextValue(val.to_string())),
+                ..ydb_proto::Value::default()
+            }),
+        })
+    }
+
+    fn to_typed_uuid(val: uuid::Uuid) -> YdbResult<ydb_proto::TypedValue> {
+        use ydb_proto::r#type::PrimitiveTypeId as pt;
+        use ydb_proto::value::Value as pv;
+
+        let (high, low) = val.as_u64_pair();
+
+        let high = high.swap_bytes();
+        let low = low.swap_bytes();
+
+        Ok(ydb_proto::TypedValue {
+            r#type: Some(ydb_proto::Type {
+                r#type: Some(ydb_proto::r#type::Type::TypeId(pt::Uuid.into())),
+            }),
+            value: Some(ydb_proto::Value {
+                value: Some(pv::Low128(low)),
+                high_128: high,
                 ..ydb_proto::Value::default()
             }),
         })
@@ -533,6 +557,8 @@ impl Value {
                     .parse::<decimal_rs::Decimal>()
                     .unwrap(),
             ),
+            Value::Uuid(uuid::Uuid::now_v7()),
+            Value::Uuid(uuid::Uuid::new_v4()),
         ];
 
         num_tests!(values, Value::Int8, i8);

--- a/ydb/src/types_converters.rs
+++ b/ydb/src/types_converters.rs
@@ -98,6 +98,7 @@ simple_convert!(f32, Value::Float);
 simple_convert!(f64, Value::Double, Value::Float);
 simple_convert!(SystemTime, Value::Timestamp, Value::Date, Value::DateTime);
 simple_convert!(decimal_rs::Decimal, Value::Decimal);
+simple_convert!(uuid::Uuid, Value::Uuid);
 
 // Impl additional Value From
 impl From<&str> for Value {

--- a/ydb/src/types_test.rs
+++ b/ydb/src/types_test.rs
@@ -1,4 +1,5 @@
-use crate::{test_helpers::test_client_builder, Query, Value, YdbResult};
+use crate::{test_helpers::test_client_builder, ydb_params, Query, Value, YdbResult};
+use uuid::Uuid;
 
 #[test]
 fn test_is_optional() -> YdbResult<()> {
@@ -34,6 +35,44 @@ async fn test_decimal() -> YdbResult<()> {
             .unwrap(),
     );
     assert_eq!(test_value, db_value);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore] // needs YDB access
+async fn test_uuid() -> YdbResult<()> {
+    let client = test_client_builder().client()?;
+
+    client.wait().await?;
+
+    let test_uuid_v7 = uuid::Uuid::now_v7();
+    let test_uuid_v4 = uuid::Uuid::new_v4();
+
+    let (v7_db_value, v4_db_value): (Option<Uuid>, Option<Uuid>) = client
+        .table_client()
+        .retry_transaction(|mut t| async move {
+            let res = t
+                .query(
+                    Query::new(
+                        "
+                select $test_uuid_v7 as v7_db_value, $test_uuid_v4 as v4_db_value",
+                    )
+                    .with_params(ydb_params! {
+                        "$test_uuid_v7" => test_uuid_v7,
+                        "$test_uuid_v4" => test_uuid_v4,
+                    }),
+                )
+                .await?;
+            let mut row = res.into_only_row()?;
+            let v7_value: Option<Uuid> = row.remove_field_by_name("v7_db_value")?.try_into()?;
+            let v4_value: Option<Uuid> = row.remove_field_by_name("v4_db_value")?.try_into()?;
+            Ok((v7_value, v4_value))
+        })
+        .await?;
+
+    assert_eq!(test_uuid_v7, v7_db_value.unwrap());
+    assert_eq!(test_uuid_v4, v4_db_value.unwrap());
 
     Ok(())
 }


### PR DESCRIPTION
# Add UUID support

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ X ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

This sdk currently does not support UUIDs. When attempting to work with UUID values, the system returns "unimplemented type" errors, and UUID fields cannot be properly serialized/deserialized between Rust and YDB.

Issue Number: N/A

## What is the new behavior?

- Added full UUID support to the YDB Rust SDK
- UUID values can now be properly converted between Rust `uuid::Uuid` type and YDB's internal representation
- Implemented proper serialization/deserialization for UUID values using the HighLow128 format
- Added support for both UUID v4 and v7 generation in tests
- Updated dependencies to use uuid crate version 1.17.0 with v4 and v7 features

## Other information

-- endianness handling was annoying 

### Files Modified:
- `ydb/src/types.rs` - Added UUID variant to Value enum and conversion logic
- `ydb/src/types_converters.rs` - Added UUID type converter
- `ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs` - Implemented UUID serialization/deserialization
- `ydb/src/grpc_wrapper/raw_table_service/value/type.rs` - Added UUID default value handling
- `ydb/src/types_test.rs` - Added comprehensive UUID test
- `ydb/Cargo.toml` - Updated uuid dependency
- `Cargo.lock` - Updated dependency versions

