### PR TITLE
Compression support in topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +1912,26 @@ dependencies = [
  "clocksource",
  "parking_lot",
  "thiserror",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3480,6 +3525,7 @@ dependencies = [
  "prost",
  "prost-types",
  "rand",
+ "rayon",
  "reqwest",
  "secrecy",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +584,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1297,6 +1316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2247,6 +2267,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -3440,6 +3466,7 @@ dependencies = [
  "decimal-rs",
  "derivative",
  "derive_builder",
+ "flate2",
  "futures-util",
  "http 1.3.1",
  "itertools 0.10.5",

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -54,6 +54,7 @@ tower = "0.4"
 url = "2.2"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
 ydb-grpc = { version = "0.2.0", path="../ydb-grpc"}
+flate2 = "1.1.9"
 
 [dev-dependencies]
 async_once = "0.2"

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -55,6 +55,7 @@ url = "2.2"
 uuid = { version = "1.17.0", features = ["v4", "v7"] }
 ydb-grpc = { version = "0.2.0", path="../ydb-grpc"}
 flate2 = "1.1.9"
+rayon = "1.10"
 
 [dev-dependencies]
 async_once = "0.2"

--- a/ydb/src/client_topic/client.rs
+++ b/ydb/src/client_topic/client.rs
@@ -242,8 +242,11 @@ impl TopicClient {
             writer_options,
             self.connection_manager.clone(),
             // currently custom codecs are returned as 0 from InitRequest, so we pass them separately
-            self.describe_topic(topic_path, DescribeTopicOptionsBuilder::default().build()?).await?.supported_codecs,
-        ).await
+            self.describe_topic(topic_path, DescribeTopicOptionsBuilder::default().build()?)
+                .await?
+                .supported_codecs,
+        )
+        .await
     }
 
     pub async fn create_writer(&mut self, path: String) -> YdbResult<TopicWriter> {
@@ -253,7 +256,9 @@ impl TopicClient {
                 .build()
                 .unwrap(),
             self.connection_manager.clone(),
-            self.describe_topic(path, DescribeTopicOptionsBuilder::default().build()?).await?.supported_codecs,
+            self.describe_topic(path, DescribeTopicOptionsBuilder::default().build()?)
+                .await?
+                .supported_codecs,
         )
         .await
     }

--- a/ydb/src/client_topic/client.rs
+++ b/ydb/src/client_topic/client.rs
@@ -237,16 +237,23 @@ impl TopicClient {
         &mut self,
         writer_options: TopicWriterOptions,
     ) -> YdbResult<TopicWriter> {
-        TopicWriter::new(writer_options, self.connection_manager.clone()).await
+        let topic_path = writer_options.topic_path.clone();
+        TopicWriter::new(
+            writer_options,
+            self.connection_manager.clone(),
+            // currently custom codecs are returned as 0 from InitRequest, so we pass them separately
+            self.describe_topic(topic_path, DescribeTopicOptionsBuilder::default().build()?).await?.supported_codecs,
+        ).await
     }
 
     pub async fn create_writer(&mut self, path: String) -> YdbResult<TopicWriter> {
         TopicWriter::new(
             TopicWriterOptionsBuilder::default()
-                .topic_path(path)
+                .topic_path(path.clone())
                 .build()
                 .unwrap(),
             self.connection_manager.clone(),
+            self.describe_topic(path, DescribeTopicOptionsBuilder::default().build()?).await?.supported_codecs,
         )
         .await
     }

--- a/ydb/src/client_topic/compression/builtin_codecs.rs
+++ b/ydb/src/client_topic/compression/builtin_codecs.rs
@@ -1,0 +1,22 @@
+use crate::{YdbError, YdbResult};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use prost::bytes::Bytes;
+use std::io::{Read, Write};
+
+pub fn gzip_compress(data: &Bytes) -> YdbResult<Bytes> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(data)
+        .and_then(|_| encoder.finish())
+        .map_err(|err| YdbError::custom(format!("gzip compress failed: {err}")))
+        .map(Bytes::from)
+}
+
+pub fn gzip_decompress(data: &Bytes) -> YdbResult<Bytes> {
+    let mut decoder = GzDecoder::new(data.as_ref());
+    let mut output = Vec::new();
+    decoder
+        .read_to_end(&mut output)
+        .map_err(|err| YdbError::custom(format!("gzip decompress failed: {err}")))
+        .map(|_| Bytes::from(output))
+}

--- a/ydb/src/client_topic/compression/codec_registry.rs
+++ b/ydb/src/client_topic/compression/codec_registry.rs
@@ -1,5 +1,5 @@
 use crate::client_topic::compression::builtin_codecs::{gzip_compress, gzip_decompress};
-use crate::{YdbError, YdbResult, Codec};
+use crate::{Codec, YdbError, YdbResult};
 use prost::bytes::Bytes;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/ydb/src/client_topic/compression/codec_registry.rs
+++ b/ydb/src/client_topic/compression/codec_registry.rs
@@ -1,8 +1,7 @@
 use crate::client_topic::compression::builtin_codecs::{gzip_compress, gzip_decompress};
-use crate::client_topic::list_types::Codec;
-use crate::{YdbError, YdbResult};
+use crate::{YdbError, YdbResult, Codec};
 use prost::bytes::Bytes;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 pub type EncoderFunc = Arc<dyn Fn(&Bytes) -> YdbResult<Bytes> + Send + Sync>;
