### PR TITLE
feat: add checks for `Value` method `list_from`

### DIFF
--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -1,4 +1,5 @@
 use crate::errors::{YdbError, YdbResult};
+use std::any::Any;
 use std::collections::HashMap;
 
 use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
@@ -264,6 +265,33 @@ impl Value {
         for (index, value) in values.iter().enumerate() {
             if std::mem::discriminant(&example_value) != std::mem::discriminant(value) {
                 return Err(YdbError::Custom(format!("failed list_from: type and value has different enum-types. index: {index}, type: '{example_value:?}', value: '{value:?}'")));
+            }
+
+            match &example_value {
+                Value::Struct(example_value_struct) => {
+                    for (i, value) in values.iter().enumerate() {
+                        match &value {
+                            Value::Struct(value_struct) => {
+                                if value_struct.fields_name != example_value_struct.fields_name {
+                                    return Err(YdbError::Custom(format!(
+                                        "failed list_from: fields of value struct with index `{i}`: '{0:?}' is not equal to fields of example value struct: '{1:?}'",
+                                        value_struct.fields_name, example_value_struct.fields_name
+                                    )));
+                                };
+                            }
+                            _ => {
+                                return Err(YdbError::Custom(format!(
+                                    "failed list_from: value with index `{i}`: '{value:?}' is not a ValueStruct"
+                                )));
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    return Err(YdbError::Custom(format!(
+                        "failed list_from: example value: '{example_value:?}' is not a ValueStruct"
+                    )));
+                }
             }
         }
 


### PR DESCRIPTION
Add checks for names of fields in the example stricture and in structures in the target vector.

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If names of fields and order in the example stricture and in structures in the target vector are not the same, it doesn't raise error, but host does it with undefined description.

Issue Number: 377

## What is the new behavior?

The user receives an error message describing the fields and structure in which the error was detected.
