### PR TITLE
Fix cargo publish after ydb-api-protos update

### DIFF
--- a/ydb/src/grpc_wrapper/raw_scheme_client/list_directory_types.rs
+++ b/ydb/src/grpc_wrapper/raw_scheme_client/list_directory_types.rs
@@ -90,6 +90,10 @@ fn from_grpc_code_to_scheme_entry_type(value: i32) -> SchemeEntryType {
         grpcT::ExternalDataSource => SchemeEntryType::ExternalDataSource,
         grpcT::ExternalTable => SchemeEntryType::ExternalTable,
         grpcT::View => SchemeEntryType::View,
+        // New scheme entry types (ResourcePool, Transfer, SysView) map to Unknown until
+        // SchemeEntryType gains dedicated variants. Catch-all stays for forward compatibility
+        // with older ydb-grpc releases where all variants are listed above.
+        #[allow(unreachable_patterns)]
         _ => SchemeEntryType::Unknown(value),
     }
 }

--- a/ydb/src/grpc_wrapper/raw_table_service/describe_table.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/describe_table.rs
@@ -18,7 +18,7 @@ impl From<RawDescribeTableRequest> for ydb_grpc::ydb_proto::table::DescribeTable
             include_table_stats: false,
             include_partition_stats: false,
             include_shard_nodes_info: false,
-            include_set_val: false,
+            ..Default::default()
         }
     }
 }

--- a/ydb/src/grpc_wrapper/raw_topic_service/alter_topic.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/alter_topic.rs
@@ -96,8 +96,7 @@ impl From<RawAlterTopicRequest> for AlterTopicRequest {
                 .map(AlterConsumer::from)
                 .collect(),
             set_metering_mode: MeteringMode::from(value.set_metering_mode).into(),
-            metrics_level: None,
-            set_content_based_deduplication: None,
+            ..Default::default()
         }
     }
 }

--- a/ydb/src/grpc_wrapper/raw_topic_service/common/consumer.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/common/consumer.rs
@@ -54,7 +54,7 @@ impl From<RawConsumer> for Consumer {
             supported_codecs: Some(value.supported_codecs.into()),
             attributes: value.attributes,
             consumer_stats: None,
-            availability_period: None,
+            ..Default::default()
         }
     }
 }
@@ -76,7 +76,7 @@ impl From<RawAlterConsumer> for AlterConsumer {
             set_read_from: value.set_read_from.map(|x| x.into()),
             set_supported_codecs: value.set_supported_codecs.map(|x| x.into()),
             alter_attributes: value.alter_attributes,
-            availability_period_action: None,
+            ..Default::default()
         }
     }
 }

--- a/ydb/src/grpc_wrapper/raw_topic_service/create_topic.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/create_topic.rs
@@ -70,8 +70,7 @@ impl From<RawCreateTopicRequest> for CreateTopicRequest {
             attributes: value.attributes,
             consumers: value.consumers.into_iter().map(Consumer::from).collect(),
             metering_mode: MeteringMode::from(value.metering_mode) as i32,
-            metrics_level: None,
-            content_based_deduplication: false,
+            ..Default::default()
         }
     }
 }

--- a/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
@@ -134,7 +134,7 @@ impl From<RawInitRequest> for stream_read_message::InitRequest {
             reader_name: value.reader_name,
             direct_read: false,
             auto_partitioning_support: false,
-            partition_max_in_flight_bytes: 0,
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
## Summary

- After PR #445 merged updated protobuf definitions, `ydb` wrapper code referenced new proto fields (`include_set_val`, `metrics_level`, `availability_period`, etc.).
- `cargo publish` for `ydb` resolves `ydb-grpc` from crates.io (0.2.0), which still has the old generated structs without those fields, causing `E0560` compile errors during tarball verification.
- Replace explicit initialization of new fields with `..Default::default()` so the same code compiles against both the workspace `ydb-grpc` and the published crates.io version.

## Test plan

- [x] `cargo publish --dry-run --allow-dirty` in `ydb/` succeeds
- [x] `cargo clippy -p ydb --all-targets` passes

## Follow-up

To ship the updated generated protos on crates.io, publish `ydb-grpc` with a version bump (e.g. 0.3.0) via the publish workflow, then bump the `ydb` dependency.

Made with [Cursor](https://cursor.com)