### PR TITLE
Fix: into_value_example() Optional converting value to None

### DIFF
--- a/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/type.rs
@@ -175,10 +175,13 @@ impl RawType {
                 })?;
                 Value::Decimal(YdbDecimal::new_unchecked(inner, dec.precision, dec.scale))
             }
-            RawType::Optional(inner_type) => Value::Optional(Box::new(ValueOptional {
-                t: (*inner_type).into_value_example()?,
-                value: None,
-            })),
+            RawType::Optional(inner_type) => {
+                let inner_example = (*inner_type).into_value_example()?;
+                Value::Optional(Box::new(ValueOptional {
+                    t: inner_example.clone(),
+                    value: Some(inner_example),
+                }))
+            }
             RawType::List(inner_type) => Value::List(Box::new(ValueList {
                 t: inner_type.into_value_example()?,
                 values: Vec::default(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Поправил поведение into_value_example() для типа Optional. Теперь он корректно возвращает нулевое значение своего внутреннего типа вместо Null. 

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
