### PR TITLE
Introduce YdbDecimal to preserve precision and scale metadata

### DIFF
--- a/ydb/src/client_table_test_integration.rs
+++ b/ydb/src/client_table_test_integration.rs
@@ -1079,7 +1079,10 @@ async fn describe_table() -> YdbResult<()> {
         .unwrap();
     match &price_col.type_value {
         Ok(Value::Optional(opt)) => match &opt.t {
-            Value::Decimal(_) => {}
+            Value::Decimal(d) => {
+                // Verify that precision and scale are preserved from the schema
+                assert!(d.precision() > 0, "precision should be set from schema");
+            }
             _ => panic!("Expected Optional<Decimal>"),
         },
         Err(e) => panic!("Type conversion failed: {:?}", e),

--- a/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
@@ -1,4 +1,5 @@
 use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
+use crate::types::YdbDecimal;
 use crate::{Bytes, SignedInterval, Value, ValueList, ValueOptional, ValueStruct};
 use std::time::SystemTime;
 use ydb_grpc::ydb_proto::r#type::{PrimitiveTypeId, Type as ProtoType};
@@ -165,7 +166,13 @@ impl RawType {
             RawType::Uuid => Value::Uuid(uuid::Uuid::nil()),
             RawType::JSONDocument => Value::JsonDocument(String::default()),
             t @ RawType::DyNumber => return unimplemented_type(t),
-            RawType::Decimal(_) => Value::Decimal(decimal_rs::Decimal::default()),
+            RawType::Decimal(dec) => {
+                // SAFETY: zero value with the schema-declared precision/scale
+                // is always representable.
+                let inner = decimal_rs::Decimal::from_parts(0, dec.scale, false)
+                    .map_err(|e| RawError::custom(format!("failed to create decimal example: {}", e)))?;
+                Value::Decimal(unsafe { YdbDecimal::new_unsafe(inner, dec.precision, dec.scale) })
+            }
             RawType::Optional(inner_type) => Value::Optional(Box::new(ValueOptional {
                 t: (*inner_type).into_value_example()?,
                 value: None,

--- a/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
@@ -169,8 +169,9 @@ impl RawType {
             RawType::Decimal(dec) => {
                 // SAFETY: zero value with the schema-declared precision/scale
                 // is always representable.
-                let inner = decimal_rs::Decimal::from_parts(0, dec.scale, false)
-                    .map_err(|e| RawError::custom(format!("failed to create decimal example: {}", e)))?;
+                let inner = decimal_rs::Decimal::from_parts(0, dec.scale, false).map_err(|e| {
+                    RawError::custom(format!("failed to create decimal example: {}", e))
+                })?;
                 Value::Decimal(unsafe { YdbDecimal::new_unsafe(inner, dec.precision, dec.scale) })
             }
             RawType::Optional(inner_type) => Value::Optional(Box::new(ValueOptional {

--- a/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
@@ -52,8 +52,8 @@ pub(crate) enum RawType {
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 pub(crate) struct DecimalType {
-    pub precision: u8,
-    pub scale: i16,
+    pub precision: u32,
+    pub scale: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
@@ -167,12 +167,13 @@ impl RawType {
             RawType::JSONDocument => Value::JsonDocument(String::default()),
             t @ RawType::DyNumber => return unimplemented_type(t),
             RawType::Decimal(dec) => {
-                // SAFETY: zero value with the schema-declared precision/scale
-                // is always representable.
-                let inner = decimal_rs::Decimal::from_parts(0, dec.scale, false).map_err(|e| {
+                let scale_i16 = i16::try_from(dec.scale).map_err(|_| {
+                    RawError::custom(format!("scale {} does not fit into i16", dec.scale))
+                })?;
+                let inner = decimal_rs::Decimal::from_parts(0, scale_i16, false).map_err(|e| {
                     RawError::custom(format!("failed to create decimal example: {}", e))
                 })?;
-                Value::Decimal(unsafe { YdbDecimal::new_unsafe(inner, dec.precision, dec.scale) })
+                Value::Decimal(YdbDecimal::new_unchecked(inner, dec.precision, dec.scale))
             }
             RawType::Optional(inner_type) => Value::Optional(Box::new(ValueOptional {
                 t: (*inner_type).into_value_example()?,
@@ -219,8 +220,8 @@ impl TryFrom<ydb_grpc::ydb_proto::Type> for RawType {
         let res: Self = match t {
             ProtoType::TypeId(type_id) => return RawType::try_from_primitive_type_id(type_id),
             ProtoType::DecimalType(decimal) => RawType::Decimal(DecimalType {
-                precision: u8::try_from(decimal.precision)?,
-                scale: i16::try_from(decimal.scale)?,
+                precision: decimal.precision,
+                scale: decimal.scale,
             }),
             ProtoType::OptionalType(optional_type) => {
                 if let Some(item) = optional_type.item {
@@ -375,8 +376,8 @@ impl From<RawType> for ydb_grpc::ydb_proto::Type {
             RawType::JSONDocument => ProtoType::TypeId(PrimitiveTypeId::JsonDocument as i32),
             RawType::DyNumber => ProtoType::TypeId(PrimitiveTypeId::Dynumber as i32),
             RawType::Decimal(decimal) => ProtoType::DecimalType(ydb_grpc::ydb_proto::DecimalType {
-                precision: decimal.precision as u32,
-                scale: decimal.scale as u32,
+                precision: decimal.precision,
+                scale: decimal.scale,
             }),
             RawType::Optional(nested) => {
                 ProtoType::OptionalType(Box::new(ydb_grpc::ydb_proto::OptionalType {

--- a/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
@@ -122,15 +122,14 @@ impl TryFrom<crate::Value> for RawTypedValue {
                 value: RawValue::Text(v),
             },
             Value::Decimal(v) => {
-                let (int_val, _scale, negative) = v.inner.into_parts();
+                let precision = v.precision();
+                let scale = v.scale();
+                let (int_val, _scale, negative) = v.decimal().into_parts();
                 let int_value = (if negative { -1 } else { 1 }) * (int_val as i128);
                 let (high, low) = split_to_parts(int_value as u128);
 
                 RawTypedValue {
-                    r#type: RawType::Decimal(DecimalType {
-                        precision: v.precision(),
-                        scale: v.scale(),
-                    }),
+                    r#type: RawType::Decimal(DecimalType { precision, scale }),
                     value: RawValue::HighLow128(high, low),
                 }
             }
@@ -297,13 +296,14 @@ impl TryFrom<RawTypedValue> for Value {
             (t @ RawType::DyNumber, _) => return type_unimplemented(t),
             (RawType::Decimal(t), RawValue::HighLow128(high, low)) => {
                 let int_val = merge_parts(high, low) as i128;
+                let scale_i16 = i16::try_from(t.scale).map_err(|_| {
+                    RawError::decode_error(format!("scale {} does not fit into i16", t.scale))
+                })?;
 
                 let inner =
-                    decimal_rs::Decimal::from_parts(int_val.unsigned_abs(), t.scale, int_val < 0)
+                    decimal_rs::Decimal::from_parts(int_val.unsigned_abs(), scale_i16, int_val < 0)
                         .map_err(|e| RawError::decode_error(e.to_string()))?;
-                // SAFETY: the value comes directly from the server with matching
-                // precision and scale, so no validation is needed.
-                let value = unsafe { YdbDecimal::new_unsafe(inner, t.precision, t.scale) };
+                let value = YdbDecimal::new_unchecked(inner, t.precision, t.scale);
                 return Ok(Value::Decimal(value));
             }
             (t @ RawType::Decimal(_), v) => return types_mismatch(t, v),

--- a/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
@@ -11,8 +11,8 @@ use super::r#type::DecimalType;
 use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
 use crate::grpc_wrapper::raw_table_service::value::r#type::{RawType, StructMember, StructType};
 use crate::grpc_wrapper::raw_table_service::value::{RawTypedValue, RawValue};
-use crate::types::SECONDS_PER_DAY;
 use crate::types::YdbDecimal;
+use crate::types::SECONDS_PER_DAY;
 use crate::{Bytes, SignedInterval, Value};
 
 impl TryFrom<crate::Value> for RawTypedValue {
@@ -303,9 +303,7 @@ impl TryFrom<RawTypedValue> for Value {
                         .map_err(|e| RawError::decode_error(e.to_string()))?;
                 // SAFETY: the value comes directly from the server with matching
                 // precision and scale, so no validation is needed.
-                let value = unsafe {
-                    YdbDecimal::new_unsafe(inner, t.precision, t.scale)
-                };
+                let value = unsafe { YdbDecimal::new_unsafe(inner, t.precision, t.scale) };
                 return Ok(Value::Decimal(value));
             }
             (t @ RawType::Decimal(_), v) => return types_mismatch(t, v),

--- a/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
@@ -12,6 +12,7 @@ use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
 use crate::grpc_wrapper::raw_table_service::value::r#type::{RawType, StructMember, StructType};
 use crate::grpc_wrapper::raw_table_service::value::{RawTypedValue, RawValue};
 use crate::types::SECONDS_PER_DAY;
+use crate::types::YdbDecimal;
 use crate::{Bytes, SignedInterval, Value};
 
 impl TryFrom<crate::Value> for RawTypedValue {
@@ -121,7 +122,7 @@ impl TryFrom<crate::Value> for RawTypedValue {
                 value: RawValue::Text(v),
             },
             Value::Decimal(v) => {
-                let (int_val, _scale, negative) = v.into_parts();
+                let (int_val, _scale, negative) = v.inner.into_parts();
                 let int_value = (if negative { -1 } else { 1 }) * (int_val as i128);
                 let (high, low) = split_to_parts(int_value as u128);
 
@@ -297,9 +298,14 @@ impl TryFrom<RawTypedValue> for Value {
             (RawType::Decimal(t), RawValue::HighLow128(high, low)) => {
                 let int_val = merge_parts(high, low) as i128;
 
-                let value =
+                let inner =
                     decimal_rs::Decimal::from_parts(int_val.unsigned_abs(), t.scale, int_val < 0)
                         .map_err(|e| RawError::decode_error(e.to_string()))?;
+                // SAFETY: the value comes directly from the server with matching
+                // precision and scale, so no validation is needed.
+                let value = unsafe {
+                    YdbDecimal::new_unsafe(inner, t.precision, t.scale)
+                };
                 return Ok(Value::Decimal(value));
             }
             (t @ RawType::Decimal(_), v) => return types_mismatch(t, v),

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -180,7 +180,7 @@ pub use crate::{
         YdbResultWithCustomerErr, YdbStatusError,
     },
     pub_traits::{Credentials, TokenInfo},
-    types::{Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueStruct},
+    types::{Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueStruct, YdbDecimal},
 };
 
 // deprecated types

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -180,7 +180,9 @@ pub use crate::{
         YdbResultWithCustomerErr, YdbStatusError,
     },
     pub_traits::{Credentials, TokenInfo},
-    types::{Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueStruct, YdbDecimal},
+    types::{
+        Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueStruct, YdbDecimal,
+    },
 };
 
 // deprecated types

--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -12,6 +12,103 @@ use ydb_grpc::ydb_proto;
 
 pub(crate) const SECONDS_PER_DAY: u64 = 60 * 60 * 24;
 
+/// A decimal value with explicit YQL type parameters (precision and scale).
+///
+/// In YQL, `Decimal(p, s)` values with different precision or scale are
+/// considered distinct, incompatible types. This wrapper preserves both
+/// parameters alongside the numeric value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct YdbDecimal {
+    pub(crate) inner: decimal_rs::Decimal,
+    precision: u8,
+    scale: i16,
+}
+
+impl YdbDecimal {
+    /// Creates a new `YdbDecimal` with validation.
+    ///
+    /// Rescaling up (increasing scale) is allowed via `normalize_to_scale`.
+    /// Returns an error if:
+    /// - The value cannot be represented within the given precision
+    /// - Rescaling would lose significant digits (decrease in scale or precision)
+    pub fn try_new(
+        value: decimal_rs::Decimal,
+        precision: u8,
+        scale: i16,
+    ) -> YdbResult<Self> {
+        let current_scale = value.scale();
+        let adjusted = if current_scale != scale {
+            if scale < current_scale {
+                return Err(YdbError::Convert(format!(
+                    "cannot decrease decimal scale from {} to {}",
+                    current_scale, scale
+                )));
+            }
+            value.normalize_to_scale(scale)
+        } else {
+            value
+        };
+
+        let digit_count = adjusted.precision();
+        if digit_count > precision {
+            return Err(YdbError::Convert(format!(
+                "decimal value has {} digits, which exceeds precision {}",
+                digit_count, precision
+            )));
+        }
+
+        Ok(Self {
+            inner: adjusted,
+            precision,
+            scale,
+        })
+    }
+
+    /// Creates a new `YdbDecimal` without validation.
+    ///
+    /// # Safety
+    /// The caller must ensure that the value can be represented within
+    /// the given precision and scale. Using incorrect parameters may
+    /// cause unexpected behavior when sending values to YDB.
+    pub unsafe fn new_unsafe(
+        value: decimal_rs::Decimal,
+        precision: u8,
+        scale: i16,
+    ) -> Self {
+        Self {
+            inner: value,
+            precision,
+            scale,
+        }
+    }
+
+    /// Returns the precision (maximum number of digits).
+    pub fn precision(&self) -> u8 {
+        self.precision
+    }
+
+    /// Returns the scale (number of digits after the decimal point).
+    pub fn scale(&self) -> i16 {
+        self.scale
+    }
+
+    /// Returns a reference to the underlying decimal value.
+    pub fn value(&self) -> &decimal_rs::Decimal {
+        &self.inner
+    }
+
+    /// Consumes self and returns the underlying decimal value.
+    pub fn into_inner(self) -> decimal_rs::Decimal {
+        self.inner
+    }
+}
+
+impl From<YdbDecimal> for Value {
+    fn from(d: YdbDecimal) -> Self {
+        Value::Decimal(d)
+    }
+}
+
 /// Internal represent database value for send to or received from database.
 ///
 /// That enum will be grow, when add support of new types
@@ -92,7 +189,7 @@ pub enum Value {
     List(Box<ValueList>),
     Struct(ValueStruct),
 
-    Decimal(decimal_rs::Decimal),
+    Decimal(YdbDecimal),
     Uuid(uuid::Uuid),
 }
 
@@ -421,7 +518,7 @@ impl Value {
         Ok(res)
     }
 
-    fn to_typed_decimal(val: decimal_rs::Decimal) -> YdbResult<ydb_proto::TypedValue> {
+    fn to_typed_decimal(val: YdbDecimal) -> YdbResult<ydb_proto::TypedValue> {
         Ok(ydb_proto::TypedValue {
             r#type: Some(ydb_proto::Type {
                 r#type: Some(ydb_proto::r#type::Type::DecimalType(
@@ -432,7 +529,7 @@ impl Value {
                 )),
             }),
             value: Some(ydb_proto::Value {
-                value: Some(ydb_proto::value::Value::TextValue(val.to_string())),
+                value: Some(ydb_proto::value::Value::TextValue(val.inner.to_string())),
                 ..ydb_proto::Value::default()
             }),
         })
@@ -565,9 +662,13 @@ impl Value {
             Value::JsonDocument("{}".into()),
             Value::Yson("1;2;3;".into()),
             Value::Decimal(
-                "123456789.987654321"
-                    .parse::<decimal_rs::Decimal>()
-                    .unwrap(),
+                YdbDecimal::try_new(
+                    "123456789.987654321"
+                        .parse::<decimal_rs::Decimal>()
+                        .unwrap(),
+                    22,
+                    9,
+                ).unwrap(),
             ),
             Value::Uuid(uuid::Uuid::now_v7()),
             Value::Uuid(uuid::Uuid::new_v4()),

--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -31,11 +31,7 @@ impl YdbDecimal {
     /// Returns an error if:
     /// - The value cannot be represented within the given precision
     /// - Rescaling would lose significant digits (decrease in scale or precision)
-    pub fn try_new(
-        value: decimal_rs::Decimal,
-        precision: u8,
-        scale: i16,
-    ) -> YdbResult<Self> {
+    pub fn try_new(value: decimal_rs::Decimal, precision: u8, scale: i16) -> YdbResult<Self> {
         let current_scale = value.scale();
         let adjusted = if current_scale != scale {
             if scale < current_scale {
@@ -70,11 +66,7 @@ impl YdbDecimal {
     /// The caller must ensure that the value can be represented within
     /// the given precision and scale. Using incorrect parameters may
     /// cause unexpected behavior when sending values to YDB.
-    pub unsafe fn new_unsafe(
-        value: decimal_rs::Decimal,
-        precision: u8,
-        scale: i16,
-    ) -> Self {
+    pub unsafe fn new_unsafe(value: decimal_rs::Decimal, precision: u8, scale: i16) -> Self {
         Self {
             inner: value,
             precision,
@@ -668,7 +660,8 @@ impl Value {
                         .unwrap(),
                     22,
                     9,
-                ).unwrap(),
+                )
+                .unwrap(),
             ),
             Value::Uuid(uuid::Uuid::now_v7()),
             Value::Uuid(uuid::Uuid::new_v4()),

--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -17,11 +17,11 @@ pub(crate) const SECONDS_PER_DAY: u64 = 60 * 60 * 24;
 /// In YQL, `Decimal(p, s)` values with different precision or scale are
 /// considered distinct, incompatible types. This wrapper preserves both
 /// parameters alongside the numeric value.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct YdbDecimal {
-    pub(crate) inner: decimal_rs::Decimal,
-    precision: u8,
-    scale: i16,
+    inner: decimal_rs::Decimal,
+    precision: u32,
+    scale: u32,
 }
 
 impl YdbDecimal {
@@ -31,21 +31,24 @@ impl YdbDecimal {
     /// Returns an error if:
     /// - The value cannot be represented within the given precision
     /// - Rescaling would lose significant digits (decrease in scale or precision)
-    pub fn try_new(value: decimal_rs::Decimal, precision: u8, scale: i16) -> YdbResult<Self> {
+    pub fn try_new(value: decimal_rs::Decimal, precision: u32, scale: u32) -> YdbResult<Self> {
+        let scale_i16: i16 = scale
+            .try_into()
+            .map_err(|_| YdbError::Convert(format!("scale {} does not fit into i16", scale)))?;
         let current_scale = value.scale();
-        let adjusted = if current_scale != scale {
-            if scale < current_scale {
+        let adjusted = if current_scale != scale_i16 {
+            if scale_i16 < current_scale {
                 return Err(YdbError::Convert(format!(
                     "cannot decrease decimal scale from {} to {}",
                     current_scale, scale
                 )));
             }
-            value.normalize_to_scale(scale)
+            value.normalize_to_scale(scale_i16)
         } else {
             value
         };
 
-        let digit_count = adjusted.precision();
+        let digit_count = adjusted.precision() as u32;
         if digit_count > precision {
             return Err(YdbError::Convert(format!(
                 "decimal value has {} digits, which exceeds precision {}",
@@ -62,11 +65,10 @@ impl YdbDecimal {
 
     /// Creates a new `YdbDecimal` without validation.
     ///
-    /// # Safety
     /// The caller must ensure that the value can be represented within
     /// the given precision and scale. Using incorrect parameters may
     /// cause unexpected behavior when sending values to YDB.
-    pub unsafe fn new_unsafe(value: decimal_rs::Decimal, precision: u8, scale: i16) -> Self {
+    pub(crate) fn new_unchecked(value: decimal_rs::Decimal, precision: u32, scale: u32) -> Self {
         Self {
             inner: value,
             precision,
@@ -75,23 +77,30 @@ impl YdbDecimal {
     }
 
     /// Returns the precision (maximum number of digits).
-    pub fn precision(&self) -> u8 {
+    pub fn precision(&self) -> u32 {
         self.precision
     }
 
     /// Returns the scale (number of digits after the decimal point).
-    pub fn scale(&self) -> i16 {
+    pub fn scale(&self) -> u32 {
         self.scale
     }
 
     /// Returns a reference to the underlying decimal value.
-    pub fn value(&self) -> &decimal_rs::Decimal {
+    pub fn decimal(&self) -> &decimal_rs::Decimal {
         &self.inner
     }
+}
 
-    /// Consumes self and returns the underlying decimal value.
-    pub fn into_inner(self) -> decimal_rs::Decimal {
-        self.inner
+impl std::fmt::Display for YdbDecimal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl From<YdbDecimal> for decimal_rs::Decimal {
+    fn from(d: YdbDecimal) -> Self {
+        d.inner
     }
 }
 
@@ -511,17 +520,17 @@ impl Value {
     }
 
     fn to_typed_decimal(val: YdbDecimal) -> YdbResult<ydb_proto::TypedValue> {
+        let precision = val.precision();
+        let scale = val.scale();
+        let text = val.decimal().to_string();
         Ok(ydb_proto::TypedValue {
             r#type: Some(ydb_proto::Type {
                 r#type: Some(ydb_proto::r#type::Type::DecimalType(
-                    ydb_proto::DecimalType {
-                        precision: val.precision().into(),
-                        scale: val.scale().try_into()?,
-                    },
+                    ydb_proto::DecimalType { precision, scale },
                 )),
             }),
             value: Some(ydb_proto::Value {
-                value: Some(ydb_proto::value::Value::TextValue(val.inner.to_string())),
+                value: Some(ydb_proto::value::Value::TextValue(text)),
                 ..ydb_proto::Value::default()
             }),
         })

--- a/ydb/src/types_converters.rs
+++ b/ydb/src/types_converters.rs
@@ -97,7 +97,43 @@ simple_convert!(
 simple_convert!(f32, Value::Float);
 simple_convert!(f64, Value::Double, Value::Float);
 simple_convert!(SystemTime, Value::Timestamp, Value::Date, Value::DateTime);
-simple_convert!(decimal_rs::Decimal, Value::Decimal);
+// decimal_rs::Decimal conversion removed: use YdbDecimal::try_new() to construct
+// Value::Decimal with explicit precision and scale.
+
+impl TryFrom<Value> for decimal_rs::Decimal {
+    type Error = YdbError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Decimal(val) => Ok(val.into_inner()),
+            value => Err(YdbError::Convert(format!(
+                "failed to convert from {} to decimal_rs::Decimal",
+                value.kind_static(),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<Value> for Option<decimal_rs::Decimal> {
+    type Error = YdbError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Optional(opt_val) => {
+                <decimal_rs::Decimal as TryFrom<Value>>::try_from(opt_val.t)?;
+
+                match opt_val.value {
+                    Some(val) => {
+                        let res_val: decimal_rs::Decimal = val.try_into()?;
+                        Ok(Some(res_val))
+                    }
+                    None => Ok(None),
+                }
+            }
+            value => Ok(Some(value.try_into()?)),
+        }
+    }
+}
 simple_convert!(uuid::Uuid, Value::Uuid);
 
 // Impl additional Value From

--- a/ydb/src/types_converters.rs
+++ b/ydb/src/types_converters.rs
@@ -97,15 +97,15 @@ simple_convert!(
 simple_convert!(f32, Value::Float);
 simple_convert!(f64, Value::Double, Value::Float);
 simple_convert!(SystemTime, Value::Timestamp, Value::Date, Value::DateTime);
-// decimal_rs::Decimal conversion removed: use YdbDecimal::try_new() to construct
-// Value::Decimal with explicit precision and scale.
+// No implicit From<decimal_rs::Decimal> for Value: precision and scale cannot be
+// unambiguously derived from a bare Decimal. Use YdbDecimal::try_new() to construct
 
 impl TryFrom<Value> for decimal_rs::Decimal {
     type Error = YdbError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         match value {
-            Value::Decimal(val) => Ok(val.into_inner()),
+            Value::Decimal(val) => Ok(val.into()),
             value => Err(YdbError::Convert(format!(
                 "failed to convert from {} to decimal_rs::Decimal",
                 value.kind_static(),

--- a/ydb/src/types_test.rs
+++ b/ydb/src/types_test.rs
@@ -1,4 +1,5 @@
 use crate::client::Client;
+use crate::types::YdbDecimal;
 use crate::{test_helpers::test_client_builder, ydb_params, Query, Value, YdbResult};
 use uuid::Uuid;
 
@@ -8,6 +9,61 @@ fn test_is_optional() -> YdbResult<()> {
     assert!(Value::optional_from(Value::Bool(false), Some(Value::Bool(false)))?.is_optional());
     assert!(!Value::Bool(false).is_optional());
     Ok(())
+}
+
+#[test]
+fn test_ydb_decimal_preserves_precision_and_scale() {
+    let value = "123.45".parse::<decimal_rs::Decimal>().unwrap();
+    let ydb_dec = YdbDecimal::try_new(value, 22, 9).unwrap();
+    assert_eq!(ydb_dec.precision(), 22);
+    assert_eq!(ydb_dec.scale(), 9);
+}
+
+#[test]
+fn test_ydb_decimal_rejects_precision_overflow() {
+    // 10 digits, precision 5 — should fail
+    let value = "1234567890.12".parse::<decimal_rs::Decimal>().unwrap();
+    let result = YdbDecimal::try_new(value, 5, 2);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_ydb_decimal_rejects_scale_decrease() {
+    // value has scale=3, requested scale=1 — should fail
+    let value = "1.234".parse::<decimal_rs::Decimal>().unwrap();
+    let result = YdbDecimal::try_new(value, 10, 1);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_ydb_decimal_allows_scale_increase() {
+    // value has scale=2, requested scale=9 — should succeed
+    let value = "123.45".parse::<decimal_rs::Decimal>().unwrap();
+    let ydb_dec = YdbDecimal::try_new(value, 22, 9).unwrap();
+    assert_eq!(ydb_dec.scale(), 9);
+    assert_eq!(ydb_dec.precision(), 22);
+}
+
+#[test]
+fn test_ydb_decimal_into_value() {
+    let value = "99.99".parse::<decimal_rs::Decimal>().unwrap();
+    let ydb_dec = YdbDecimal::try_new(value, 10, 2).unwrap();
+    let v: Value = ydb_dec.into();
+    match v {
+        Value::Decimal(d) => {
+            assert_eq!(d.precision(), 10);
+            assert_eq!(d.scale(), 2);
+        }
+        _ => panic!("expected Value::Decimal"),
+    }
+}
+
+#[test]
+fn test_ydb_decimal_new_unsafe() {
+    let value = "1.5".parse::<decimal_rs::Decimal>().unwrap();
+    let ydb_dec = unsafe { YdbDecimal::new_unsafe(value, 22, 9) };
+    assert_eq!(ydb_dec.precision(), 22);
+    assert_eq!(ydb_dec.scale(), 9);
 }
 
 #[tokio::test]

--- a/ydb/src/types_test.rs
+++ b/ydb/src/types_test.rs
@@ -59,9 +59,9 @@ fn test_ydb_decimal_into_value() {
 }
 
 #[test]
-fn test_ydb_decimal_new_unsafe() {
+fn test_ydb_decimal_new_unchecked() {
     let value = "1.5".parse::<decimal_rs::Decimal>().unwrap();
-    let ydb_dec = unsafe { YdbDecimal::new_unsafe(value, 22, 9) };
+    let ydb_dec = YdbDecimal::new_unchecked(value, 22, 9);
     assert_eq!(ydb_dec.precision(), 22);
     assert_eq!(ydb_dec.scale(), 9);
 }


### PR DESCRIPTION
  Fixes #391.

  ## Pull request type

  - [x] Bugfix
  - [x] Feature
  - [ ] Code style update (formatting, renaming)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] Documentation content changes
  - [ ] Other (please describe):

  ## What is the current behavior?

  `into_value_example()` in `type.rs:168` discards both precision and scale from `DecimalType`, returning `Decimal::default()` with `scale=0`. Additionally, deserialization in `value_ydb.rs:297-304`
  discards precision from the gRPC response. This causes `describe_table()` to report incorrect type metadata for Decimal columns.

  Issue Number: #391

  ## What is the new behavior?

  - `Value::Decimal` now wraps `YdbDecimal` instead of `decimal_rs::Decimal`
  - `YdbDecimal` stores explicit precision and scale from the YDB schema
  - `YdbDecimal::try_new()` — validated constructor; rescaling up allowed, errors on precision overflow or scale decrease
  - `YdbDecimal::new_unsafe()` — unchecked constructor for trusted sources (e.g. server responses)
  - `From<YdbDecimal> for Value` for convenient value construction
  - `TryFrom<Value> for decimal_rs::Decimal` still works for extraction
  - 6 unit tests added, all passing

  ## Other information

  **Breaking change:** `Value::Decimal(decimal_rs::Decimal)` → `Value::Decimal(YdbDecimal)`.

  Migration:
  - Construct: `YdbDecimal::try_new(value, precision, scale)?` then `.into()` for `Value`
  - Extract: `TryFrom<Value> for decimal_rs::Decimal` returns the inner decimal value