@@ -57,6 +56,13 @@ impl CodecRegistry {
         self.funcs
             .get(codec)
             .ok_or_else(|| YdbError::custom(format!("unsupported codec {:?}", codec)))
+    }
+
+    pub fn supported_codecs(&self) -> HashSet<Codec> {
+        let mut codecs = HashSet::new();
+        codecs.insert(Codec::RAW);
+        codecs.extend(self.funcs.keys());
+        codecs
     }
 
     pub fn compress(&self, data: &Bytes, codec: &Codec) -> YdbResult<Bytes> {

--- a/ydb/src/client_topic/compression/codec_registry.rs
+++ b/ydb/src/client_topic/compression/codec_registry.rs
@@ -1,0 +1,69 @@
+use crate::client_topic::compression::builtin_codecs::{gzip_compress, gzip_decompress};
+use crate::client_topic::list_types::Codec;
+use crate::{YdbError, YdbResult};
+use prost::bytes::Bytes;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub type EncoderFunc = Arc<dyn Fn(&Bytes) -> YdbResult<Bytes> + Send + Sync>;
+pub type DecoderFunc = Arc<dyn Fn(&Bytes) -> YdbResult<Bytes> + Send + Sync>;
+
+#[derive(Clone)]
+pub struct CodecRegistry {
+    funcs: HashMap<Codec, (EncoderFunc, DecoderFunc)>,
+}
+
+impl Default for CodecRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodecRegistry {
+    pub fn new() -> Self {
+        let mut funcs: HashMap<Codec, (EncoderFunc, DecoderFunc)> = HashMap::new();
+        funcs.insert(
+            Codec::GZIP,
+            (Arc::new(gzip_compress), Arc::new(gzip_decompress)),
+        );
+        Self { funcs }
+    }
+
+    pub fn register_codec(
+        &mut self,
+        codec: Codec,
+        compress: EncoderFunc,
+        decompress: DecoderFunc,
+    ) -> YdbResult<()> {
+        if !codec.is_custom() {
+            return Err(YdbError::custom(format!(
+                "non-custom codec {:?} cannot be registered",
+                codec
+            )));
+        }
+
+        if self.funcs.contains_key(&codec) {
+            return Err(YdbError::custom(format!(
+                "codec {:?} is already registered",
+                codec
+            )));
+        }
+
+        self.funcs.insert(codec, (compress, decompress));
+        Ok(())
+    }
+
+    fn get_codec(&self, codec: &Codec) -> YdbResult<&(EncoderFunc, DecoderFunc)> {
+        self.funcs
+            .get(codec)
+            .ok_or_else(|| YdbError::custom(format!("unsupported codec {:?}", codec)))
+    }
+
+    pub fn compress(&self, data: &Bytes, codec: &Codec) -> YdbResult<Bytes> {
+        self.get_codec(codec).and_then(|(encode, _)| encode(data))
+    }
+
+    pub fn decompress(&self, data: &Bytes, codec: &Codec) -> YdbResult<Bytes> {
+        self.get_codec(codec).and_then(|(_, decode)| decode(data))
+    }
+}

--- a/ydb/src/client_topic/compression/codec_selector.rs
+++ b/ydb/src/client_topic/compression/codec_selector.rs
@@ -63,8 +63,8 @@ impl CodecSelector {
 
     pub fn codec(&self) -> Codec {
         match self {
-            Self::Fixed(c) => c.clone(),
-            Self::Auto { current_codec, .. } => current_codec.clone(),
+            Self::Fixed(c) => *c,
+            Self::Auto { current_codec, .. } => *current_codec,
         }
     }
 

--- a/ydb/src/client_topic/compression/codec_selector.rs
+++ b/ydb/src/client_topic/compression/codec_selector.rs
@@ -1,0 +1,145 @@
+use crate::client_topic::compression::codec_registry::CodecRegistry;
+use crate::client_topic::list_types::Codec;
+use crate::client_topic::topicwriter::message::TopicWriterMessage;
+use crate::{YdbError, YdbResult};
+use prost::bytes::Bytes;
+use std::sync::Arc;
+
+const DEFAULT_MEASURE_INTERVAL: usize = 100;
+
+pub enum CodecSelector {
+    Fixed(Codec),
+    Auto {
+        allowed_codecs: Vec<Codec>,
+        codec_registry: Arc<CodecRegistry>,
+        batch_counter: usize,
+        current_codec: Codec,
+        measure_interval: usize,
+    },
+}
+
+impl CodecSelector {
+    pub fn new(
+        user_codec: Option<Codec>,
+        server_codecs: Vec<Codec>,
+        codec_registry: Arc<CodecRegistry>,
+    ) -> YdbResult<Self> {
+        match user_codec {
+            Some(codec) => {
+                if !server_codecs.contains(&codec) {
+                    return Err(YdbError::custom(format!(
+                        "codec {:?} is not supported by the topic (supported_codecs: {:?})",
+                        codec, server_codecs
+                    )));
+                }
+                if codec != Codec::RAW && !codec_registry.supported_codecs().contains(&codec) {
+                    return Err(YdbError::custom(format!(
+                        "codec {:?} is not registered in the codec registry",
+                        codec
+                    )));
+                }
+                Ok(Self::Fixed(codec))
+            }
+            None => {
+                let allowed = calculate_allowed_codecs(&codec_registry, &server_codecs);
+                if allowed.is_empty() {
+                    return Err(YdbError::custom(
+                        "no common codecs between server and client",
+                    ));
+                }
+                if allowed.len() == 1 {
+                    return Ok(Self::Fixed(allowed[0]));
+                }
+                Ok(Self::Auto {
+                    current_codec: allowed[0],
+                    allowed_codecs: allowed,
+                    codec_registry,
+                    batch_counter: 0,
+                    measure_interval: DEFAULT_MEASURE_INTERVAL,
+                })
+            }
+        }
+    }
+
+    pub fn codec(&self) -> Codec {
+        match self {
+            Self::Fixed(c) => c.clone(),
+            Self::Auto { current_codec, .. } => current_codec.clone(),
+        }
+    }
+
+    pub fn step(&mut self, sample: &[TopicWriterMessage]) {
+        if let Self::Auto {
+            allowed_codecs,
+            codec_registry,
+            batch_counter,
+            current_codec,
+            measure_interval,
+        } = self
+        {
+            if *batch_counter % *measure_interval == 0 {
+                if let Some(best) = measure_codecs(sample, allowed_codecs, codec_registry) {
+                    *current_codec = best;
+                }
+            }
+            *batch_counter += 1;
+        }
+    }
+}
+
+fn calculate_allowed_codecs(registry: &CodecRegistry, server_codecs: &[Codec]) -> Vec<Codec> {
+    let server_list = if server_codecs.is_empty() {
+        vec![Codec::RAW, Codec::GZIP]
+    } else {
+        server_codecs.to_vec()
+    };
+
+    let supported = registry.supported_codecs();
+
+    server_list
+        .into_iter()
+        .filter(|c| supported.contains(c))
+        .collect()
+}
+
+fn measure_codecs(
+    sample: &[TopicWriterMessage],
+    codecs: &[Codec],
+    registry: &CodecRegistry,
+) -> Option<Codec> {
+    if sample.is_empty() || codecs.is_empty() {
+        return codecs.first().copied();
+    }
+
+    let mut best_codec = None;
+    let mut best_size = usize::MAX;
+
+    for &codec in codecs {
+        let total_size: usize = if codec == Codec::RAW {
+            sample.iter().map(|m| m.data.len()).sum()
+        } else {
+            let mut size = 0;
+            let mut failed = false;
+            for msg in sample {
+                match registry.compress(&Bytes::copy_from_slice(&msg.data), &codec) {
+                    Ok(compressed) => size += compressed.len(),
+                    Err(_) => {
+                        failed = true;
+                        break;
+                    }
+                }
+            }
+            if failed {
+                continue; // skip codecs that fail to compress
+            }
+            size
+        };
+
+        if total_size < best_size {
+            best_size = total_size;
+            best_codec = Some(codec);
+        }
+    }
+
+    best_codec
+}

--- a/ydb/src/client_topic/compression/compression_worker.rs
+++ b/ydb/src/client_topic/compression/compression_worker.rs
@@ -1,0 +1,91 @@
+use super::ordered_task_queue::OrderedTaskQueue;
+use crate::client_topic::compression::codec_registry::CodecRegistry;
+use crate::client_topic::compression::error_strategy::ErrorHandlingStrategy;
+use crate::client_topic::list_types::Codec;
+use crate::client_topic::topicwriter::message::TopicWriterMessage;
+use crate::YdbResult;
+use prost::bytes::Bytes;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+pub struct CompressionWorker {
+    codec: Option<Codec>,
+    codec_registry: Arc<CodecRegistry>,
+    error_strategy: ErrorHandlingStrategy,
+    queue: OrderedTaskQueue<Vec<TopicWriterMessage>>,
+}
+
+impl CompressionWorker {
+    pub fn new(
+        codec: Option<Codec>,
+        codec_registry: Arc<CodecRegistry>,
+        error_strategy: ErrorHandlingStrategy,
+    ) -> (
+        Self,
+        mpsc::UnboundedReceiver<YdbResult<Vec<TopicWriterMessage>>>,
+    ) {
+        let (queue, receiver) = OrderedTaskQueue::new();
+        (
+            Self {
+                codec,
+                codec_registry,
+                error_strategy,
+                queue,
+            },
+            receiver,
+        )
+    }
+
+    pub async fn process_batch(&self, batch: Vec<TopicWriterMessage>) -> YdbResult<()> {
+        let registry = self.codec_registry.clone();
+        let strategy = self.error_strategy.clone();
+        let codec = self.codec;
+
+        self.queue
+            .submit(Box::new(move || {
+                compress_batch(batch, &registry, &codec, &strategy)
+            }))
+            .await
+    }
+}
+
+fn compress_batch(
+    mut batch: Vec<TopicWriterMessage>,
+    registry: &CodecRegistry,
+    codec: &Option<Codec>,
+    strategy: &ErrorHandlingStrategy,
+) -> YdbResult<Vec<TopicWriterMessage>> {
+    let codec = match codec {
+        None => return Ok(batch),
+        Some(c) => c,
+    };
+
+    for message in batch.iter_mut() {
+        message
+            .uncompressed_size
+            .get_or_insert(message.data.len() as i64);
+
+        let data_bytes = Bytes::from(std::mem::take(&mut message.data));
+        match registry.compress(&data_bytes, codec) {
+            Ok(compressed) => {
+                message.data = compressed.to_vec();
+                message.codec = Some(*codec);
+            }
+            Err(err) => match strategy {
+                ErrorHandlingStrategy::FailFast => {
+                    return Err(err);
+                }
+                ErrorHandlingStrategy::Skip => {
+                    warn!(
+                        "compression failed for message (seq_no: {:?}), sending as RAW: {}",
+                        message.seq_no, err
+                    );
+                    message.data = data_bytes.to_vec();
+                }
+            },
+        }
+    }
+
+    Ok(batch)
+}

--- a/ydb/src/client_topic/compression/compression_worker.rs
+++ b/ydb/src/client_topic/compression/compression_worker.rs
@@ -9,7 +9,7 @@ use crate::YdbResult;
 use prost::bytes::Bytes;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::{warn};
+use tracing::warn;
 
 pub struct CompressionWorker {
     codec_selector: CodecSelector,

--- a/ydb/src/client_topic/compression/compression_worker.rs
+++ b/ydb/src/client_topic/compression/compression_worker.rs
@@ -1,18 +1,21 @@
 use super::ordered_task_queue::OrderedTaskQueue;
 use crate::client_topic::compression::codec_registry::CodecRegistry;
+use crate::client_topic::compression::codec_selector::CodecSelector;
 use crate::client_topic::compression::error_strategy::ErrorHandlingStrategy;
+use crate::client_topic::compression::executor::Executor;
 use crate::client_topic::list_types::Codec;
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::YdbResult;
 use prost::bytes::Bytes;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use tracing::warn;
+use tracing::{warn};
 
 pub struct CompressionWorker {
-    codec: Option<Codec>,
+    codec_selector: CodecSelector,
     codec_registry: Arc<CodecRegistry>,
     error_strategy: ErrorHandlingStrategy,
+    parallelism: usize,
     queue: OrderedTaskQueue<Vec<TopicWriterMessage>>,
 }
 
@@ -21,45 +24,54 @@ impl CompressionWorker {
         codec: Option<Codec>,
         codec_registry: Arc<CodecRegistry>,
         error_strategy: ErrorHandlingStrategy,
-    ) -> (
+        executor: Arc<dyn Executor>,
+        server_codecs: Vec<Codec>,
+    ) -> YdbResult<(
         Self,
         mpsc::UnboundedReceiver<YdbResult<Vec<TopicWriterMessage>>>,
-    ) {
-        let (queue, receiver) = OrderedTaskQueue::new();
-        (
+    )> {
+        let codec_selector = CodecSelector::new(codec, server_codecs, codec_registry.clone())?;
+        let parallelism = executor.available_parallelism();
+        let (queue, receiver) = OrderedTaskQueue::new(executor);
+        Ok((
             Self {
-                codec,
+                codec_selector,
                 codec_registry,
                 error_strategy,
+                parallelism,
                 queue,
             },
             receiver,
-        )
+        ))
     }
 
-    pub async fn process_batch(&self, batch: Vec<TopicWriterMessage>) -> YdbResult<()> {
-        let registry = self.codec_registry.clone();
-        let strategy = self.error_strategy.clone();
-        let codec = self.codec;
+    pub fn process_batch(&mut self, mut batch: Vec<TopicWriterMessage>) {
+        self.codec_selector.step(&batch);
+        let codec = self.codec_selector.codec();
 
-        self.queue
-            .submit(Box::new(move || {
-                compress_batch(batch, &registry, &codec, &strategy)
-            }))
-            .await
+        let chunk_size = (batch.len() / self.parallelism).max(1);
+        while !batch.is_empty() {
+            let chunk: Vec<TopicWriterMessage> =
+                batch.drain(..chunk_size.min(batch.len())).collect();
+            let registry = self.codec_registry.clone();
+            let strategy = self.error_strategy.clone();
+
+            self.queue.submit(Box::new(move || {
+                compress_batch(chunk, &registry, codec, &strategy)
+            }));
+        }
     }
 }
 
 fn compress_batch(
     mut batch: Vec<TopicWriterMessage>,
     registry: &CodecRegistry,
-    codec: &Option<Codec>,
+    codec: Codec,
     strategy: &ErrorHandlingStrategy,
 ) -> YdbResult<Vec<TopicWriterMessage>> {
-    let codec = match codec {
-        None => return Ok(batch),
-        Some(c) => c,
-    };
+    if codec == Codec::RAW {
+        return Ok(batch);
+    }
 
     for message in batch.iter_mut() {
         message
@@ -67,10 +79,10 @@ fn compress_batch(
             .get_or_insert(message.data.len() as i64);
 
         let data_bytes = Bytes::from(std::mem::take(&mut message.data));
-        match registry.compress(&data_bytes, codec) {
+        match registry.compress(&data_bytes, &codec) {
             Ok(compressed) => {
                 message.data = compressed.to_vec();
-                message.codec = Some(*codec);
+                message.codec = Some(codec);
             }
             Err(err) => match strategy {
                 ErrorHandlingStrategy::FailFast => {
@@ -82,6 +94,7 @@ fn compress_batch(
                         message.seq_no, err
                     );
                     message.data = data_bytes.to_vec();
+                    message.codec = Some(Codec::RAW);
                 }
             },
         }

--- a/ydb/src/client_topic/compression/decompression_worker.rs
+++ b/ydb/src/client_topic/compression/decompression_worker.rs
@@ -1,9 +1,10 @@
 use super::ordered_task_queue::OrderedTaskQueue;
 use crate::client_topic::compression::codec_registry::CodecRegistry;
 use crate::client_topic::compression::error_strategy::ErrorHandlingStrategy;
+use crate::client_topic::compression::executor::Executor;
 use crate::client_topic::list_types::Codec;
 use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-    DecompressedBatch, RawBatchWithId,
+    RawBatch, RawBatchWithId, RawMessageData,
 };
 use crate::YdbResult;
 use prost::bytes::Bytes;
@@ -14,59 +15,77 @@ use tracing::warn;
 pub struct DecompressionWorker {
     codec_registry: Arc<CodecRegistry>,
     error_strategy: ErrorHandlingStrategy,
-    queue: OrderedTaskQueue<DecompressedBatch>,
+    parallelism: usize,
+    queue: OrderedTaskQueue<RawBatchWithId>,
 }
 
 impl DecompressionWorker {
     pub fn new(
         codec_registry: Arc<CodecRegistry>,
         error_strategy: ErrorHandlingStrategy,
-    ) -> (Self, mpsc::UnboundedReceiver<YdbResult<DecompressedBatch>>) {
-        let (queue, receiver) = OrderedTaskQueue::new();
+        executor: Arc<dyn Executor>,
+    ) -> (Self, mpsc::UnboundedReceiver<YdbResult<RawBatchWithId>>) {
+        let parallelism = executor.available_parallelism();
+        let (queue, receiver) = OrderedTaskQueue::new(executor);
         (
             Self {
                 codec_registry,
                 error_strategy,
+                parallelism,
                 queue,
             },
             receiver,
         )
     }
 
-    pub async fn process_batch(&self, batch: RawBatchWithId) -> YdbResult<()> {
-        let registry = self.codec_registry.clone();
-        let strategy = self.error_strategy.clone();
+    pub fn process_batch(&self, mut batch: RawBatchWithId) {
+        let chunk_size = (batch.batch.message_data.len() / self.parallelism).max(1);
+        let total_bytes = batch.read_session_size_bytes;
 
-        self.queue
-            .submit(Box::new(move || {
-                decompress_batch(batch, &registry, &strategy)
-            }))
-            .await
+        while !batch.batch.message_data.is_empty() {
+            let chunk: Vec<RawMessageData> = batch
+                .batch
+                .message_data
+                .drain(..chunk_size.min(batch.batch.message_data.len()))
+                .collect();
+            let is_last = batch.batch.message_data.is_empty();
+
+            let chunk_batch = RawBatchWithId {
+                partition_session_id: batch.partition_session_id,
+                read_session_size_bytes: if is_last { total_bytes } else { 0 },
+                batch: RawBatch {
+                    producer_id: batch.batch.producer_id.clone(),
+                    write_session_meta: batch.batch.write_session_meta.clone(),
+                    codec: batch.batch.codec.clone(),
+                    written_at: batch.batch.written_at.clone(),
+                    message_data: chunk,
+                },
+            };
+            let registry = self.codec_registry.clone();
+            let strategy = self.error_strategy.clone();
+
+            self.queue.submit(Box::new(move || {
+                decompress_batch(chunk_batch, &registry, &strategy)
+            }));
+        }
     }
 }
 
 fn decompress_batch(
-    mut batch_with_id: RawBatchWithId,
+    mut batch: RawBatchWithId,
     registry: &CodecRegistry,
     strategy: &ErrorHandlingStrategy,
-) -> YdbResult<DecompressedBatch> {
-    let read_session_size_bytes = batch_with_id.batch.get_read_session_size();
-    let partition_session_id = batch_with_id.partition_session_id;
-    let batch = &mut batch_with_id.batch;
+) -> YdbResult<RawBatchWithId> {
     let codec = Codec {
-        code: batch.codec.code,
+        code: batch.batch.codec.code,
     };
     if codec == Codec::RAW {
-        return Ok(DecompressedBatch {
-            partition_session_id,
-            batch: batch_with_id.batch,
-            read_session_size_bytes,
-        });
+        return Ok(batch);
     }
 
     let mut failed_offsets = Vec::new();
 
-    for message in batch.message_data.iter_mut() {
+    for message in batch.batch.message_data.iter_mut() {
         let data_bytes = Bytes::from(std::mem::take(&mut message.data));
         match registry.decompress(&data_bytes, &codec) {
             Ok(decompressed) => {
@@ -90,13 +109,10 @@ fn decompress_batch(
 
     if !failed_offsets.is_empty() {
         batch
+            .batch
             .message_data
             .retain(|m| !failed_offsets.contains(&m.offset));
     }
 
-    Ok(DecompressedBatch {
-        partition_session_id,
-        batch: batch_with_id.batch,
-        read_session_size_bytes,
-    })
+    Ok(batch)
 }

--- a/ydb/src/client_topic/compression/decompression_worker.rs
+++ b/ydb/src/client_topic/compression/decompression_worker.rs
@@ -3,10 +3,7 @@ use crate::client_topic::compression::codec_registry::CodecRegistry;
 use crate::client_topic::compression::error_strategy::ErrorHandlingStrategy;
 use crate::client_topic::compression::executor::Executor;
 use crate::client_topic::list_types::Codec;
-use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-    RawBatch, RawBatchWithId, RawMessageData,
-};
-use crate::YdbResult;
+use crate::{TopicReaderMessage, YdbResult};
 use prost::bytes::Bytes;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -16,7 +13,7 @@ pub struct DecompressionWorker {
     codec_registry: Arc<CodecRegistry>,
     error_strategy: ErrorHandlingStrategy,
     parallelism: usize,
-    queue: OrderedTaskQueue<RawBatchWithId>,
+    queue: OrderedTaskQueue<Vec<TopicReaderMessage>>,
 }
 
 impl DecompressionWorker {
@@ -24,7 +21,10 @@ impl DecompressionWorker {
         codec_registry: Arc<CodecRegistry>,
         error_strategy: ErrorHandlingStrategy,
         executor: Arc<dyn Executor>,
-    ) -> (Self, mpsc::UnboundedReceiver<YdbResult<RawBatchWithId>>) {
+    ) -> (
+        Self,
+        mpsc::UnboundedReceiver<YdbResult<Vec<TopicReaderMessage>>>,
+    ) {
         let parallelism = executor.available_parallelism();
         let (queue, receiver) = OrderedTaskQueue::new(executor);
         (
@@ -38,58 +38,40 @@ impl DecompressionWorker {
         )
     }
 
-    pub fn process_batch(&self, mut batch: RawBatchWithId) {
-        let chunk_size = (batch.batch.message_data.len() / self.parallelism).max(1);
-        let total_bytes = batch.read_session_size_bytes;
+    pub fn process_batch(&self, mut batch: Vec<TopicReaderMessage>, codec: Codec) {
+        let chunk_size = (batch.len() / self.parallelism).max(1);
 
-        while !batch.batch.message_data.is_empty() {
-            let chunk: Vec<RawMessageData> = batch
-                .batch
-                .message_data
-                .drain(..chunk_size.min(batch.batch.message_data.len()))
-                .collect();
-            let is_last = batch.batch.message_data.is_empty();
-
-            let chunk_batch = RawBatchWithId {
-                partition_session_id: batch.partition_session_id,
-                read_session_size_bytes: if is_last { total_bytes } else { 0 },
-                batch: RawBatch {
-                    producer_id: batch.batch.producer_id.clone(),
-                    write_session_meta: batch.batch.write_session_meta.clone(),
-                    codec: batch.batch.codec.clone(),
-                    written_at: batch.batch.written_at.clone(),
-                    message_data: chunk,
-                },
-            };
+        while !batch.is_empty() {
+            let chunk: Vec<TopicReaderMessage> =
+                batch.drain(..chunk_size.min(batch.len())).collect();
             let registry = self.codec_registry.clone();
             let strategy = self.error_strategy.clone();
 
             self.queue.submit(Box::new(move || {
-                decompress_batch(chunk_batch, &registry, &strategy)
+                decompress_batch(chunk, codec, &registry, &strategy)
             }));
         }
     }
 }
 
 fn decompress_batch(
-    mut batch: RawBatchWithId,
+    mut batch: Vec<TopicReaderMessage>,
+    codec: Codec,
     registry: &CodecRegistry,
     strategy: &ErrorHandlingStrategy,
-) -> YdbResult<RawBatchWithId> {
-    let codec = Codec {
-        code: batch.batch.codec.code,
-    };
+) -> YdbResult<Vec<TopicReaderMessage>> {
     if codec == Codec::RAW {
         return Ok(batch);
     }
 
-    let mut failed_offsets = Vec::new();
-
-    for message in batch.batch.message_data.iter_mut() {
-        let data_bytes = Bytes::from(std::mem::take(&mut message.data));
+    for message in batch.iter_mut() {
+        if message.raw_data.is_none() {
+            continue;
+        }
+        let data_bytes = Bytes::from(std::mem::take(message.raw_data.as_mut().unwrap()));
         match registry.decompress(&data_bytes, &codec) {
             Ok(decompressed) => {
-                message.data = decompressed.to_vec();
+                message.raw_data = Some(decompressed.to_vec());
             }
             Err(err) => match strategy {
                 ErrorHandlingStrategy::FailFast => {
@@ -101,17 +83,10 @@ fn decompress_batch(
                          dropping message: {}",
                         message.offset, message.seq_no, err
                     );
-                    failed_offsets.push(message.offset);
+                    message.decompression_failed = true;
                 }
             },
         }
-    }
-
-    if !failed_offsets.is_empty() {
-        batch
-            .batch
-            .message_data
-            .retain(|m| !failed_offsets.contains(&m.offset));
     }
 
     Ok(batch)

--- a/ydb/src/client_topic/compression/decompression_worker.rs
+++ b/ydb/src/client_topic/compression/decompression_worker.rs
@@ -1,0 +1,102 @@
+use super::ordered_task_queue::OrderedTaskQueue;
+use crate::client_topic::compression::codec_registry::CodecRegistry;
+use crate::client_topic::compression::error_strategy::ErrorHandlingStrategy;
+use crate::client_topic::list_types::Codec;
+use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
+    DecompressedBatch, RawBatchWithId,
+};
+use crate::YdbResult;
+use prost::bytes::Bytes;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+pub struct DecompressionWorker {
+    codec_registry: Arc<CodecRegistry>,
+    error_strategy: ErrorHandlingStrategy,
+    queue: OrderedTaskQueue<DecompressedBatch>,
+}
+
+impl DecompressionWorker {
+    pub fn new(
+        codec_registry: Arc<CodecRegistry>,
+        error_strategy: ErrorHandlingStrategy,
+    ) -> (Self, mpsc::UnboundedReceiver<YdbResult<DecompressedBatch>>) {
+        let (queue, receiver) = OrderedTaskQueue::new();
+        (
+            Self {
+                codec_registry,
+                error_strategy,
+                queue,
+            },
+            receiver,
+        )
+    }
+
+    pub async fn process_batch(&self, batch: RawBatchWithId) -> YdbResult<()> {
+        let registry = self.codec_registry.clone();
+        let strategy = self.error_strategy.clone();
+
+        self.queue
+            .submit(Box::new(move || {
+                decompress_batch(batch, &registry, &strategy)
+            }))
+            .await
+    }
+}
+
+fn decompress_batch(
+    mut batch_with_id: RawBatchWithId,
+    registry: &CodecRegistry,
+    strategy: &ErrorHandlingStrategy,
+) -> YdbResult<DecompressedBatch> {
+    let read_session_size_bytes = batch_with_id.batch.get_read_session_size();
+    let partition_session_id = batch_with_id.partition_session_id;
+    let batch = &mut batch_with_id.batch;
+    let codec = Codec {
+        code: batch.codec.code,
+    };
+    if codec == Codec::RAW {
+        return Ok(DecompressedBatch {
+            partition_session_id,
+            batch: batch_with_id.batch,
+            read_session_size_bytes,
+        });
+    }
+
+    let mut failed_offsets = Vec::new();
+
+    for message in batch.message_data.iter_mut() {
+        let data_bytes = Bytes::from(std::mem::take(&mut message.data));
+        match registry.decompress(&data_bytes, &codec) {
+            Ok(decompressed) => {
+                message.data = decompressed.to_vec();
+            }
+            Err(err) => match strategy {
+                ErrorHandlingStrategy::FailFast => {
+                    return Err(err);
+                }
+                ErrorHandlingStrategy::Skip => {
+                    warn!(
+                        "decompression failed for message (offset: {}, seq_no: {}), \
+                         dropping message: {}",
+                        message.offset, message.seq_no, err
+                    );
+                    failed_offsets.push(message.offset);
+                }
+            },
+        }
+    }
+
+    if !failed_offsets.is_empty() {
+        batch
+            .message_data
+            .retain(|m| !failed_offsets.contains(&m.offset));
+    }
+
+    Ok(DecompressedBatch {
+        partition_session_id,
+        batch: batch_with_id.batch,
+        read_session_size_bytes,
+    })
+}

--- a/ydb/src/client_topic/compression/error_strategy.rs
+++ b/ydb/src/client_topic/compression/error_strategy.rs
@@ -1,4 +1,4 @@
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum ErrorHandlingStrategy {
     FailFast,
     Skip,

--- a/ydb/src/client_topic/compression/error_strategy.rs
+++ b/ydb/src/client_topic/compression/error_strategy.rs
@@ -1,0 +1,5 @@
+#[derive(Clone)]
+pub enum ErrorHandlingStrategy {
+    FailFast,
+    Skip,
+}

--- a/ydb/src/client_topic/compression/executor.rs
+++ b/ydb/src/client_topic/compression/executor.rs
@@ -1,0 +1,49 @@
+use std::sync::{Arc, LazyLock};
+
+pub trait Executor: Send + Sync {
+    /// Returns the number of threads available for parallel processing.
+    fn available_parallelism(&self) -> usize;
+
+    /// Submits a task for execution. Fire-and-forget.
+    fn execute(&self, task: Box<dyn FnOnce() + Send + 'static>);
+}
+
+pub struct RayonExecutor {
+    pool: rayon::ThreadPool,
+}
+
+impl RayonExecutor {
+    pub fn new(num_threads: usize) -> Self {
+        Self {
+            pool: rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .build()
+                .expect("failed to create rayon thread pool"),
+        }
+    }
+}
+
+const DEFAULT_THREAD_COUNT: usize = 4;
+
+impl Default for RayonExecutor {
+    fn default() -> Self {
+        Self::new(DEFAULT_THREAD_COUNT)
+    }
+}
+
+impl Executor for RayonExecutor {
+    fn available_parallelism(&self) -> usize {
+        self.pool.current_num_threads()
+    }
+
+    fn execute(&self, task: Box<dyn FnOnce() + Send + 'static>) {
+        self.pool.spawn(move || task());
+    }
+}
+
+static DEFAULT_EXECUTOR: LazyLock<Arc<dyn Executor>> =
+    LazyLock::new(|| Arc::new(RayonExecutor::default()));
+
+pub fn default_executor() -> Arc<dyn Executor> {
+    DEFAULT_EXECUTOR.clone()
+}

--- a/ydb/src/client_topic/compression/executor.rs
+++ b/ydb/src/client_topic/compression/executor.rs
@@ -47,3 +47,27 @@ static DEFAULT_EXECUTOR: LazyLock<Arc<dyn Executor>> =
 pub fn default_executor() -> Arc<dyn Executor> {
     DEFAULT_EXECUTOR.clone()
 }
+
+pub struct InplaceExecutor {}
+
+impl InplaceExecutor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for InplaceExecutor {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl Executor for InplaceExecutor {
+    fn available_parallelism(&self) -> usize {
+        1
+    }
+
+    fn execute(&self, task: Box<dyn FnOnce() + Send + 'static>) {
+        task();
+    }
+}

--- a/ydb/src/client_topic/compression/executor.rs
+++ b/ydb/src/client_topic/compression/executor.rs
@@ -48,17 +48,12 @@ pub fn default_executor() -> Arc<dyn Executor> {
     DEFAULT_EXECUTOR.clone()
 }
 
+#[derive(Default)]
 pub struct InplaceExecutor {}
 
 impl InplaceExecutor {
     pub fn new() -> Self {
         Self::default()
-    }
-}
-
-impl Default for InplaceExecutor {
-    fn default() -> Self {
-        Self {}
     }
 }
 

--- a/ydb/src/client_topic/compression/executor.rs
+++ b/ydb/src/client_topic/compression/executor.rs
@@ -37,7 +37,7 @@ impl Executor for RayonExecutor {
     }
 
     fn execute(&self, task: Box<dyn FnOnce() + Send + 'static>) {
-        self.pool.spawn(move || task());
+        self.pool.spawn(task);
     }
 }
 

--- a/ydb/src/client_topic/compression/mod.rs
+++ b/ydb/src/client_topic/compression/mod.rs
@@ -1,0 +1,11 @@
+mod builtin_codecs;
+mod codec_registry;
+mod compression_worker;
+mod decompression_worker;
+mod error_strategy;
+mod ordered_task_queue;
+
+pub use codec_registry::CodecRegistry;
+pub use compression_worker::CompressionWorker;
+pub use decompression_worker::DecompressionWorker;
+pub use error_strategy::ErrorHandlingStrategy;

--- a/ydb/src/client_topic/compression/mod.rs
+++ b/ydb/src/client_topic/compression/mod.rs
@@ -11,4 +11,4 @@ pub use codec_registry::CodecRegistry;
 pub use compression_worker::CompressionWorker;
 pub use decompression_worker::DecompressionWorker;
 pub use error_strategy::ErrorHandlingStrategy;
-pub use executor::{default_executor, Executor, RayonExecutor};
+pub use executor::{default_executor, Executor, InplaceExecutor, RayonExecutor};

--- a/ydb/src/client_topic/compression/mod.rs
+++ b/ydb/src/client_topic/compression/mod.rs
@@ -1,11 +1,14 @@
 mod builtin_codecs;
 mod codec_registry;
+mod codec_selector;
 mod compression_worker;
 mod decompression_worker;
 mod error_strategy;
+mod executor;
 mod ordered_task_queue;
 
 pub use codec_registry::CodecRegistry;
 pub use compression_worker::CompressionWorker;
 pub use decompression_worker::DecompressionWorker;
 pub use error_strategy::ErrorHandlingStrategy;
+pub use executor::{default_executor, Executor, RayonExecutor};

--- a/ydb/src/client_topic/compression/ordered_task_queue.rs
+++ b/ydb/src/client_topic/compression/ordered_task_queue.rs
@@ -1,0 +1,39 @@
+use crate::{YdbError, YdbResult};
+use tokio::sync::mpsc;
+
+type WorkerTask<T> = Box<dyn FnOnce() -> YdbResult<T> + Send + 'static>;
+
+const DEFAULT_TASK_CHANNEL_CAPACITY: usize = 32;
+
+pub struct OrderedTaskQueue<T> {
+    task_sender: mpsc::Sender<WorkerTask<T>>,
+}
+
+impl<T: Send + 'static> OrderedTaskQueue<T> {
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<YdbResult<T>>) {
+        Self::with_capacity(DEFAULT_TASK_CHANNEL_CAPACITY)
+    }
+
+    pub fn with_capacity(capacity: usize) -> (Self, mpsc::UnboundedReceiver<YdbResult<T>>) {
+        let (task_sender, mut task_receiver) = mpsc::channel::<WorkerTask<T>>(capacity);
+        let (result_sender, result_receiver) = mpsc::unbounded_channel::<YdbResult<T>>();
+
+        std::thread::spawn(move || {
+            while let Some(task) = task_receiver.blocking_recv() {
+                let result = task();
+                if result_sender.send(result).is_err() {
+                    break;
+                }
+            }
+        });
+
+        (Self { task_sender }, result_receiver)
+    }
+
+    pub async fn submit(&self, task: WorkerTask<T>) -> YdbResult<()> {
+        self.task_sender
+            .send(task)
+            .await
+            .map_err(|err| YdbError::custom(format!("ordered queue is closed: {err}")))
+    }
+}

--- a/ydb/src/client_topic/compression/ordered_task_queue.rs
+++ b/ydb/src/client_topic/compression/ordered_task_queue.rs
@@ -1,39 +1,61 @@
-use crate::{YdbError, YdbResult};
+use crate::client_topic::compression::executor::Executor;
+use crate::YdbResult;
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
 type WorkerTask<T> = Box<dyn FnOnce() -> YdbResult<T> + Send + 'static>;
 
-const DEFAULT_TASK_CHANNEL_CAPACITY: usize = 32;
+pub struct OrderedTaskQueue<T: Send + 'static> {
+    executor: Arc<dyn Executor>,
+    state: Arc<Mutex<ReorderState<T>>>,
+    next_seq: AtomicU64,
+}
 
-pub struct OrderedTaskQueue<T> {
-    task_sender: mpsc::Sender<WorkerTask<T>>,
+struct ReorderState<T> {
+    next_expected: u64,
+    pending: BTreeMap<u64, YdbResult<T>>,
+    result_sender: mpsc::UnboundedSender<YdbResult<T>>,
+}
+
+impl<T: Send + 'static> ReorderState<T> {
+    fn insert_and_drain(&mut self, seq: u64, result: YdbResult<T>) {
+        self.pending.insert(seq, result);
+
+        while let Some(result) = self.pending.remove(&self.next_expected) {
+            if self.result_sender.send(result).is_err() {
+                break; // consumer dropped
+            }
+            self.next_expected += 1;
+        }
+    }
 }
 
 impl<T: Send + 'static> OrderedTaskQueue<T> {
-    pub fn new() -> (Self, mpsc::UnboundedReceiver<YdbResult<T>>) {
-        Self::with_capacity(DEFAULT_TASK_CHANNEL_CAPACITY)
-    }
-
-    pub fn with_capacity(capacity: usize) -> (Self, mpsc::UnboundedReceiver<YdbResult<T>>) {
-        let (task_sender, mut task_receiver) = mpsc::channel::<WorkerTask<T>>(capacity);
+    pub fn new(executor: Arc<dyn Executor>) -> (Self, mpsc::UnboundedReceiver<YdbResult<T>>) {
         let (result_sender, result_receiver) = mpsc::unbounded_channel::<YdbResult<T>>();
-
-        std::thread::spawn(move || {
-            while let Some(task) = task_receiver.blocking_recv() {
-                let result = task();
-                if result_sender.send(result).is_err() {
-                    break;
-                }
-            }
-        });
-
-        (Self { task_sender }, result_receiver)
+        (
+            Self {
+                executor,
+                state: Arc::new(Mutex::new(ReorderState {
+                    next_expected: 0,
+                    pending: BTreeMap::new(),
+                    result_sender,
+                })),
+                next_seq: AtomicU64::new(0),
+            },
+            result_receiver,
+        )
     }
 
-    pub async fn submit(&self, task: WorkerTask<T>) -> YdbResult<()> {
-        self.task_sender
-            .send(task)
-            .await
-            .map_err(|err| YdbError::custom(format!("ordered queue is closed: {err}")))
+    pub fn submit(&self, task: WorkerTask<T>) {
+        let seq = self.next_seq.fetch_add(1, Ordering::Relaxed);
+        let state = self.state.clone();
+
+        self.executor.execute(Box::new(move || {
+            let result = task();
+            state.lock().unwrap().insert_and_drain(seq, result);
+        }));
     }
 }

--- a/ydb/src/client_topic/list_types.rs
+++ b/ydb/src/client_topic/list_types.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::option::Option;
 use std::time::SystemTime;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Copy)]
 pub struct Codec {
     pub code: i32,
 }

--- a/ydb/src/client_topic/mod.rs
+++ b/ydb/src/client_topic/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod client;
+pub(crate) mod compression;
 pub(crate) mod list_types;
 pub(crate) mod topicreader;
 pub(crate) mod topicwriter;

--- a/ydb/src/client_topic/topicreader/messages.rs
+++ b/ydb/src/client_topic/topicreader/messages.rs
@@ -53,6 +53,7 @@ impl TopicReaderBatch {
                         },
 
                         bytes_to_release: 0,
+                        decompression_failed: false,
                     }
                 })
                 .collect(),
@@ -101,12 +102,13 @@ pub struct TopicReaderMessage {
     pub uncompressed_size: i64, // as sent by sender, server/sdk doesn't check the field. It may be empty or wrong.
 
     producer_id: String,
-    raw_data: Option<Vec<u8>>,
+    pub(crate) raw_data: Option<Vec<u8>>,
     pub(crate) commit_marker: TopicReaderCommitMarker,
 
     // Non-zero only on the last message of a server ReadResponse; carries the
     // response's bytes_size for flow-control (sent back as ReadRequest).
     pub(crate) bytes_to_release: i64,
+    pub(crate) decompression_failed: bool,
 }
 
 impl TopicReaderMessage {

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -1,4 +1,5 @@
 use crate::client_common::TokenCache;
+use crate::client_topic::compression::DecompressionWorker;
 use crate::client_topic::topicreader::cancelation_token::YdbCancellationToken;
 use crate::client_topic::topicreader::messages::{TopicReaderBatch, TopicReaderMessage};
 use crate::client_topic::topicreader::partition_state::PartitionSession;
@@ -11,9 +12,9 @@ use crate::grpc_wrapper::raw_topic_service::client::RawTopicClient;
 use crate::grpc_wrapper::raw_topic_service::common::partition::RawOffsetsRange;
 use crate::grpc_wrapper::raw_topic_service::common::update_token::RawUpdateTokenRequest;
 use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-    PartitionCommitOffset, RawCommitOffsetRequest, RawFromClientOneOf, RawFromServer,
-    RawInitRequest, RawReadRequest, RawReadResponse, RawStartPartitionSessionResponse,
-    RawStopPartitionSessionResponse, RawTopicReadSettings,
+    DecompressedBatch, PartitionCommitOffset, RawBatchWithId, RawCommitOffsetRequest,
+    RawFromClientOneOf, RawFromServer, RawInitRequest, RawReadRequest,
+    RawStartPartitionSessionResponse, RawStopPartitionSessionResponse, RawTopicReadSettings,
 };
 use crate::grpc_wrapper::raw_topic_service::update_offsets_in_transaction::{
     RawPartitionOffsets, RawTopicOffsets, RawTransactionIdentity,
@@ -29,6 +30,7 @@ use std::sync::{Arc, Mutex};
 use std::time;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::select;
+use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Notify;
 use tracing::{debug, error, info, warn};
@@ -210,10 +212,15 @@ impl TopicReader {
         let shared = Arc::new(ReaderShared::new());
         let stop_backgroung_work_token = YdbCancellationToken::new();
 
+        let (decompression_worker, decompression_receiver) =
+            DecompressionWorker::new(options.codec_registry, options.compression_error_strategy);
+
         tokio::spawn(receive_loop(
             stream,
             shared.clone(),
             stop_backgroung_work_token.clone(),
+            decompression_worker,
+            decompression_receiver,
         ));
 
         tokio::spawn(Self::update_token_loop(
@@ -324,6 +331,8 @@ async fn receive_loop(
     mut stream: AsyncGrpcStreamWrapper<FromClient, FromServer>,
     shared: Arc<ReaderShared>,
     stop: YdbCancellationToken,
+    decompression_worker: DecompressionWorker,
+    mut decompression_receiver: mpsc::UnboundedReceiver<YdbResult<DecompressedBatch>>,
 ) {
     let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
     let tokio_stop = stop.to_tokio_token();
@@ -344,10 +353,18 @@ async fn receive_loop(
                             msg,
                             &mut sessions,
                             &sender_for_responses,
-                            &shared,
-                        ) {
+                            &decompression_worker,
+                        ).await {
                             break Some(e);
                         }
+                    }
+                }
+            }
+            Some(result) = decompression_receiver.recv() => {
+                match result {
+                    Err(e) => break Some(e),
+                    Ok(batch) => {
+                        handle_batch(batch, &mut sessions, &shared);
                     }
                 }
             }
@@ -357,14 +374,25 @@ async fn receive_loop(
     close_with_error(&shared, err);
 }
 
-fn handle_incoming(
+async fn handle_incoming(
     msg: RawFromServer,
     sessions: &mut HashMap<i64, PartitionSession>,
     sender: &UnboundedSender<FromClient>,
-    shared: &ReaderShared,
+    decompression_worker: &DecompressionWorker,
 ) -> YdbResult<()> {
     match msg {
-        RawFromServer::ReadResponse(resp) => handle_read_response(resp, sessions, shared)?,
+        RawFromServer::ReadResponse(resp) => {
+            for partition_data in resp.partition_data {
+                for batch in partition_data.batches {
+                    decompression_worker
+                        .process_batch(RawBatchWithId {
+                            partition_session_id: partition_data.partition_session_id,
+                            batch,
+                        })
+                        .await?;
+                }
+            }
+        }
         RawFromServer::InitResponse(resp) => {
             info!("init response for topic reader: {:?}", resp)
         }
@@ -404,50 +432,47 @@ fn handle_incoming(
     Ok(())
 }
 
-/// Parses a RawReadResponse into TopicReaderMessages and appends them to the
-/// shared buffer in FIFO order. The `bytes_to_release` tag is set by
-/// `RawBatch::get_read_session_size()` — non-zero only on the very last message
-/// of the entire response (see `From<ReadResponse> for RawReadResponse`).
-pub(crate) fn handle_read_response(
-    resp: RawReadResponse,
+/// Converts a decompressed batch into TopicReaderMessages and appends them to
+/// the shared buffer in FIFO order. The `read_session_size_bytes` is stamped on
+/// the last message for flow-control (sent back as ReadRequest).
+fn handle_batch(
+    decompressed: DecompressedBatch,
     sessions: &mut HashMap<i64, PartitionSession>,
     shared: &ReaderShared,
-) -> YdbResult<()> {
-    for partition_data in resp.partition_data {
-        let partition_session_id = partition_data.partition_session_id;
-        let session = match sessions.get_mut(&partition_session_id) {
-            Some(s) => s,
-            None => {
-                error!(
-                    "read_response for unknown partition_session_id: {}",
-                    partition_session_id
-                );
-                continue;
-            }
-        };
-        for raw_batch in partition_data.batches {
-            if raw_batch.message_data.is_empty() {
-                continue;
-            }
-            let batch_bytes = raw_batch.get_read_session_size();
-            let batch = TopicReaderBatch::new(raw_batch, session);
-            let mut messages = batch.messages;
-            if let Some(last) = messages.last_mut() {
-                last.bytes_to_release = batch_bytes;
-            }
+) {
+    let partition_session_id = decompressed.partition_session_id;
+    let raw_batch = decompressed.batch;
 
-            {
-                let mut buf = shared
-                    .buffer
-                    .lock()
-                    .expect("topic reader buffer mutex poisoned");
-                buf.extend(messages);
-            }
-            // push-then-notify: no lost wakeups
-            shared.notify.notify_one();
-        }
+    if raw_batch.message_data.is_empty() {
+        return;
     }
-    Ok(())
+
+    let session = match sessions.get_mut(&partition_session_id) {
+        Some(s) => s,
+        None => {
+            error!(
+                "read_response for unknown partition_session_id: {}",
+                partition_session_id
+            );
+            return;
+        }
+    };
+
+    let batch = TopicReaderBatch::new(raw_batch, session);
+    let mut messages = batch.messages;
+    if let Some(last) = messages.last_mut() {
+        last.bytes_to_release = decompressed.read_session_size_bytes;
+    }
+
+    {
+        let mut buf = shared
+            .buffer
+            .lock()
+            .expect("topic reader buffer mutex poisoned");
+        buf.extend(messages);
+    }
+    // push-then-notify: no lost wakeups
+    shared.notify.notify_one();
 }
 
 pub(crate) fn close_with_error(shared: &ReaderShared, err: Option<YdbError>) {
@@ -556,7 +581,7 @@ mod tests {
     use crate::client_topic::topicreader::messages::TopicReaderBatch;
     use crate::grpc_wrapper::raw_topic_service::common::codecs::RawCodec;
     use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-        RawBatch, RawMessageData, RawPartitionData,
+        RawBatch, RawMessageData, RawPartitionData, RawReadResponse,
     };
     use crate::grpc_wrapper::raw_topic_service::update_offsets_in_transaction::*;
     use std::time::Duration;
@@ -763,7 +788,30 @@ mod tests {
         assert_eq!(bytes_second, 1234);
     }
 
-    // ---- handle_read_response ----
+    // ---- handle_batch (via process_response helper) ----
+
+    /// Test helper: processes a RawReadResponse through handle_batch, mimicking
+    /// the production pipeline for RAW (uncompressed) batches.
+    fn process_response(
+        resp: RawReadResponse,
+        sessions: &mut HashMap<i64, PartitionSession>,
+        shared: &ReaderShared,
+    ) {
+        for partition_data in resp.partition_data {
+            for raw_batch in partition_data.batches {
+                let bytes = raw_batch.get_read_session_size();
+                handle_batch(
+                    DecompressedBatch {
+                        partition_session_id: partition_data.partition_session_id,
+                        batch: raw_batch,
+                        read_session_size_bytes: bytes,
+                    },
+                    sessions,
+                    shared,
+                );
+            }
+        }
+    }
 
     fn make_raw_partition_data(
         partition_session_id: i64,
@@ -797,7 +845,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_read_response_preserves_fifo_across_partition_data() {
+    fn test_handle_batch_preserves_fifo_across_partition_data() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t-a", 0));
@@ -809,7 +857,7 @@ mod tests {
         let pd_a2 = make_raw_partition_data(3, vec![make_raw_batch(0, 2)]);
 
         let resp = make_raw_read_response(9999, vec![pd_a1, pd_b, pd_a2]);
-        handle_read_response(resp, &mut sessions, &shared).unwrap();
+        process_response(resp, &mut sessions, &shared);
 
         let buf = shared.buffer.lock().unwrap();
         assert_eq!(buf.len(), 9);
@@ -829,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_read_response_skips_empty_batches() {
+    fn test_handle_batch_skips_empty_batches() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 0));
@@ -844,7 +892,7 @@ mod tests {
         let pd = make_raw_partition_data(1, vec![empty_batch, make_raw_batch(0, 2)]);
         let resp = make_raw_read_response(500, vec![pd]);
 
-        handle_read_response(resp, &mut sessions, &shared).unwrap();
+        process_response(resp, &mut sessions, &shared);
 
         let buf = shared.buffer.lock().unwrap();
         assert_eq!(buf.len(), 2);
@@ -854,7 +902,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_read_response_advances_next_commit_offset_start() {
+    fn test_handle_batch_advances_next_commit_offset_start() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 100));
@@ -862,13 +910,13 @@ mod tests {
         let pd = make_raw_partition_data(1, vec![make_raw_batch(100, 3)]);
         let resp = make_raw_read_response(10, vec![pd]);
 
-        handle_read_response(resp, &mut sessions, &shared).unwrap();
+        process_response(resp, &mut sessions, &shared);
 
         assert_eq!(sessions.get(&1).unwrap().next_commit_offset_start, 103);
     }
 
     #[test]
-    fn test_handle_read_response_drops_data_for_unknown_session() {
+    fn test_handle_batch_drops_data_for_unknown_session() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 0));
@@ -877,7 +925,7 @@ mod tests {
         let pd_known = make_raw_partition_data(1, vec![make_raw_batch(0, 2)]);
         let resp = make_raw_read_response(123, vec![pd_unknown, pd_known]);
 
-        handle_read_response(resp, &mut sessions, &shared).unwrap();
+        process_response(resp, &mut sessions, &shared);
 
         let buf = shared.buffer.lock().unwrap();
         assert_eq!(buf.len(), 2);
@@ -887,7 +935,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_read_response_notifies_after_push() {
+    async fn test_handle_batch_notifies_after_push() {
         let shared = Arc::new(ReaderShared::new());
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 0));
@@ -898,7 +946,7 @@ mod tests {
 
         let pd = make_raw_partition_data(1, vec![make_raw_batch(0, 2)]);
         let resp = make_raw_read_response(100, vec![pd]);
-        handle_read_response(resp, &mut sessions, shared.as_ref()).unwrap();
+        process_response(resp, &mut sessions, shared.as_ref());
 
         tokio::time::timeout(Duration::from_millis(100), notified)
             .await

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -12,8 +12,8 @@ use crate::grpc_wrapper::raw_topic_service::client::RawTopicClient;
 use crate::grpc_wrapper::raw_topic_service::common::partition::RawOffsetsRange;
 use crate::grpc_wrapper::raw_topic_service::common::update_token::RawUpdateTokenRequest;
 use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-    PartitionCommitOffset, RawBatchWithId, RawCommitOffsetRequest, RawFromClientOneOf,
-    RawFromServer, RawInitRequest, RawReadRequest, RawStartPartitionSessionResponse,
+    PartitionCommitOffset, RawCommitOffsetRequest, RawFromClientOneOf, RawFromServer,
+    RawInitRequest, RawReadRequest, RawReadResponse, RawStartPartitionSessionResponse,
     RawStopPartitionSessionResponse, RawTopicReadSettings,
 };
 use crate::grpc_wrapper::raw_topic_service::update_offsets_in_transaction::{
@@ -22,7 +22,7 @@ use crate::grpc_wrapper::raw_topic_service::update_offsets_in_transaction::{
 };
 use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
 use crate::transaction::{Transaction, TransactionInfo};
-use crate::{YdbError, YdbResult};
+use crate::{Codec, YdbError, YdbResult};
 use secrecy::ExposeSecret;
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -320,6 +320,9 @@ pub(crate) fn cut_prefix(
             Some(m) if m.commit_marker.partition_session_id == session_id => {
                 let m = buffer.pop_front().expect("front() returned Some");
                 bytes += m.bytes_to_release;
+                if m.decompression_failed {
+                    continue;
+                }
                 out.push(m);
             }
             _ => break,
@@ -335,7 +338,7 @@ async fn receive_loop(
     shared: Arc<ReaderShared>,
     stop: YdbCancellationToken,
     decompression_worker: DecompressionWorker,
-    mut decompression_receiver: mpsc::UnboundedReceiver<YdbResult<RawBatchWithId>>,
+    mut decompression_receiver: mpsc::UnboundedReceiver<YdbResult<Vec<TopicReaderMessage>>>,
 ) {
     let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
     let tokio_stop = stop.to_tokio_token();
@@ -366,8 +369,16 @@ async fn receive_loop(
             Some(result) = decompression_receiver.recv() => {
                 match result {
                     Err(e) => break Some(e),
-                    Ok(batch) => {
-                        handle_batch(batch, &mut sessions, &shared);
+                    Ok(messages) => {
+                        {
+                            let mut buf = shared
+                                .buffer
+                                .lock()
+                                .expect("topic reader buffer mutex poisoned");
+                            buf.extend(messages);
+                        }
+                        // push-then-notify: no lost wakeups
+                        shared.notify.notify_one();
                     }
                 }
             }
@@ -385,16 +396,7 @@ fn handle_incoming(
 ) -> YdbResult<()> {
     match msg {
         RawFromServer::ReadResponse(resp) => {
-            for partition_data in resp.partition_data {
-                for batch in partition_data.batches {
-                    let read_session_size_bytes = batch.get_read_session_size();
-                    decompression_worker.process_batch(RawBatchWithId {
-                        partition_session_id: partition_data.partition_session_id,
-                        read_session_size_bytes,
-                        batch,
-                    });
-                }
-            }
+            handle_read_response(resp, sessions, decompression_worker)?
         }
         RawFromServer::InitResponse(resp) => {
             info!("init response for topic reader: {:?}", resp)
@@ -435,47 +437,44 @@ fn handle_incoming(
     Ok(())
 }
 
-/// Converts a decompressed batch into TopicReaderMessages and appends them to
-/// the shared buffer in FIFO order. The `read_session_size_bytes` is stamped on
-/// the last message for flow-control (sent back as ReadRequest).
-fn handle_batch(
-    decompressed: RawBatchWithId,
+/// Parses a RawReadResponse into TopicReaderMessages and appends them to the
+/// shared buffer in FIFO order. The `bytes_to_release` tag is set by
+/// `RawBatch::get_read_session_size()` — non-zero only on the very last message
+/// of the entire response (see `From<ReadResponse> for RawReadResponse`).
+pub(crate) fn handle_read_response(
+    resp: RawReadResponse,
     sessions: &mut HashMap<i64, PartitionSession>,
-    shared: &ReaderShared,
-) {
-    let partition_session_id = decompressed.partition_session_id;
-    let raw_batch = decompressed.batch;
-
-    if raw_batch.message_data.is_empty() {
-        return;
-    }
-
-    let session = match sessions.get_mut(&partition_session_id) {
-        Some(s) => s,
-        None => {
-            error!(
-                "read_response for unknown partition_session_id: {}",
-                partition_session_id
-            );
-            return;
+    decompression_worker: &DecompressionWorker,
+) -> YdbResult<()> {
+    for partition_data in resp.partition_data {
+        let partition_session_id = partition_data.partition_session_id;
+        let session = match sessions.get_mut(&partition_session_id) {
+            Some(s) => s,
+            None => {
+                error!(
+                    "read_response for unknown partition_session_id: {}",
+                    partition_session_id
+                );
+                continue;
+            }
+        };
+        for raw_batch in partition_data.batches {
+            if raw_batch.message_data.is_empty() {
+                continue;
+            }
+            let batch_bytes = raw_batch.get_read_session_size();
+            let codec = Codec {
+                code: raw_batch.codec.code,
+            };
+            let batch = TopicReaderBatch::new(raw_batch, session);
+            let mut messages = batch.messages;
+            if let Some(last) = messages.last_mut() {
+                last.bytes_to_release = batch_bytes;
+            }
+            decompression_worker.process_batch(messages, codec);
         }
-    };
-
-    let batch = TopicReaderBatch::new(raw_batch, session);
-    let mut messages = batch.messages;
-    if let Some(last) = messages.last_mut() {
-        last.bytes_to_release = decompressed.read_session_size_bytes;
     }
-
-    {
-        let mut buf = shared
-            .buffer
-            .lock()
-            .expect("topic reader buffer mutex poisoned");
-        buf.extend(messages);
-    }
-    // push-then-notify: no lost wakeups
-    shared.notify.notify_one();
+    Ok(())
 }
 
 pub(crate) fn close_with_error(shared: &ReaderShared, err: Option<YdbError>) {
@@ -581,12 +580,14 @@ pub struct TopicReaderCommitMarker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client_topic::compression::InplaceExecutor;
     use crate::client_topic::topicreader::messages::TopicReaderBatch;
     use crate::grpc_wrapper::raw_topic_service::common::codecs::RawCodec;
     use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-        RawBatch, RawMessageData, RawPartitionData, RawReadResponse,
+        RawBatch, RawMessageData, RawPartitionData,
     };
     use crate::grpc_wrapper::raw_topic_service::update_offsets_in_transaction::*;
+    use crate::CodecRegistry;
     use std::time::Duration;
 
     #[test]
@@ -791,30 +792,7 @@ mod tests {
         assert_eq!(bytes_second, 1234);
     }
 
-    // ---- handle_batch (via process_response helper) ----
-
-    /// Test helper: processes a RawReadResponse through handle_batch, mimicking
-    /// the production pipeline for RAW (uncompressed) batches.
-    fn process_response(
-        resp: RawReadResponse,
-        sessions: &mut HashMap<i64, PartitionSession>,
-        shared: &ReaderShared,
-    ) {
-        for partition_data in resp.partition_data {
-            for raw_batch in partition_data.batches {
-                let bytes = raw_batch.get_read_session_size();
-                handle_batch(
-                    RawBatchWithId {
-                        partition_session_id: partition_data.partition_session_id,
-                        read_session_size_bytes: bytes,
-                        batch: raw_batch,
-                    },
-                    sessions,
-                    shared,
-                );
-            }
-        }
-    }
+    // ---- handle_read_response ----
 
     fn make_raw_partition_data(
         partition_session_id: i64,
@@ -847,8 +825,33 @@ mod tests {
         resp
     }
 
+    fn handle_read_response_test(
+        resp: RawReadResponse,
+        sessions: &mut HashMap<i64, PartitionSession>,
+        shared: &ReaderShared,
+    ) -> YdbResult<()> {
+        let (decompression_worker, mut decompression_receiver) = DecompressionWorker::new(
+            Arc::new(CodecRegistry::new()),
+            crate::ErrorHandlingStrategy::FailFast,
+            Arc::new(InplaceExecutor::new()),
+        );
+
+        handle_read_response(resp, sessions, &decompression_worker)?;
+
+        while let Ok(messages) = decompression_receiver.try_recv() {
+            let mut buf = shared
+                .buffer
+                .lock()
+                .expect("topic reader buffer mutex poisoned");
+            buf.extend(messages.unwrap());
+        }
+        shared.notify.notify_one();
+
+        Ok(())
+    }
+
     #[test]
-    fn test_handle_batch_preserves_fifo_across_partition_data() {
+    fn test_handle_read_response_preserves_fifo_across_partition_data() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t-a", 0));
@@ -860,7 +863,7 @@ mod tests {
         let pd_a2 = make_raw_partition_data(3, vec![make_raw_batch(0, 2)]);
 
         let resp = make_raw_read_response(9999, vec![pd_a1, pd_b, pd_a2]);
-        process_response(resp, &mut sessions, &shared);
+        handle_read_response_test(resp, &mut sessions, &shared).unwrap();
 
         let buf = shared.buffer.lock().unwrap();
         assert_eq!(buf.len(), 9);
@@ -880,7 +883,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_batch_skips_empty_batches() {
+    fn test_handle_read_response_skips_empty_batches() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 0));
@@ -895,7 +898,7 @@ mod tests {
         let pd = make_raw_partition_data(1, vec![empty_batch, make_raw_batch(0, 2)]);
         let resp = make_raw_read_response(500, vec![pd]);
 
-        process_response(resp, &mut sessions, &shared);
+        handle_read_response_test(resp, &mut sessions, &shared).unwrap();
 
         let buf = shared.buffer.lock().unwrap();
         assert_eq!(buf.len(), 2);
@@ -905,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn test_handle_batch_advances_next_commit_offset_start() {
+    fn test_handle_read_response_advances_next_commit_offset_start() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 100));
@@ -913,13 +916,13 @@ mod tests {
         let pd = make_raw_partition_data(1, vec![make_raw_batch(100, 3)]);
         let resp = make_raw_read_response(10, vec![pd]);
 
-        process_response(resp, &mut sessions, &shared);
+        handle_read_response_test(resp, &mut sessions, &shared).unwrap();
 
         assert_eq!(sessions.get(&1).unwrap().next_commit_offset_start, 103);
     }
 
     #[test]
-    fn test_handle_batch_drops_data_for_unknown_session() {
+    fn test_handle_read_response_drops_data_for_unknown_session() {
         let shared = ReaderShared::new();
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 0));
@@ -928,7 +931,7 @@ mod tests {
         let pd_known = make_raw_partition_data(1, vec![make_raw_batch(0, 2)]);
         let resp = make_raw_read_response(123, vec![pd_unknown, pd_known]);
 
-        process_response(resp, &mut sessions, &shared);
+        handle_read_response_test(resp, &mut sessions, &shared).unwrap();
 
         let buf = shared.buffer.lock().unwrap();
         assert_eq!(buf.len(), 2);
@@ -938,7 +941,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_batch_notifies_after_push() {
+    async fn test_handle_read_response_notifies_after_push() {
         let shared = Arc::new(ReaderShared::new());
         let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
         sessions.insert(1, make_session(1, 11, "t", 0));
@@ -949,7 +952,7 @@ mod tests {
 
         let pd = make_raw_partition_data(1, vec![make_raw_batch(0, 2)]);
         let resp = make_raw_read_response(100, vec![pd]);
-        process_response(resp, &mut sessions, shared.as_ref());
+        handle_read_response_test(resp, &mut sessions, shared.as_ref()).unwrap();
 
         tokio::time::timeout(Duration::from_millis(100), notified)
             .await

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -12,9 +12,9 @@ use crate::grpc_wrapper::raw_topic_service::client::RawTopicClient;
 use crate::grpc_wrapper::raw_topic_service::common::partition::RawOffsetsRange;
 use crate::grpc_wrapper::raw_topic_service::common::update_token::RawUpdateTokenRequest;
 use crate::grpc_wrapper::raw_topic_service::stream_read::messages::{
-    DecompressedBatch, PartitionCommitOffset, RawBatchWithId, RawCommitOffsetRequest,
-    RawFromClientOneOf, RawFromServer, RawInitRequest, RawReadRequest,
-    RawStartPartitionSessionResponse, RawStopPartitionSessionResponse, RawTopicReadSettings,
+    PartitionCommitOffset, RawBatchWithId, RawCommitOffsetRequest, RawFromClientOneOf,
+    RawFromServer, RawInitRequest, RawReadRequest, RawStartPartitionSessionResponse,
+    RawStopPartitionSessionResponse, RawTopicReadSettings,
 };
 use crate::grpc_wrapper::raw_topic_service::update_offsets_in_transaction::{
     RawPartitionOffsets, RawTopicOffsets, RawTransactionIdentity,
@@ -212,8 +212,11 @@ impl TopicReader {
         let shared = Arc::new(ReaderShared::new());
         let stop_backgroung_work_token = YdbCancellationToken::new();
 
-        let (decompression_worker, decompression_receiver) =
-            DecompressionWorker::new(options.codec_registry, options.compression_error_strategy);
+        let (decompression_worker, decompression_receiver) = DecompressionWorker::new(
+            options.codec_registry,
+            options.compression_error_strategy,
+            options.compression_executor,
+        );
 
         tokio::spawn(receive_loop(
             stream,
@@ -332,7 +335,7 @@ async fn receive_loop(
     shared: Arc<ReaderShared>,
     stop: YdbCancellationToken,
     decompression_worker: DecompressionWorker,
-    mut decompression_receiver: mpsc::UnboundedReceiver<YdbResult<DecompressedBatch>>,
+    mut decompression_receiver: mpsc::UnboundedReceiver<YdbResult<RawBatchWithId>>,
 ) {
     let mut sessions: HashMap<i64, PartitionSession> = HashMap::new();
     let tokio_stop = stop.to_tokio_token();
@@ -354,7 +357,7 @@ async fn receive_loop(
                             &mut sessions,
                             &sender_for_responses,
                             &decompression_worker,
-                        ).await {
+                        ) {
                             break Some(e);
                         }
                     }
@@ -374,7 +377,7 @@ async fn receive_loop(
     close_with_error(&shared, err);
 }
 
-async fn handle_incoming(
+fn handle_incoming(
     msg: RawFromServer,
     sessions: &mut HashMap<i64, PartitionSession>,
     sender: &UnboundedSender<FromClient>,
@@ -384,12 +387,12 @@ async fn handle_incoming(
         RawFromServer::ReadResponse(resp) => {
             for partition_data in resp.partition_data {
                 for batch in partition_data.batches {
-                    decompression_worker
-                        .process_batch(RawBatchWithId {
-                            partition_session_id: partition_data.partition_session_id,
-                            batch,
-                        })
-                        .await?;
+                    let read_session_size_bytes = batch.get_read_session_size();
+                    decompression_worker.process_batch(RawBatchWithId {
+                        partition_session_id: partition_data.partition_session_id,
+                        read_session_size_bytes,
+                        batch,
+                    });
                 }
             }
         }
@@ -436,7 +439,7 @@ async fn handle_incoming(
 /// the shared buffer in FIFO order. The `read_session_size_bytes` is stamped on
 /// the last message for flow-control (sent back as ReadRequest).
 fn handle_batch(
-    decompressed: DecompressedBatch,
+    decompressed: RawBatchWithId,
     sessions: &mut HashMap<i64, PartitionSession>,
     shared: &ReaderShared,
 ) {
@@ -801,10 +804,10 @@ mod tests {
             for raw_batch in partition_data.batches {
                 let bytes = raw_batch.get_read_session_size();
                 handle_batch(
-                    DecompressedBatch {
+                    RawBatchWithId {
                         partition_session_id: partition_data.partition_session_id,
-                        batch: raw_batch,
                         read_session_size_bytes: bytes,
+                        batch: raw_batch,
                     },
                     sessions,
                     shared,

--- a/ydb/src/client_topic/topicreader/reader_options.rs
+++ b/ydb/src/client_topic/topicreader/reader_options.rs
@@ -1,4 +1,6 @@
-use crate::client_topic::compression::{CodecRegistry, ErrorHandlingStrategy};
+use crate::client_topic::compression::{
+    default_executor, CodecRegistry, ErrorHandlingStrategy, Executor,
+};
 use crate::client_topic::topicreader::reader::TopicSelectors;
 use crate::errors;
 use derive_builder::Builder;
@@ -20,4 +22,6 @@ pub struct TopicReaderOptions {
     pub(crate) codec_registry: Arc<CodecRegistry>,
     #[builder(default = "ErrorHandlingStrategy::FailFast")]
     pub(crate) compression_error_strategy: ErrorHandlingStrategy,
+    #[builder(default = "default_executor()")]
+    pub(crate) compression_executor: Arc<dyn Executor>,
 }

--- a/ydb/src/client_topic/topicreader/reader_options.rs
+++ b/ydb/src/client_topic/topicreader/reader_options.rs
@@ -1,6 +1,12 @@
+use crate::client_topic::compression::{CodecRegistry, ErrorHandlingStrategy};
 use crate::client_topic::topicreader::reader::TopicSelectors;
 use crate::errors;
 use derive_builder::Builder;
+use std::sync::Arc;
+
+fn default_codec_registry() -> Arc<CodecRegistry> {
+    Arc::new(CodecRegistry::new())
+}
 
 #[derive(Builder, Clone)]
 #[builder(build_fn(error = "errors::YdbError"))]
@@ -10,4 +16,8 @@ pub struct TopicReaderOptions {
 
     #[builder(default = "1000")]
     pub(crate) batch_size: usize,
+    #[builder(default = "default_codec_registry()")]
+    pub(crate) codec_registry: Arc<CodecRegistry>,
+    #[builder(default = "ErrorHandlingStrategy::FailFast")]
+    pub(crate) compression_error_strategy: ErrorHandlingStrategy,
 }

--- a/ydb/src/client_topic/topicwriter/message.rs
+++ b/ydb/src/client_topic/topicwriter/message.rs
@@ -1,8 +1,9 @@
+use crate::client_topic::list_types::Codec;
 use crate::{errors, YdbResult};
 use derive_builder::Builder;
 use std::time;
 
-#[derive(Builder)]
+#[derive(Builder, Debug)]
 #[builder(build_fn(error = "errors::YdbError", validate = "Self::validate"))]
 #[allow(dead_code)]
 pub struct TopicWriterMessage {
@@ -12,6 +13,11 @@ pub struct TopicWriterMessage {
     pub(crate) created_at: time::SystemTime,
 
     pub(crate) data: Vec<u8>,
+
+    #[builder(default = "None", setter(skip))]
+    pub(crate) uncompressed_size: Option<i64>,
+    #[builder(default = "None", setter(skip))]
+    pub(crate) codec: Option<Codec>,
 }
 
 impl TopicWriterMessageBuilder {

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -11,7 +11,7 @@ use crate::grpc_wrapper::grpc_stream_wrapper::AsyncGrpcStreamWrapper;
 use crate::grpc_wrapper::raw_topic_service::common::codecs::RawSupportedCodecs;
 use crate::grpc_wrapper::raw_topic_service::stream_write::init::RawInitResponse;
 use crate::grpc_wrapper::raw_topic_service::stream_write::RawServerMessage;
-use crate::{Codec, ErrorHandlingStrategy, YdbError, YdbResult, grpc_wrapper};
+use crate::{grpc_wrapper, Codec, ErrorHandlingStrategy, YdbError, YdbResult};
 use std::borrow::{Borrow, BorrowMut};
 
 use std::future::Future;
@@ -27,7 +27,7 @@ use tokio::task::JoinHandle;
 
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
-use tracing::log::{trace};
+use tracing::log::trace;
 use tracing::warn;
 use ydb_grpc::ydb_proto::topic::stream_write_message;
 use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage;
@@ -124,11 +124,13 @@ impl TopicWriter {
         let mut stream = topic_service.stream_write(init_request_body).await?;
         let init_response = RawInitResponse::try_from(stream.receive::<RawServerMessage>().await?)?;
 
-        let mut server_codecs: Vec<crate::Codec> = supported_codecs.clone().into();
+        let mut server_codecs: Vec<crate::Codec> = supported_codecs.clone();
         if server_codecs.is_empty() {
             server_codecs = vec![Codec::RAW, Codec::GZIP]
         }
-        if !server_codecs.contains(&Codec::RAW) && writer_options.compression_error_strategy == ErrorHandlingStrategy::Skip {
+        if !server_codecs.contains(&Codec::RAW)
+            && writer_options.compression_error_strategy == ErrorHandlingStrategy::Skip
+        {
             return Err(YdbError::custom(format!(
                 "Skip compression error handling strategy requires RAW codec support, topic supports only {:?}", server_codecs)));
         }

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -1,3 +1,4 @@
+use crate::client_topic::compression::CompressionWorker;
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::client_topic::topicwriter::message_write_status::{MessageWriteStatus, WriteAck};
 use crate::client_topic::topicwriter::writer_options::TopicWriterOptions;
@@ -10,7 +11,7 @@ use crate::grpc_wrapper::grpc_stream_wrapper::AsyncGrpcStreamWrapper;
 use crate::grpc_wrapper::raw_topic_service::common::codecs::RawSupportedCodecs;
 use crate::grpc_wrapper::raw_topic_service::stream_write::init::RawInitResponse;
 use crate::grpc_wrapper::raw_topic_service::stream_write::RawServerMessage;
-use crate::{grpc_wrapper, YdbError, YdbResult};
+use crate::{grpc_wrapper, Codec, YdbError, YdbResult};
 use std::borrow::{Borrow, BorrowMut};
 
 use std::future::Future;
@@ -22,7 +23,6 @@ use std::time::Instant;
 use std::time::{Duration, UNIX_EPOCH};
 
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
 
 use tokio::time::timeout;
@@ -55,7 +55,7 @@ pub struct TopicWriter {
     pub(crate) auto_set_seq_no: bool,
     pub(crate) codecs_from_server: RawSupportedCodecs,
 
-    writer_message_sender: mpsc::Sender<TopicWriterMessage>,
+    compression_worker: CompressionWorker,
     writer_loop: JoinHandle<()>,
     receive_messages_loop: JoinHandle<()>,
 
@@ -123,10 +123,12 @@ impl TopicWriter {
         let mut stream = topic_service.stream_write(init_request_body).await?;
         let init_response = RawInitResponse::try_from(stream.receive::<RawServerMessage>().await?)?;
 
-        let (messages_sender, messages_receiver): (
-            mpsc::Sender<TopicWriterMessage>,
-            mpsc::Receiver<TopicWriterMessage>,
-        ) = mpsc::channel(32_usize);
+        let (compression_worker, mut compression_receiver) = CompressionWorker::new(
+            writer_options.codec,
+            writer_options.codec_registry.clone(),
+            writer_options.compression_error_strategy.clone(),
+        );
+
         let cancellation_token = CancellationToken::new();
         let topic_writer_state = Arc::new(Mutex::new(TopicWriterMode::Working));
         let confirmation_reception_queue = Arc::new(Mutex::new(TopicWriterReceptionQueue::new()));
@@ -145,12 +147,11 @@ impl TopicWriter {
             request_stream: stream.clone_sender(),
         };
         let writer_loop = tokio::spawn(async move {
-            let mut message_receiver = messages_receiver; // force move inside
             let task_params = writer_loop_task_params; // force move inside
 
             loop {
                 match TopicWriter::write_loop_iteration(
-                    message_receiver.borrow_mut(),
+                    &mut compression_receiver,
                     task_params.borrow(),
                 )
                 .await
@@ -205,7 +206,7 @@ impl TopicWriter {
             write_request_send_messages_period: writer_options.write_request_send_messages_period,
             auto_set_seq_no: writer_options.auto_seq_no,
             codecs_from_server: init_response.supported_codecs,
-            writer_message_sender: messages_sender,
+            compression_worker,
             writer_loop,
             receive_messages_loop,
             cancellation_token,
@@ -215,11 +216,34 @@ impl TopicWriter {
         })
     }
 
+    fn send_write_request(
+        task_params: &WriterPeriodicTaskParams,
+        messages: Vec<MessageData>,
+        codec: Codec,
+    ) -> YdbResult<()> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        trace!("Sending topic message to grpc stream...");
+        task_params
+            .request_stream
+            .send(stream_write_message::FromClient {
+                client_message: Some(ClientMessage::WriteRequest(WriteRequest {
+                    messages,
+                    codec: codec.code,
+                    tx: None,
+                })),
+            })
+            .map_err(|err| YdbError::Custom(format!("Error sending write request: {}", err)))
+    }
+
     async fn write_loop_iteration(
-        messages_receiver: &mut Receiver<TopicWriterMessage>,
+        compression_receiver: &mut mpsc::UnboundedReceiver<YdbResult<Vec<TopicWriterMessage>>>,
         task_params: &WriterPeriodicTaskParams,
     ) -> YdbResult<()> {
         let start = Instant::now();
+        let mut current_codec = None;
         let mut messages = vec![];
 
         // wait messages loop
@@ -233,28 +257,48 @@ impl TopicWriter {
 
             match timeout(
                 task_params.write_request_send_messages_period - elapsed,
-                messages_receiver.recv(),
+                compression_receiver.recv(),
             )
             .await
             {
-                Ok(Some(message)) => {
-                    let data_size = message.data.len() as i64;
-                    messages.push(MessageData {
-                        seq_no: message
-                            .seq_no
-                            .ok_or_else(|| YdbError::custom("empty message seq_no"))?,
-                        created_at: Some(ydb_grpc::google_proto_workaround::protobuf::Timestamp {
-                            seconds: message.created_at.duration_since(UNIX_EPOCH)?.as_secs()
-                                as i64,
-                            nanos: message.created_at.duration_since(UNIX_EPOCH)?.as_nanos() as i32,
-                        }),
-                        metadata_items: vec![],
-                        data: message.data,
-                        uncompressed_size: data_size,
-                        partitioning: Some(message_data::Partitioning::MessageGroupId(
-                            task_params.producer_id.clone().unwrap_or_default(),
-                        )),
-                    });
+                Ok(Some(batch_result)) => {
+                    for message in batch_result? {
+                        let message_codec = message.codec.unwrap_or(Codec::RAW);
+                        if current_codec.is_some() && current_codec.unwrap() != message_codec {
+                            Self::send_write_request(
+                                task_params,
+                                messages,
+                                current_codec.unwrap(),
+                            )?;
+                            messages = vec![];
+                        }
+                        current_codec = Some(message_codec);
+
+                        messages.push(MessageData {
+                            seq_no: message
+                                .seq_no
+                                .ok_or_else(|| YdbError::custom("empty message seq_no"))?,
+                            created_at: Some(
+                                ydb_grpc::google_proto_workaround::protobuf::Timestamp {
+                                    seconds: message
+                                        .created_at
+                                        .duration_since(UNIX_EPOCH)?
+                                        .as_secs()
+                                        as i64,
+                                    nanos: message.created_at.duration_since(UNIX_EPOCH)?.as_nanos()
+                                        as i32,
+                                },
+                            ),
+                            metadata_items: vec![],
+                            uncompressed_size: message
+                                .uncompressed_size
+                                .unwrap_or(message.data.len() as i64),
+                            data: message.data,
+                            partitioning: Some(message_data::Partitioning::MessageGroupId(
+                                task_params.producer_id.clone().unwrap_or_default(),
+                            )),
+                        });
+                    }
                 }
                 Ok(None) => {
                     trace!("Channel has been closed. Stop topic send messages loop.");
@@ -266,18 +310,8 @@ impl TopicWriter {
             }
         }
 
-        if !messages.is_empty() {
-            trace!("Sending topic message to grpc stream...");
-            task_params
-                .request_stream
-                .send(stream_write_message::FromClient {
-                    client_message: Some(ClientMessage::WriteRequest(WriteRequest {
-                        messages,
-                        codec: 1,
-                        tx: None,
-                    })),
-                })
-                .unwrap(); // TODO: HANDLE ERROR
+        if let Some(codec) = current_codec {
+            Self::send_write_request(task_params, messages, codec)?;
         }
         Ok(())
     }
@@ -404,11 +438,12 @@ impl TopicWriter {
             return Err(YdbError::custom("need to set message seq_no"));
         };
 
-        self.writer_message_sender
-            .borrow_mut()
-            .send(message)
+        self.compression_worker
+            .process_batch(vec![message])
             .await
-            .map_err(|err| YdbError::custom(format!("can't send the message to channel: {err}")))?;
+            .map_err(|err| {
+                YdbError::custom(format!("can't submit message to compression: {err}"))
+            })?;
 
         let reception_type = wait_ack.map_or(
             TopicWriterReceptionType::NoConfirmationExpected,

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -11,7 +11,7 @@ use crate::grpc_wrapper::grpc_stream_wrapper::AsyncGrpcStreamWrapper;
 use crate::grpc_wrapper::raw_topic_service::common::codecs::RawSupportedCodecs;
 use crate::grpc_wrapper::raw_topic_service::stream_write::init::RawInitResponse;
 use crate::grpc_wrapper::raw_topic_service::stream_write::RawServerMessage;
-use crate::{grpc_wrapper, Codec, YdbError, YdbResult};
+use crate::{Codec, ErrorHandlingStrategy, YdbError, YdbResult, grpc_wrapper};
 use std::borrow::{Borrow, BorrowMut};
 
 use std::future::Future;
@@ -27,7 +27,7 @@ use tokio::task::JoinHandle;
 
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
-use tracing::log::trace;
+use tracing::log::{trace};
 use tracing::warn;
 use ydb_grpc::ydb_proto::topic::stream_write_message;
 use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage;
@@ -95,6 +95,7 @@ impl TopicWriter {
     pub(crate) async fn new(
         writer_options: TopicWriterOptions,
         connection_manager: GrpcConnectionManager,
+        supported_codecs: Vec<Codec>, // bypass of InitRequest returning 0 for custom codecs
     ) -> YdbResult<Self> {
         //TODO: split to smaller functions
 
@@ -123,11 +124,22 @@ impl TopicWriter {
         let mut stream = topic_service.stream_write(init_request_body).await?;
         let init_response = RawInitResponse::try_from(stream.receive::<RawServerMessage>().await?)?;
 
+        let mut server_codecs: Vec<crate::Codec> = supported_codecs.clone().into();
+        if server_codecs.is_empty() {
+            server_codecs = vec![Codec::RAW, Codec::GZIP]
+        }
+        if !server_codecs.contains(&Codec::RAW) && writer_options.compression_error_strategy == ErrorHandlingStrategy::Skip {
+            return Err(YdbError::custom(format!(
+                "Skip compression error handling strategy requires RAW codec support, topic supports only {:?}", server_codecs)));
+        }
+
         let (compression_worker, mut compression_receiver) = CompressionWorker::new(
             writer_options.codec,
             writer_options.codec_registry.clone(),
             writer_options.compression_error_strategy.clone(),
-        );
+            writer_options.compression_executor.clone(),
+            server_codecs,
+        )?;
 
         let cancellation_token = CancellationToken::new();
         let topic_writer_state = Arc::new(Mutex::new(TopicWriterMode::Working));
@@ -438,12 +450,7 @@ impl TopicWriter {
             return Err(YdbError::custom("need to set message seq_no"));
         };
 
-        self.compression_worker
-            .process_batch(vec![message])
-            .await
-            .map_err(|err| {
-                YdbError::custom(format!("can't submit message to compression: {err}"))
-            })?;
+        self.compression_worker.process_batch(vec![message]);
 
         let reception_type = wait_ack.map_or(
             TopicWriterReceptionType::NoConfirmationExpected,
@@ -470,7 +477,10 @@ impl TopicWriter {
             reception_queue.init_flush_op()?
         };
 
-        Ok(flush_op_completed.await?)
+        tokio::select! {
+            _ = self.cancellation_token.cancelled() => self.is_cancelled().await,
+            _ = flush_op_completed => Ok(()),
+        }
     }
 
     async fn is_cancelled(&self) -> YdbResult<()> {

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -278,13 +278,11 @@ impl TopicWriter {
                 Ok(Some(batch_result)) => {
                     for message in batch_result? {
                         let message_codec = message.codec.unwrap_or(Codec::RAW);
-                        if current_codec.is_some() && current_codec.unwrap() != message_codec {
-                            Self::send_write_request(
-                                task_params,
-                                messages,
-                                current_codec.unwrap(),
-                            )?;
-                            messages = vec![];
+                        if let Some(codec) = current_codec {
+                            if codec != message_codec {
+                                Self::send_write_request(task_params, messages, codec)?;
+                                messages = vec![];
+                            }
                         }
                         current_codec = Some(message_codec);
 

--- a/ydb/src/client_topic/topicwriter/writer_options.rs
+++ b/ydb/src/client_topic/topicwriter/writer_options.rs
@@ -1,12 +1,15 @@
+use crate::client_topic::compression::{CodecRegistry, ErrorHandlingStrategy};
 use crate::client_topic::list_types::Codec;
 use crate::client_topic::topicwriter::partitioning::PartitioningStrategy;
 use crate::errors;
 use derive_builder::Builder;
-use prost::bytes::Bytes;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
-type EncoderFunc = fn(Bytes) -> Bytes;
+fn default_codec_registry() -> Arc<CodecRegistry> {
+    Arc::new(CodecRegistry::new())
+}
 
 #[allow(dead_code)]
 #[derive(Builder, Clone)]
@@ -29,9 +32,11 @@ pub struct TopicWriterOptions {
     #[builder(default = "Duration::from_secs(1)")]
     pub(crate) write_request_send_messages_period: Duration,
     #[builder(setter(strip_option), default)]
-    pub(crate) codec: Option<Codec>, // in case of no specified codec, codec is auto-selected
-    #[builder(setter(strip_option), default)]
-    pub(crate) custom_encoders: Option<HashMap<Codec, EncoderFunc>>,
+    pub(crate) codec: Option<Codec>,
+    #[builder(default = "default_codec_registry()")]
+    pub(crate) codec_registry: Arc<CodecRegistry>,
+    #[builder(default = "ErrorHandlingStrategy::FailFast")]
+    pub(crate) compression_error_strategy: ErrorHandlingStrategy,
 
     #[builder(default = "TopicWriterConnectionOptionsBuilder::default().build()?")]
     pub(crate) connection_options: TopicWriterConnectionOptions,

--- a/ydb/src/client_topic/topicwriter/writer_options.rs
+++ b/ydb/src/client_topic/topicwriter/writer_options.rs
@@ -1,4 +1,6 @@
-use crate::client_topic::compression::{CodecRegistry, ErrorHandlingStrategy};
+use crate::client_topic::compression::{
+    default_executor, CodecRegistry, ErrorHandlingStrategy, Executor,
+};
 use crate::client_topic::list_types::Codec;
 use crate::client_topic::topicwriter::partitioning::PartitioningStrategy;
 use crate::errors;
@@ -37,6 +39,8 @@ pub struct TopicWriterOptions {
     pub(crate) codec_registry: Arc<CodecRegistry>,
     #[builder(default = "ErrorHandlingStrategy::FailFast")]
     pub(crate) compression_error_strategy: ErrorHandlingStrategy,
+    #[builder(default = "default_executor()")]
+    pub(crate) compression_executor: Arc<dyn Executor>,
 
     #[builder(default = "TopicWriterConnectionOptionsBuilder::default().build()?")]
     pub(crate) connection_options: TopicWriterConnectionOptions,

--- a/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
@@ -272,12 +272,6 @@ impl From<stream_read_message::read_response::Batch> for RawBatch {
 pub(crate) struct RawBatchWithId {
     pub partition_session_id: i64,
     pub batch: RawBatch,
-}
-
-#[derive(Debug)]
-pub(crate) struct DecompressedBatch {
-    pub partition_session_id: i64,
-    pub batch: RawBatch,
     pub read_session_size_bytes: i64,
 }
 

--- a/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
@@ -269,6 +269,19 @@ impl From<stream_read_message::read_response::Batch> for RawBatch {
 }
 
 #[derive(Debug)]
+pub(crate) struct RawBatchWithId {
+    pub partition_session_id: i64,
+    pub batch: RawBatch,
+}
+
+#[derive(Debug)]
+pub(crate) struct DecompressedBatch {
+    pub partition_session_id: i64,
+    pub batch: RawBatch,
+    pub read_session_size_bytes: i64,
+}
+
+#[derive(Debug)]
 pub(crate) struct RawMessageData {
     pub offset: i64,
     pub seq_no: i64,

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -131,7 +131,6 @@ pub use client_topic::topicreader::messages::{TopicReaderBatch, TopicReaderMessa
 pub use client_topic::topicreader::reader::{
     TopicReader, TopicReaderCommitMarker, TopicSelector, TopicSelectors,
 };
-// full enum pub types
 pub use client_topic::topicreader::reader_options::{
     TopicReaderOptions, TopicReaderOptionsBuilder,
 };
@@ -142,6 +141,7 @@ pub use client_topic::topicwriter::partitioning::PartitioningStrategy;
 // full enum pub types
 pub use client_topic::topicwriter::writer::TopicWriter;
 // full enum pub types
+pub use client_topic::compression::{CodecRegistry, ErrorHandlingStrategy};
 pub use client_topic::topicwriter::writer_options::{
     TopicWriterConnectionOptions, TopicWriterOptions, TopicWriterOptionsBuilder,
     TopicWriterRetrySettings,

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -88,9 +88,9 @@ mod table_service_types;
 #[cfg(test)]
 mod test_integration_helper;
 #[cfg(test)]
-pub(crate) mod topics_test;
-#[cfg(test)]
 pub(crate) mod topics_compression_test;
+#[cfg(test)]
+pub(crate) mod topics_test;
 mod trace_helpers;
 mod trait_operation;
 pub(crate) mod transaction;

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -144,7 +144,8 @@ pub use client_topic::topicwriter::partitioning::PartitioningStrategy;
 pub use client_topic::topicwriter::writer::TopicWriter;
 // full enum pub types
 pub use client_topic::compression::{
-    default_executor, CodecRegistry, ErrorHandlingStrategy, Executor, RayonExecutor,
+    default_executor, CodecRegistry, ErrorHandlingStrategy, Executor, InplaceExecutor,
+    RayonExecutor,
 };
 pub use client_topic::topicwriter::writer_options::{
     TopicWriterConnectionOptions, TopicWriterOptions, TopicWriterOptionsBuilder,

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -89,6 +89,8 @@ mod table_service_types;
 mod test_integration_helper;
 #[cfg(test)]
 pub(crate) mod topics_test;
+#[cfg(test)]
+pub(crate) mod topics_compression_test;
 mod trace_helpers;
 mod trait_operation;
 pub(crate) mod transaction;
@@ -141,7 +143,9 @@ pub use client_topic::topicwriter::partitioning::PartitioningStrategy;
 // full enum pub types
 pub use client_topic::topicwriter::writer::TopicWriter;
 // full enum pub types
-pub use client_topic::compression::{CodecRegistry, ErrorHandlingStrategy};
+pub use client_topic::compression::{
+    default_executor, CodecRegistry, ErrorHandlingStrategy, Executor, RayonExecutor,
+};
 pub use client_topic::topicwriter::writer_options::{
     TopicWriterConnectionOptions, TopicWriterOptions, TopicWriterOptionsBuilder,
     TopicWriterRetrySettings,

--- a/ydb/src/topics_compression_test.rs
+++ b/ydb/src/topics_compression_test.rs
@@ -634,7 +634,7 @@ async fn codec_auto() -> YdbResult<()> {
             "this text is boring this text is boring this text is boring this text is boring"
                 .to_string()
                 .into_bytes();
-        if i < 101 || i > 300 {
+        if !(101..=300).contains(&i) {
             data.iter_mut().for_each(|x| *x = rand::random());
         }
         expected_messages.push(data.clone());

--- a/ydb/src/topics_compression_test.rs
+++ b/ydb/src/topics_compression_test.rs
@@ -630,7 +630,10 @@ async fn codec_auto() -> YdbResult<()> {
     let message_count = 500;
     let mut expected_messages: Vec<Vec<u8>> = Vec::new();
     for i in 0..message_count {
-        let mut data: Vec<u8> = "this text is boring this text is boring this text is boring this text is boring".to_string().into_bytes();
+        let mut data: Vec<u8> =
+            "this text is boring this text is boring this text is boring this text is boring"
+                .to_string()
+                .into_bytes();
         if i < 101 || i > 300 {
             data.iter_mut().for_each(|x| *x = rand::random());
         }

--- a/ydb/src/topics_compression_test.rs
+++ b/ydb/src/topics_compression_test.rs
@@ -1,0 +1,563 @@
+use std::sync::Arc;
+use std::time::{Duration};
+use tokio::time::timeout;
+use tracing_test::traced_test;
+use prost::bytes::Bytes;
+use std::time;
+use std::thread;
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use crate::ErrorHandlingStrategy;
+use crate::client_topic::list_types::ConsumerBuilder;
+use crate::test_integration_helper::create_client;
+use crate::{
+    client_topic::client::{CreateTopicOptionsBuilder},
+    Codec, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, TopicReaderOptionsBuilder, YdbError,
+    YdbResult, CodecRegistry, RayonExecutor
+};
+use tracing::trace;
+
+impl Codec {
+    pub const INC13: Codec = Codec { code: 10001 };
+    pub const SLOW_INC13: Codec = Codec { code: 10002 };
+    pub const FAILY: Codec = Codec { code: 10003 };
+}
+
+fn inc13_compress(data: &Bytes) -> YdbResult<Bytes> {
+    Ok(data.iter().map(|x| ((*x as i32) + 13) as u8).collect())
+}
+
+fn inc13_decompress(data: &Bytes) -> YdbResult<Bytes> {
+    Ok(data.iter().map(|x| ((*x as i32) - 13) as u8).collect())
+}
+
+fn slow_inc13_compress(data: &Bytes) -> YdbResult<Bytes> {
+    thread::sleep(time::Duration::from_secs(1));
+    inc13_compress(data)
+}
+
+fn slow_inc13_decompress(data: &Bytes) -> YdbResult<Bytes> {
+    thread::sleep(time::Duration::from_secs(1));
+    inc13_decompress(data)
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_fail_fast_write() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "codec_fail_fast_write".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    // Codec that fails first 5 iterations
+    let counter = Arc::new(AtomicI64::new(0));
+    let faily_inc13_compress = move |data: &Bytes| -> YdbResult<Bytes> {
+        if counter.fetch_add(1, Ordering::Relaxed) < 5 {
+            return Err(YdbError::from_str("failing for compression testing"));
+        }
+        Ok(data.iter().map(|x| *x + 13).collect())
+    };
+
+    let mut registry = CodecRegistry::default();
+    registry.register_codec(Codec::INC13, Arc::new(faily_inc13_compress), Arc::new(inc13_decompress))?;
+    let registry = Arc::new(registry);
+    trace!("codec registry created");
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::RAW, Codec::INC13])
+                .consumers(vec![
+                    ConsumerBuilder::default()
+                        .name(consumer_name.clone())
+                        .build()?,
+                ])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec_registry(registry.clone())
+                .codec(Codec::INC13)
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let message_count = 20;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let data: Vec<u8> = format!("some test message {i}").into_bytes();
+        expected_messages.push(data.clone());
+        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+    }
+    trace!("messages written, waiting for sending");
+
+    writer.stop().await?;
+    trace!("writer stopped, all messages sent");
+
+    let mut reader = topic_client
+        .create_reader_with_params(TopicReaderOptionsBuilder::default()
+            .topic(topic_path.clone().into())
+            .consumer(consumer_name)
+            .codec_registry(registry.clone())
+            .build()?)
+        .await?;
+    trace!("reader created");
+
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let mut batch = timeout(Duration::from_secs(2), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+        for mut message in std::mem::take(&mut batch.messages) {
+            if let Some(data) = message.read_and_take().await? {
+                received_messages.push(data);
+            }
+        }
+        reader.commit(batch.get_commit_marker())?
+    }
+
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_skip_errors() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "codec_skip_errors".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    let counter= Arc::new(std::sync::Mutex::new(0));
+    let faily_inc13_compress = move |data: &Bytes| -> YdbResult<Bytes> {
+        let mut cnt = counter.lock()?;
+        *cnt += 1;
+        if *cnt < 5 {
+            return Err(YdbError::from_str("compression error"));
+        }
+        Ok(data.iter().map(|x| *x + 13).collect())
+    };
+
+    let other_counter = Arc::new(std::sync::Mutex::new(0));
+    let faily_inc13_decompress = move |data: &Bytes| -> YdbResult<Bytes> {
+        let mut cnt = other_counter.lock()?;
+        *cnt += 1;
+        if *cnt > 14 { // do not count messages skipped in write, because they are not compressed
+            return Err(YdbError::from_str("compression error"));
+        }
+        Ok(data.iter().map(|x| *x - 13).collect())
+    };
+
+    // single-threaded to correctly track skipped messages
+    let executor = Arc::new(RayonExecutor::new(1));
+
+    let mut registry = CodecRegistry::default();
+    registry.register_codec(Codec::INC13, Arc::new(faily_inc13_compress), Arc::new(faily_inc13_decompress))?;
+    let registry = Arc::new(registry);
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::RAW, Codec::INC13])
+                .consumers(vec![
+                    ConsumerBuilder::default()
+                        .name(consumer_name.clone())
+                        .build()?,
+                ])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec(Codec::INC13)
+                .codec_registry(registry.clone())
+                .compression_error_strategy(ErrorHandlingStrategy::Skip)
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let mut message_count: usize = 20;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let data: Vec<u8> = vec![i as u8];
+        if i < 18 {
+            expected_messages.push(data.clone());
+        }
+        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+    }
+    message_count -= 2;
+    expected_messages = expected_messages[0..message_count].to_vec();
+    writer.stop().await?;
+
+    let mut reader = topic_client
+        .create_reader_with_params(TopicReaderOptionsBuilder::default()
+            .topic(topic_path.clone().into())
+            .compression_error_strategy(ErrorHandlingStrategy::Skip)
+            .consumer(consumer_name)
+            .codec_registry(registry.clone())
+            .compression_executor(executor)
+            .build()?)
+        .await?;
+
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let batch = timeout(Duration::from_secs(2), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+        for mut message in batch.messages {
+            if let Some(data) = message.read_and_take().await? {
+                trace!("got message with {:?}", data);
+                received_messages.push(data);
+            }
+        }
+    }
+
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_gzip_roundtrip() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "gzip_roundtrip".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .consumers(vec![
+                    ConsumerBuilder::default()
+                        .name(consumer_name.clone())
+                        .build()?,
+                ])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec(Codec::GZIP)
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let message_count = 20;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
+        expected_messages.push(data.clone());
+        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+    }
+    writer.flush().await?;
+    writer.stop().await?;
+
+    let mut reader = topic_client
+        .create_reader(consumer_name, topic_path)
+        .await?;
+
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let batch = timeout(Duration::from_secs(30), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+        for mut message in batch.messages {
+            if let Some(data) = message.read_and_take().await? {
+                received_messages.push(data);
+            }
+        }
+    }
+
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_custom_roundtrip() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "codec_custom_roundtrip".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::INC13])
+                .consumers(vec![
+                    ConsumerBuilder::default()
+                        .name(consumer_name.clone())
+                        .build()?,
+                ])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+    let mut registry = CodecRegistry::default();
+    registry.register_codec(Codec::INC13, Arc::new(inc13_compress), Arc::new(inc13_decompress))?;
+    let registry = Arc::new(registry);
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec(Codec::INC13)
+                .codec_registry(registry.clone())
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let message_count = 20;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
+        expected_messages.push(data.clone());
+        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+    }
+    writer.flush().await?;
+    writer.stop().await?;
+
+    let mut reader = topic_client
+        .create_reader_with_params(TopicReaderOptionsBuilder::default()
+            .topic(topic_path.clone().into())
+            .consumer(consumer_name)
+            .codec_registry(registry.clone())
+            .build()?)
+        .await?;
+
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let batch = timeout(Duration::from_secs(30), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+        for mut message in batch.messages {
+            if let Some(data) = message.read_and_take().await? {
+                received_messages.push(data);
+            }
+        }
+    }
+
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_parallelism() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "codec_parallelism".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    let mut registry = CodecRegistry::default();
+    registry.register_codec(Codec::SLOW_INC13, Arc::new(slow_inc13_compress), Arc::new(slow_inc13_decompress))?;
+    let registry = Arc::new(registry);
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::SLOW_INC13])
+                .consumers(vec![
+                    ConsumerBuilder::default()
+                        .name(consumer_name.clone())
+                        .build()?,
+                ])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec(Codec::SLOW_INC13)
+                .codec_registry(registry.clone())
+                .compression_executor(Arc::new(RayonExecutor::new(8)))
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let message_count = 10;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
+        expected_messages.push(data.clone());
+        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+    }
+    timeout(Duration::from_secs(5), writer.flush()).await.map_err(
+        |err| YdbError::custom(format!("Error waiting for messages write {err}")
+    ))??;
+    writer.stop().await?;
+
+    let mut reader = topic_client
+        .create_reader_with_params(TopicReaderOptionsBuilder::default()
+            .topic(topic_path.clone().into())
+            .consumer(consumer_name)
+            .codec_registry(registry.clone())
+            .build()?)
+        .await?;
+
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let batch = timeout(Duration::from_secs(5), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+        for mut message in batch.messages {
+            if let Some(data) = message.read_and_take().await? {
+                received_messages.push(data);
+            }
+        }
+    }
+
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_auto() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "codec_autoselection".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    let mut registry = CodecRegistry::default();
+    registry.register_codec(Codec::INC13, Arc::new(inc13_compress), Arc::new(inc13_decompress))?;
+    let registry = Arc::new(registry);
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::RAW, Codec::INC13, Codec::GZIP])
+                .consumers(vec![
+                    ConsumerBuilder::default()
+                        .name(consumer_name.clone())
+                        .build()?,
+                ])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec_registry(registry.clone())
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let message_count = 1000;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let mut data: Vec<u8> = format!("this text is boring this text is boring this text is boring this text is boring").into_bytes();
+        if i > 500 {
+            data.iter_mut().for_each(|x| *x = rand::random());
+        }
+        expected_messages.push(data.clone());
+        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+    }
+    writer.stop().await?;
+
+    let mut reader = topic_client
+        .create_reader_with_params(TopicReaderOptionsBuilder::default()
+            .topic(topic_path.clone().into())
+            .consumer(consumer_name)
+            .codec_registry(registry.clone())
+            .build()?)
+        .await?;
+
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let batch = timeout(Duration::from_secs(5), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+
+        for mut message in batch.messages {
+            if let Some(data) = message.read_and_take().await? {
+                received_messages.push(data);
+            }
+        }
+    }
+
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
+
+    Ok(())
+}

--- a/ydb/src/topics_compression_test.rs
+++ b/ydb/src/topics_compression_test.rs
@@ -1,20 +1,20 @@
+use prost::bytes::Bytes;
 use std::sync::Arc;
-use std::time::{Duration};
+use std::thread;
+use std::time;
+use std::time::Duration;
 use tokio::time::timeout;
 use tracing_test::traced_test;
-use prost::bytes::Bytes;
-use std::time;
-use std::thread;
 
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use crate::ErrorHandlingStrategy;
 use crate::client_topic::list_types::ConsumerBuilder;
 use crate::test_integration_helper::create_client;
+use crate::ErrorHandlingStrategy;
 use crate::{
-    client_topic::client::{CreateTopicOptionsBuilder},
-    Codec, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, TopicReaderOptionsBuilder, YdbError,
-    YdbResult, CodecRegistry, RayonExecutor
+    client_topic::client::CreateTopicOptionsBuilder, Codec, CodecRegistry, RayonExecutor,
+    TopicReaderOptionsBuilder, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, YdbError,
+    YdbResult,
 };
 use tracing::trace;
 
@@ -66,7 +66,11 @@ async fn codec_fail_fast_write() -> YdbResult<()> {
     };
 
     let mut registry = CodecRegistry::default();
-    registry.register_codec(Codec::INC13, Arc::new(faily_inc13_compress), Arc::new(inc13_decompress))?;
+    registry.register_codec(
+        Codec::INC13,
+        Arc::new(faily_inc13_compress),
+        Arc::new(inc13_decompress),
+    )?;
     let registry = Arc::new(registry);
     trace!("codec registry created");
 
@@ -75,11 +79,9 @@ async fn codec_fail_fast_write() -> YdbResult<()> {
             topic_path.clone(),
             CreateTopicOptionsBuilder::default()
                 .supported_codecs(vec![Codec::RAW, Codec::INC13])
-                .consumers(vec![
-                    ConsumerBuilder::default()
-                        .name(consumer_name.clone())
-                        .build()?,
-                ])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
                 .build()?,
         )
         .await?;
@@ -101,37 +103,119 @@ async fn codec_fail_fast_write() -> YdbResult<()> {
     for i in 0..message_count {
         let data: Vec<u8> = format!("some test message {i}").into_bytes();
         expected_messages.push(data.clone());
-        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
     }
     trace!("messages written, waiting for sending");
 
+    assert!(writer.stop().await.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn codec_fail_fast_read() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = "codec_fail_fast_reader".to_string();
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = format!("test-consumer-{topic_name}");
+
+    let mut topic_client = client.topic_client();
+    let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
+    trace!("previous topic removed");
+
+    let other_counter = Arc::new(std::sync::Mutex::new(0));
+    let faily_inc13_decompress = move |data: &Bytes| -> YdbResult<Bytes> {
+        let mut cnt = other_counter.lock()?;
+        *cnt += 1;
+        if *cnt == 20 {
+            return Err(YdbError::from_str("error for fail fast reader"));
+        }
+        Ok(data.iter().map(|x| *x - 13).collect())
+    };
+
+    // single-threaded to correctly track skipped messages
+    let executor = Arc::new(RayonExecutor::new(1));
+
+    let mut registry = CodecRegistry::default();
+    registry.register_codec(
+        Codec::INC13,
+        Arc::new(inc13_compress),
+        Arc::new(faily_inc13_decompress),
+    )?;
+    let registry = Arc::new(registry);
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::RAW, Codec::INC13])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
+                .build()?,
+        )
+        .await?;
+    trace!("topic created");
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec(Codec::INC13)
+                .codec_registry(registry.clone())
+                .build()?,
+        )
+        .await?;
+    trace!("writer created");
+
+    let message_count: usize = 20;
+    for i in 0..message_count {
+        let data: Vec<u8> = format!("message {i}").into_bytes();
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
+    }
     writer.stop().await?;
-    trace!("writer stopped, all messages sent");
 
     let mut reader = topic_client
-        .create_reader_with_params(TopicReaderOptionsBuilder::default()
-            .topic(topic_path.clone().into())
-            .consumer(consumer_name)
-            .codec_registry(registry.clone())
-            .build()?)
+        .create_reader_with_params(
+            TopicReaderOptionsBuilder::default()
+                .topic(topic_path.clone().into())
+                .consumer(consumer_name)
+                .codec_registry(registry.clone())
+                .compression_executor(executor)
+                .build()?,
+        )
         .await?;
-    trace!("reader created");
 
     let mut received_messages: Vec<Vec<u8>> = Vec::new();
     while received_messages.len() < message_count {
-        let mut batch = timeout(Duration::from_secs(2), reader.read_batch())
+        let batch = timeout(Duration::from_secs(5), reader.read_batch())
             .await
-            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
-        for mut message in std::mem::take(&mut batch.messages) {
-            if let Some(data) = message.read_and_take().await? {
-                received_messages.push(data);
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))?;
+
+        match batch {
+            Ok(batch) => {
+                for mut message in batch.messages {
+                    if let Some(data) = message.read_and_take().await? {
+                        trace!("got total {} messages", received_messages.len());
+                        received_messages.push(data);
+                    }
+                }
+            }
+            Err(err) => {
+                trace!("got error reading batch {}", err);
+                break;
             }
         }
-        reader.commit(batch.get_commit_marker())?
     }
 
-    assert_eq!(received_messages.len(), message_count);
-    assert_eq!(received_messages, expected_messages);
+    assert!(received_messages.len() < message_count);
 
     Ok(())
 }
@@ -150,7 +234,7 @@ async fn codec_skip_errors() -> YdbResult<()> {
     let _ = topic_client.drop_topic(topic_path.clone()).await; // ignoring error
     trace!("previous topic removed");
 
-    let counter= Arc::new(std::sync::Mutex::new(0));
+    let counter = Arc::new(std::sync::Mutex::new(0));
     let faily_inc13_compress = move |data: &Bytes| -> YdbResult<Bytes> {
         let mut cnt = counter.lock()?;
         *cnt += 1;
@@ -164,7 +248,8 @@ async fn codec_skip_errors() -> YdbResult<()> {
     let faily_inc13_decompress = move |data: &Bytes| -> YdbResult<Bytes> {
         let mut cnt = other_counter.lock()?;
         *cnt += 1;
-        if *cnt > 14 { // do not count messages skipped in write, because they are not compressed
+        if *cnt > 14 {
+            // do not count messages skipped in write, because they are not compressed
             return Err(YdbError::from_str("compression error"));
         }
         Ok(data.iter().map(|x| *x - 13).collect())
@@ -174,7 +259,11 @@ async fn codec_skip_errors() -> YdbResult<()> {
     let executor = Arc::new(RayonExecutor::new(1));
 
     let mut registry = CodecRegistry::default();
-    registry.register_codec(Codec::INC13, Arc::new(faily_inc13_compress), Arc::new(faily_inc13_decompress))?;
+    registry.register_codec(
+        Codec::INC13,
+        Arc::new(faily_inc13_compress),
+        Arc::new(faily_inc13_decompress),
+    )?;
     let registry = Arc::new(registry);
 
     topic_client
@@ -182,11 +271,9 @@ async fn codec_skip_errors() -> YdbResult<()> {
             topic_path.clone(),
             CreateTopicOptionsBuilder::default()
                 .supported_codecs(vec![Codec::RAW, Codec::INC13])
-                .consumers(vec![
-                    ConsumerBuilder::default()
-                        .name(consumer_name.clone())
-                        .build()?,
-                ])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
                 .build()?,
         )
         .await?;
@@ -211,20 +298,24 @@ async fn codec_skip_errors() -> YdbResult<()> {
         if i < 18 {
             expected_messages.push(data.clone());
         }
-        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
     }
     message_count -= 2;
     expected_messages = expected_messages[0..message_count].to_vec();
     writer.stop().await?;
 
     let mut reader = topic_client
-        .create_reader_with_params(TopicReaderOptionsBuilder::default()
-            .topic(topic_path.clone().into())
-            .compression_error_strategy(ErrorHandlingStrategy::Skip)
-            .consumer(consumer_name)
-            .codec_registry(registry.clone())
-            .compression_executor(executor)
-            .build()?)
+        .create_reader_with_params(
+            TopicReaderOptionsBuilder::default()
+                .topic(topic_path.clone().into())
+                .compression_error_strategy(ErrorHandlingStrategy::Skip)
+                .consumer(consumer_name)
+                .codec_registry(registry.clone())
+                .compression_executor(executor)
+                .build()?,
+        )
         .await?;
 
     let mut received_messages: Vec<Vec<u8>> = Vec::new();
@@ -264,11 +355,9 @@ async fn codec_gzip_roundtrip() -> YdbResult<()> {
         .create_topic(
             topic_path.clone(),
             CreateTopicOptionsBuilder::default()
-                .consumers(vec![
-                    ConsumerBuilder::default()
-                        .name(consumer_name.clone())
-                        .build()?,
-                ])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
                 .build()?,
         )
         .await?;
@@ -289,7 +378,9 @@ async fn codec_gzip_roundtrip() -> YdbResult<()> {
     for i in 0..message_count {
         let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
         expected_messages.push(data.clone());
-        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
     }
     writer.flush().await?;
     writer.stop().await?;
@@ -335,18 +426,20 @@ async fn codec_custom_roundtrip() -> YdbResult<()> {
             topic_path.clone(),
             CreateTopicOptionsBuilder::default()
                 .supported_codecs(vec![Codec::INC13])
-                .consumers(vec![
-                    ConsumerBuilder::default()
-                        .name(consumer_name.clone())
-                        .build()?,
-                ])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
                 .build()?,
         )
         .await?;
     trace!("topic created");
 
     let mut registry = CodecRegistry::default();
-    registry.register_codec(Codec::INC13, Arc::new(inc13_compress), Arc::new(inc13_decompress))?;
+    registry.register_codec(
+        Codec::INC13,
+        Arc::new(inc13_compress),
+        Arc::new(inc13_decompress),
+    )?;
     let registry = Arc::new(registry);
 
     let mut writer = topic_client
@@ -365,17 +458,21 @@ async fn codec_custom_roundtrip() -> YdbResult<()> {
     for i in 0..message_count {
         let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
         expected_messages.push(data.clone());
-        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
     }
     writer.flush().await?;
     writer.stop().await?;
 
     let mut reader = topic_client
-        .create_reader_with_params(TopicReaderOptionsBuilder::default()
-            .topic(topic_path.clone().into())
-            .consumer(consumer_name)
-            .codec_registry(registry.clone())
-            .build()?)
+        .create_reader_with_params(
+            TopicReaderOptionsBuilder::default()
+                .topic(topic_path.clone().into())
+                .consumer(consumer_name)
+                .codec_registry(registry.clone())
+                .build()?,
+        )
         .await?;
 
     let mut received_messages: Vec<Vec<u8>> = Vec::new();
@@ -411,7 +508,11 @@ async fn codec_parallelism() -> YdbResult<()> {
     trace!("previous topic removed");
 
     let mut registry = CodecRegistry::default();
-    registry.register_codec(Codec::SLOW_INC13, Arc::new(slow_inc13_compress), Arc::new(slow_inc13_decompress))?;
+    registry.register_codec(
+        Codec::SLOW_INC13,
+        Arc::new(slow_inc13_compress),
+        Arc::new(slow_inc13_decompress),
+    )?;
     let registry = Arc::new(registry);
 
     topic_client
@@ -419,16 +520,13 @@ async fn codec_parallelism() -> YdbResult<()> {
             topic_path.clone(),
             CreateTopicOptionsBuilder::default()
                 .supported_codecs(vec![Codec::SLOW_INC13])
-                .consumers(vec![
-                    ConsumerBuilder::default()
-                        .name(consumer_name.clone())
-                        .build()?,
-                ])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
                 .build()?,
         )
         .await?;
     trace!("topic created");
-
 
     let mut writer = topic_client
         .create_writer_with_params(
@@ -447,19 +545,23 @@ async fn codec_parallelism() -> YdbResult<()> {
     for i in 0..message_count {
         let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
         expected_messages.push(data.clone());
-        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
     }
-    timeout(Duration::from_secs(5), writer.flush()).await.map_err(
-        |err| YdbError::custom(format!("Error waiting for messages write {err}")
-    ))??;
+    timeout(Duration::from_secs(5), writer.flush())
+        .await
+        .map_err(|err| YdbError::custom(format!("Error waiting for messages write {err}")))??;
     writer.stop().await?;
 
     let mut reader = topic_client
-        .create_reader_with_params(TopicReaderOptionsBuilder::default()
-            .topic(topic_path.clone().into())
-            .consumer(consumer_name)
-            .codec_registry(registry.clone())
-            .build()?)
+        .create_reader_with_params(
+            TopicReaderOptionsBuilder::default()
+                .topic(topic_path.clone().into())
+                .consumer(consumer_name)
+                .codec_registry(registry.clone())
+                .build()?,
+        )
         .await?;
 
     let mut received_messages: Vec<Vec<u8>> = Vec::new();
@@ -495,7 +597,11 @@ async fn codec_auto() -> YdbResult<()> {
     trace!("previous topic removed");
 
     let mut registry = CodecRegistry::default();
-    registry.register_codec(Codec::INC13, Arc::new(inc13_compress), Arc::new(inc13_decompress))?;
+    registry.register_codec(
+        Codec::INC13,
+        Arc::new(inc13_compress),
+        Arc::new(inc13_decompress),
+    )?;
     let registry = Arc::new(registry);
 
     topic_client
@@ -503,11 +609,9 @@ async fn codec_auto() -> YdbResult<()> {
             topic_path.clone(),
             CreateTopicOptionsBuilder::default()
                 .supported_codecs(vec![Codec::RAW, Codec::INC13, Codec::GZIP])
-                .consumers(vec![
-                    ConsumerBuilder::default()
-                        .name(consumer_name.clone())
-                        .build()?,
-                ])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .build()?])
                 .build()?,
         )
         .await?;
@@ -523,24 +627,28 @@ async fn codec_auto() -> YdbResult<()> {
         .await?;
     trace!("writer created");
 
-    let message_count = 1000;
+    let message_count = 500;
     let mut expected_messages: Vec<Vec<u8>> = Vec::new();
     for i in 0..message_count {
-        let mut data: Vec<u8> = format!("this text is boring this text is boring this text is boring this text is boring").into_bytes();
-        if i > 500 {
+        let mut data: Vec<u8> = "this text is boring this text is boring this text is boring this text is boring".to_string().into_bytes();
+        if i < 101 || i > 300 {
             data.iter_mut().for_each(|x| *x = rand::random());
         }
         expected_messages.push(data.clone());
-        writer.write(TopicWriterMessageBuilder::default().data(data).build()?).await?;
+        writer
+            .write(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
     }
     writer.stop().await?;
 
     let mut reader = topic_client
-        .create_reader_with_params(TopicReaderOptionsBuilder::default()
-            .topic(topic_path.clone().into())
-            .consumer(consumer_name)
-            .codec_registry(registry.clone())
-            .build()?)
+        .create_reader_with_params(
+            TopicReaderOptionsBuilder::default()
+                .topic(topic_path.clone().into())
+                .consumer(consumer_name)
+                .codec_registry(registry.clone())
+                .build()?,
+        )
         .await?;
 
     let mut received_messages: Vec<Vec<u8>> = Vec::new();

--- a/ydb/src/topics_test.rs
+++ b/ydb/src/topics_test.rs
@@ -9,12 +9,12 @@ use crate::client_topic::client::DescribeConsumerOptionsBuilder;
 use crate::client_topic::list_types::ConsumerBuilder;
 use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
 use crate::test_integration_helper::create_client;
+use crate::DescribeTopicOptionsBuilder;
 use crate::{
     client_topic::client::{AlterTopicOptionsBuilder, CreateTopicOptionsBuilder},
-    PartitioningStrategy, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, YdbError,
+    Codec, PartitioningStrategy, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, YdbError,
     YdbResult,
 };
-use crate::{Codec, DescribeTopicOptionsBuilder};
 use tracing::{debug, info, trace, warn};
 use ydb_grpc::ydb_proto::topic::stream_read_message;
 use ydb_grpc::ydb_proto::topic::stream_read_message::init_request::TopicReadSettings;
@@ -488,6 +488,67 @@ async fn start_read_topic(
     });
 
     Ok(topic_messages_rx)
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn write_and_read_with_gzip_codec_roundtrip() -> YdbResult<()> {
+    let client = create_client().await?;
+    let database_path = client.database();
+    let topic_name = format!("write_read_gzip_{}", uuid::Uuid::new_v4().simple());
+    let topic_path = format!("{database_path}/{topic_name}");
+    let consumer_name = "test-consumer-gzip".to_string();
+
+    let mut topic_client = client.topic_client();
+
+    topic_client
+        .create_topic(
+            topic_path.clone(),
+            CreateTopicOptionsBuilder::default()
+                .supported_codecs(vec![Codec::RAW, Codec::GZIP])
+                .consumers(vec![ConsumerBuilder::default()
+                    .name(consumer_name.clone())
+                    .supported_codecs(vec![Codec::RAW, Codec::GZIP])
+                    .build()?])
+                .build()?,
+        )
+        .await?;
+
+    let mut writer = topic_client
+        .create_writer_with_params(
+            TopicWriterOptionsBuilder::default()
+                .topic_path(topic_path.clone())
+                .codec(Codec::GZIP)
+                .build()?,
+        )
+        .await?;
+
+    let expected = vec![1_u8, 2_u8, 3_u8, 4_u8];
+    writer
+        .write_with_ack(
+            TopicWriterMessageBuilder::default()
+                .data(expected.clone())
+                .build()?,
+        )
+        .await?;
+    writer.stop().await?;
+
+    let mut reader = topic_client
+        .create_reader(consumer_name, topic_path)
+        .await?;
+
+    let mut batch = timeout(Duration::from_secs(30), reader.read_batch())
+        .await
+        .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+    let mut message = batch
+        .messages
+        .pop()
+        .ok_or_else(|| YdbError::custom("empty batch"))?;
+
+    assert_eq!(message.read_and_take().await?.unwrap(), expected);
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/ydb/src/topics_test.rs
+++ b/ydb/src/topics_test.rs
@@ -9,12 +9,12 @@ use crate::client_topic::client::DescribeConsumerOptionsBuilder;
 use crate::client_topic::list_types::ConsumerBuilder;
 use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
 use crate::test_integration_helper::create_client;
-use crate::DescribeTopicOptionsBuilder;
 use crate::{
     client_topic::client::{AlterTopicOptionsBuilder, CreateTopicOptionsBuilder},
-    Codec, PartitioningStrategy, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, YdbError,
+    PartitioningStrategy, TopicWriterMessageBuilder, TopicWriterOptionsBuilder, YdbError,
     YdbResult,
 };
+use crate::{Codec, DescribeTopicOptionsBuilder};
 use tracing::{debug, info, trace, warn};
 use ydb_grpc::ydb_proto::topic::stream_read_message;
 use ydb_grpc::ydb_proto::topic::stream_read_message::init_request::TopicReadSettings;
@@ -488,73 +488,6 @@ async fn start_read_topic(
     });
 
     Ok(topic_messages_rx)
-}
-
-#[tokio::test]
-#[traced_test]
-#[ignore] // need YDB access
-async fn write_and_read_with_gzip_codec_roundtrip() -> YdbResult<()> {
-    let client = create_client().await?;
-    let database_path = client.database();
-    let topic_name = format!("write_read_gzip_{}", uuid::Uuid::new_v4().simple());
-    let topic_path = format!("{database_path}/{topic_name}");
-    let consumer_name = "test-consumer-gzip".to_string();
-
-    let mut topic_client = client.topic_client();
-
-    topic_client
-        .create_topic(
-            topic_path.clone(),
-            CreateTopicOptionsBuilder::default()
-                .supported_codecs(vec![Codec::RAW, Codec::GZIP])
-                .consumers(vec![ConsumerBuilder::default()
-                    .name(consumer_name.clone())
-                    .supported_codecs(vec![Codec::RAW, Codec::GZIP])
-                    .build()?])
-                .build()?,
-        )
-        .await?;
-
-    let mut writer = topic_client
-        .create_writer_with_params(
-            TopicWriterOptionsBuilder::default()
-                .topic_path(topic_path.clone())
-                .codec(Codec::GZIP)
-                .build()?,
-        )
-        .await?;
-
-    let message_count = 20;
-    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
-    for i in 0..message_count {
-        let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
-        expected_messages.push(data.clone());
-        writer
-            .write_with_ack(TopicWriterMessageBuilder::default().data(data).build()?)
-            .await?;
-    }
-    writer.stop().await?;
-
-    let mut reader = topic_client
-        .create_reader(consumer_name, topic_path)
-        .await?;
-
-    let mut received_messages: Vec<Vec<u8>> = Vec::new();
-    while received_messages.len() < message_count {
-        let batch = timeout(Duration::from_secs(30), reader.read_batch())
-            .await
-            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
-        for mut message in batch.messages {
-            if let Some(data) = message.read_and_take().await? {
-                received_messages.push(data);
-            }
-        }
-    }
-
-    assert_eq!(received_messages.len(), message_count);
-    assert_eq!(received_messages, expected_messages);
-
-    Ok(())
 }
 
 #[tokio::test]

--- a/ydb/src/topics_test.rs
+++ b/ydb/src/topics_test.rs
@@ -524,29 +524,35 @@ async fn write_and_read_with_gzip_codec_roundtrip() -> YdbResult<()> {
         )
         .await?;
 
-    let expected = vec![1_u8, 2_u8, 3_u8, 4_u8];
-    writer
-        .write_with_ack(
-            TopicWriterMessageBuilder::default()
-                .data(expected.clone())
-                .build()?,
-        )
-        .await?;
+    let message_count = 20;
+    let mut expected_messages: Vec<Vec<u8>> = Vec::new();
+    for i in 0..message_count {
+        let data: Vec<u8> = format!("gzip-test-message-{i}").into_bytes();
+        expected_messages.push(data.clone());
+        writer
+            .write_with_ack(TopicWriterMessageBuilder::default().data(data).build()?)
+            .await?;
+    }
     writer.stop().await?;
 
     let mut reader = topic_client
         .create_reader(consumer_name, topic_path)
         .await?;
 
-    let mut batch = timeout(Duration::from_secs(30), reader.read_batch())
-        .await
-        .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
-    let mut message = batch
-        .messages
-        .pop()
-        .ok_or_else(|| YdbError::custom("empty batch"))?;
+    let mut received_messages: Vec<Vec<u8>> = Vec::new();
+    while received_messages.len() < message_count {
+        let batch = timeout(Duration::from_secs(30), reader.read_batch())
+            .await
+            .map_err(|err| YdbError::custom(format!("timeout waiting reader batch: {err}")))??;
+        for mut message in batch.messages {
+            if let Some(data) = message.read_and_take().await? {
+                received_messages.push(data);
+            }
+        }
+    }
 
-    assert_eq!(message.read_and_take().await?.unwrap(), expected);
+    assert_eq!(received_messages.len(), message_count);
+    assert_eq!(received_messages, expected_messages);
 
     Ok(())
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Topic writer sends messages to the server without compression (hardcoded codec: RAW). Topic reader receives messages and delivers them to the consumer without decompression -- compressed messages would be delivered as raw compressed bytes.

Issue Number: N/A

## What is the new behavior?

- Added transparent compression/decompression for topic writer and reader
- GZIP codec supported out of the box; custom codecs can be registered via CodecRegistry
- Compression is offloaded to a background thread to avoid blocking the async runtime
- Configurable error handling strategy: fail fast or skip failed messages
- New TopicReaderOptions for configuring reader decompression behavior

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
