### PR TITLE
Fix publish retry when version tag already exists

### DIFF
--- a/.github/scripts/version-up.sh
+++ b/.github/scripts/version-up.sh
@@ -17,7 +17,25 @@ function git_set_tags(){
 
   local GIT_TAG
   for GIT_TAG in "${GIT_TAGS[@]}";  do
-    git tag "$GIT_TAG"
+    git tag -f "$GIT_TAG"
+  done
+}
+
+function git push_tags() {
+  local GIT_TAG remote_sha local_sha
+  for GIT_TAG in "${GIT_TAGS[@]}"; do
+    remote_sha="$(git ls-remote --tags origin "refs/tags/$GIT_TAG" | cut -f1)"
+    local_sha="$(git rev-parse "$GIT_TAG")"
+    if [ -n "$remote_sha" ]; then
+      if [ "$remote_sha" = "$local_sha" ]; then
+        echo "Tag $GIT_TAG already exists on remote at the same commit, skipping push"
+      else
+        echo "Tag $GIT_TAG exists on remote at a different commit, force-updating"
+        git push origin "refs/tags/$GIT_TAG":refs/tags/"$GIT_TAG" --force
+      fi
+    else
+      git push origin "$GIT_TAG"
+    fi
   done
 }
 
@@ -123,7 +141,7 @@ git diff
 git_set_tags
 
 # push tags before publish - for fix repository state if failed in middle of publish crates
-git push --tags
+git push_tags
 
 for CRATE in "${CRATES[@]}"; do
   publish_crate "$CRATE"


### PR DESCRIPTION
## Summary

- When `cargo publish` fails after the version tag is pushed, re-running the workflow bumps the same version again and fails on `git push --tags` because the tag already exists on the remote.
- Use `git tag -f` locally and force-update remote tags when they point to a different commit.

## Context

The orphaned `ydb-0.13.2` tag (from a publish attempt before PR #446) was deleted manually so the next publish run can proceed.

## Test plan

- [ ] Re-run publish workflow for `ydb` / `patch` after merging PR #446

Made with [Cursor](https://cursor.com)