### PR TITLE
fix: share the same SharedLoadBalancer between Client and GrpcConnectionManager to eliminate flaky "empty endpoint list" race condition

### DIFF
--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -29,12 +29,11 @@ impl Client {
         credentials: DBCredentials,
         discovery: Arc<Box<dyn Discovery>>,
         connection_manager: GrpcConnectionManager,
+        load_balancer: SharedLoadBalancer,
     ) -> YdbResult<Self> {
-        let discovery_ref = discovery.as_ref().as_ref();
-
         Ok(Client {
             credentials,
-            load_balancer: SharedLoadBalancer::new(discovery_ref),
+            load_balancer,
             discovery,
             timeouts: TimeoutSettings::default(),
             connection_manager,

--- a/ydb/src/client_builder.rs
+++ b/ydb/src/client_builder.rs
@@ -296,14 +296,14 @@ impl ClientBuilder {
 
         let load_balancer = SharedLoadBalancer::new(discovery.as_ref().as_ref());
         let connection_manager = GrpcConnectionManager::new(
-            load_balancer,
+            load_balancer.clone(),
             db_cred.database.clone(),
             interceptor,
             self.cert_path,
             self.grpc_max_message_size,
         );
 
-        Client::new(db_cred, discovery, connection_manager)
+        Client::new(db_cred, discovery, connection_manager, load_balancer)
     }
 
     pub fn with_credentials<T: 'static + Credentials>(mut self, cred: T) -> Self {


### PR DESCRIPTION
Fixes the intermittently failing `tests (RUST_VERSION_OLD)` CI job where `topics_test::read_batch_merges_and_respects_hard_limit` would fail with:

```
Error: Custom("empty endpoint list for service: scheme_service")
```

## Root Cause

`Client::new()` was creating a **second, independent** `SharedLoadBalancer` from the discovery reference, while `ClientBuilder::client()` had already created a **first** `SharedLoadBalancer` and moved it into `connection_manager`. This gave the `Client` two completely separate balancers — each with its own `update_load_balancer` Tokio background task consuming discovery updates independently:

| | Balancer | Used by |
|---|---|---|
| #1 (from `client_builder.rs`) | owned by `connection_manager` | all gRPC service calls (`scheme`, `table`, `topic`, …) |
| #2 (from `Client::new()`) | `Client.load_balancer` | only `client.wait()` |

After `client.wait()` returned `Ok` (balancer #2 became ready), balancer #1 might still have an empty `discovery_state` because its `update_load_balancer` task hadn't processed the non-empty discovery response yet. Any immediate service call (e.g. `scheme.list_directory()`) would then hit balancer #1 via `connection_manager` and fail with `"empty endpoint list"`.

## Fix

Two surgical changes in `client.rs` and `client_builder.rs`:

- `Client::new()` now accepts the `SharedLoadBalancer` as an explicit parameter instead of creating a new one from discovery.
- `ClientBuilder::client()` clones the single `SharedLoadBalancer` into `connection_manager` and passes the original to `Client::new()`.

Since `SharedLoadBalancer` is `Arc`-backed (`inner: Arc<RwLock<Box<dyn LoadBalancer>>>`), the clone and original share the same underlying state. `client.wait()` and all gRPC service calls now observe identical readiness state, eliminating the race condition. As a side effect, one redundant `update_load_balancer` background task is removed.

## Testing

```bash
cargo fmt --check
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace
```


Made with [Cursor](https://cursor.com)