### PR TITLE
Add Codecov test coverage reporting to CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -44,6 +44,7 @@ jobs:
       uses: dtolnay/rust-toolchain@v1
       with:
         toolchain: ${{ env[matrix.rust_version] }}
+        components: llvm-tools-preview
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -61,7 +62,19 @@ jobs:
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Run tests
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
+
+    - name: Run tests with coverage
       env:
         YDB_CONNECTION_STRING: grpc://localhost:2136?database=/local
-      run: cargo test --verbose --workspace -- --include-ignored
+      run: cargo llvm-cov --workspace --exclude ydb-slo-tests --lcov --output-path lcov.info -- --include-ignored
+
+    - name: Upload coverage report to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./lcov.info
+        flags: tests,ubuntu,rust-${{ steps.rust_version_step.outputs.version }}
+        name: tests
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Latest Version](https://img.shields.io/crates/v/ydb.svg)](https://crates.io/crates/ydb)
 [![Released API docs](https://docs.rs/ydb/badge.svg)](https://docs.rs/ydb)
 [![YDB tests](https://github.com/ydb-platform/ydb-rs-sdk/actions/workflows/rust-tests.yml/badge.svg?branch=master&event=schedule)](https://github.com/ydb-platform/ydb-rs-sdk/actions/workflows/rust-tests.yml)
+[![codecov](https://codecov.io/gh/ydb-platform/ydb-rs-sdk/badge.svg?precision=2)](https://app.codecov.io/gh/ydb-platform/ydb-rs-sdk)
 
 Rust SDK for YDB.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+# https://github.com/codecov/support/blob/master/codecov.yml
+ignore:
+  - ydb-grpc/src/generated
+  - ydb/examples
+  - ydb-slo-tests


### PR DESCRIPTION
## Summary
- Collect test coverage in `rust-tests` CI using `cargo-llvm-cov` (LLVM source-based instrumentation) instead of plain `cargo test`
- Upload LCOV reports to Codecov with flags per Rust version, matching the approach used in ydb-go-sdk
- Add `codecov.yml` to exclude generated gRPC code, examples, and SLO tests from coverage stats
- Add Codecov badge to README

## Test plan
- [ ] CI `rust-tests` job passes on both Rust 1.82 and 1.91.0 matrix entries
- [ ] Coverage report is uploaded to Codecov (`CODECOV_TOKEN` org secret)
- [ ] Codecov badge appears in README after the first successful upload


Made with [Cursor](https://cursor.com)