### PR TITLE
feat(scheme): add DescribePath to SchemeClient

### DIFF
--- a/ydb/src/client_directory_test_integration.rs
+++ b/ydb/src/client_directory_test_integration.rs
@@ -3,6 +3,7 @@ use std::time::UNIX_EPOCH;
 
 use tracing_test::traced_test;
 
+use crate::client_scheme::list_types::SchemeEntryType;
 use crate::errors::YdbResult;
 use crate::test_integration_helper::create_client;
 
@@ -18,6 +19,11 @@ async fn create_list_remove_directory() -> YdbResult<()> {
     let directory_path = format!("{}/{}", database_path, directory_name.clone());
 
     scheme_client.make_directory(directory_path.clone()).await?;
+
+    let entry = scheme_client.describe_path(directory_path.clone()).await?;
+    assert_eq!(entry.name, directory_name);
+    assert!(matches!(entry.r#type, SchemeEntryType::Directory));
+
     let directories = scheme_client.list_directory(database_path.clone()).await?;
     assert!(directories.iter().any(|d| d.name == directory_name));
 

--- a/ydb/src/client_scheme/client.rs
+++ b/ydb/src/client_scheme/client.rs
@@ -4,6 +4,7 @@ use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_scheme_client::client::{
     RawMakeDirectoryRequest, RawRemoveDirectoryRequest,
 };
+use crate::grpc_wrapper::raw_scheme_client::describe_path_types::RawDescribePathRequest;
 use crate::grpc_wrapper::raw_scheme_client::list_directory_types::RawListDirectoryRequest;
 use crate::{grpc_wrapper, YdbResult};
 
@@ -32,6 +33,18 @@ impl SchemeClient {
         let mut service = self.connection().await?;
         service.make_directory(req).await?;
         Ok(())
+    }
+
+    pub async fn describe_path(&mut self, path: String) -> YdbResult<SchemeEntry> {
+        let req = RawDescribePathRequest {
+            operation_params: self.timeouts.operation_params(),
+            path,
+        };
+
+        let mut service = self.connection().await?;
+        let res = service.describe_path(req).await?;
+
+        Ok(res.entry)
     }
 
     pub async fn list_directory(&mut self, path: String) -> YdbResult<Vec<SchemeEntry>> {

--- a/ydb/src/grpc_wrapper/raw_scheme_client/client.rs
+++ b/ydb/src/grpc_wrapper/raw_scheme_client/client.rs
@@ -1,5 +1,8 @@
 use crate::grpc_wrapper::grpc_limits::WithGrpcMaxMessageSize;
 use crate::grpc_wrapper::raw_errors::RawResult;
+use crate::grpc_wrapper::raw_scheme_client::describe_path_types::{
+    RawDescribePathRequest, RawDescribePathResult,
+};
 use crate::grpc_wrapper::raw_scheme_client::list_directory_types::{
     RawListDirectoryRequest, RawListDirectoryResult,
 };
@@ -57,6 +60,18 @@ impl RawSchemeClient {
         request_without_result!(
             self.service.remove_directory,
             req => ydb_grpc::ydb_proto::scheme::RemoveDirectoryRequest
+        );
+    }
+
+    #[instrument(skip(self), err, ret)]
+    pub async fn describe_path(
+        &mut self,
+        req: RawDescribePathRequest,
+    ) -> RawResult<RawDescribePathResult> {
+        request_with_result!(
+            self.service.describe_path,
+            req => ydb_grpc::ydb_proto::scheme::DescribePathRequest,
+            ydb_grpc::ydb_proto::scheme::DescribePathResult => RawDescribePathResult
         );
     }
 }

--- a/ydb/src/grpc_wrapper/raw_scheme_client/describe_path_types.rs
+++ b/ydb/src/grpc_wrapper/raw_scheme_client/describe_path_types.rs
@@ -1,0 +1,41 @@
+use crate::grpc_wrapper::raw_errors::RawError;
+use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
+use crate::SchemeEntry;
+
+use super::list_directory_types::from_grpc_to_scheme_entry;
+
+#[derive(Debug)]
+pub(crate) struct RawDescribePathRequest {
+    pub(crate) operation_params: RawOperationParams,
+    pub(crate) path: String,
+}
+
+impl From<RawDescribePathRequest> for ydb_grpc::ydb_proto::scheme::DescribePathRequest {
+    fn from(v: RawDescribePathRequest) -> Self {
+        Self {
+            operation_params: Some(v.operation_params.into()),
+            path: v.path,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RawDescribePathResult {
+    pub(crate) entry: SchemeEntry,
+}
+
+impl TryFrom<ydb_grpc::ydb_proto::scheme::DescribePathResult> for RawDescribePathResult {
+    type Error = RawError;
+
+    fn try_from(
+        value: ydb_grpc::ydb_proto::scheme::DescribePathResult,
+    ) -> Result<Self, Self::Error> {
+        let entry = value.self_.ok_or(RawError::ProtobufDecodeError(
+            "describe path self entry is empty".to_string(),
+        ))?;
+
+        Ok(Self {
+            entry: from_grpc_to_scheme_entry(entry),
+        })
+    }
+}

--- a/ydb/src/grpc_wrapper/raw_scheme_client/mod.rs
+++ b/ydb/src/grpc_wrapper/raw_scheme_client/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod client;
+pub(crate) mod describe_path_types;
 pub(crate) mod list_directory_types;

--- a/ydb/src/trait_operation.rs
+++ b/ydb/src/trait_operation.rs
@@ -6,7 +6,7 @@ use ydb_grpc::ydb_proto::coordination::{
 use ydb_grpc::ydb_proto::discovery::{ListEndpointsResponse, WhoAmIResponse};
 use ydb_grpc::ydb_proto::operations::Operation as YdbOperation;
 use ydb_grpc::ydb_proto::scheme::{
-    ListDirectoryResponse, MakeDirectoryResponse, RemoveDirectoryResponse,
+    DescribePathResponse, ListDirectoryResponse, MakeDirectoryResponse, RemoveDirectoryResponse,
 };
 use ydb_grpc::ydb_proto::table::{
     BulkUpsertResponse, CommitTransactionResponse, CopyTableResponse, CopyTablesResponse,
@@ -45,6 +45,7 @@ operation_impl_for!(RollbackTransactionResponse);
 operation_impl_for!(WhoAmIResponse);
 operation_impl_for!(MakeDirectoryResponse);
 operation_impl_for!(ListDirectoryResponse);
+operation_impl_for!(DescribePathResponse);
 operation_impl_for!(RemoveDirectoryResponse);
 operation_impl_for!(AlterTopicResponse);
 operation_impl_for!(CreateTopicResponse);


### PR DESCRIPTION
## Summary

- Add `SchemeClient::describe_path(path)` that returns `SchemeEntry` for a single scheme object by path
- Wire up the `DescribePath` gRPC RPC through `RawSchemeClient`, reusing existing `SchemeEntry` conversion from `list_directory_types`
- Extend the directory integration test to verify `describe_path` on a created directory

Closes #279

## Test plan

- [x] `cargo check -p ydb` passes
- [ ] `cargo test -p ydb create_list_remove_directory -- --ignored` (requires YDB access)


Made with [Cursor](https://cursor.com)