### PR TITLE
SLO: key-value workload over Query Service client

### DIFF
--- a/.github/scripts/build-slo-image.sh
+++ b/.github/scripts/build-slo-image.sh
@@ -77,6 +77,9 @@ case "$src_path" in
   native/table)
     pkg_name="slo-native-table"
     ;;
+  native/query)
+    pkg_name="slo-native-query"
+    ;;
   *)
     die "Unknown --src-path: $src_path"
     ;;

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Run tests with coverage
       env:
         YDB_CONNECTION_STRING: grpc://localhost:2136?database=/local
-      run: cargo llvm-cov --workspace --exclude slo-framework --exclude slo-native-table --lcov --output-path lcov.info -- --include-ignored
+      run: cargo llvm-cov --workspace --exclude slo-framework --exclude slo-native-table --exclude slo-native-query --lcov --output-path lcov.info -- --include-ignored
 
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -47,6 +47,8 @@ jobs:
         sdk:
           - name: native-table
             path: native/table
+          - name: native-query
+            path: native/query
 
     concurrency:
       group: slo-${{ github.ref }}-${{ matrix.sdk.name }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,6 +2499,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "slo-native-query"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "slo-framework",
+ "tokio",
+ "ydb",
+]
+
+[[package]]
 name = "slo-native-table"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     #    "ydb-grpc-helpers",
     "tests/slo/slo-framework",
     "tests/slo/native/table",
+    "tests/slo/native/query",
 ]
 
 [workspace.package]

--- a/tests/slo/README.md
+++ b/tests/slo/README.md
@@ -8,9 +8,10 @@ SLO tests exercise the SDK against a YDB cluster under chaos (node failures, net
 
 ```
 tests/slo/
-  Dockerfile                 # builds slo-native-table binary
+  Dockerfile                 # builds slo-native-table / slo-native-query binaries
   slo-framework/             # shared framework (config, metrics, kv workload)
   native/table/              # TableClient key-value workload (#420)
+  native/query/              # QueryClient key-value workload (#453)
 ```
 
 ## CI
@@ -25,6 +26,8 @@ The workload runs **setup → run → teardown** in one process (create table, p
 
 ```bash
 cargo build --release -p slo-native-table
+# or
+cargo build --release -p slo-native-query
 
 export YDB_CONNECTION_STRING=grpc://localhost:2136/local
 export WORKLOAD_REF=local
@@ -34,6 +37,12 @@ export WORKLOAD_DURATION=60
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:9090/api/v1/otlp
 
 ./target/release/slo-native-table \
+  --read-rps 100 \
+  --write-rps 10 \
+  --prefill-count 1000
+
+# Query Service workload (same flags; set WORKLOAD_NAME=native-query):
+./target/release/slo-native-query \
   --read-rps 100 \
   --write-rps 10 \
   --prefill-count 1000
@@ -47,6 +56,13 @@ WORKLOAD_REF=local \
 WORKLOAD_NAME=native-table \
 WORKLOAD_DURATION=60 \
 cargo run --release -p slo-native-table -- --read-rps 100 --write-rps 10
+
+# Query Service:
+YDB_CONNECTION_STRING=grpc://localhost:2136/local \
+WORKLOAD_REF=local \
+WORKLOAD_NAME=native-query \
+WORKLOAD_DURATION=60 \
+cargo run --release -p slo-native-query -- --read-rps 100 --write-rps 10
 ```
 
 ### CLI flags

--- a/tests/slo/native/query/Cargo.toml
+++ b/tests/slo/native/query/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+publish = false
+name = "slo-native-query"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85"
+
+[[bin]]
+name = "slo-native-query"
+path = "src/main.rs"
+
+[dependencies]
+async-trait = "0.1"
+slo-framework = { path = "../../slo-framework" }
+tokio = { version = "=1.38.1", features = ["full"] }
+ydb = { path = "../../../../ydb" }

--- a/tests/slo/native/query/src/main.rs
+++ b/tests/slo/native/query/src/main.rs
@@ -1,0 +1,8 @@
+mod storage;
+
+use slo_framework::run;
+
+#[tokio::main]
+async fn main() {
+    run(|fw| Box::pin(storage::new_workload(fw.clone()))).await;
+}

--- a/tests/slo/native/query/src/storage.rs
+++ b/tests/slo/native/query/src/storage.rs
@@ -1,0 +1,196 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use slo_framework::kv::{Database, KvWorkload, Params};
+use slo_framework::{Framework, RowID, TestRow, Workload};
+use ydb::ClientBuilder;
+use ydb::QueryClient;
+
+pub struct Storage {
+    query_client: QueryClient,
+    table_path: String,
+    read_timeout: Duration,
+    write_timeout: Duration,
+    partition_size: u64,
+    min_partition_count: u64,
+    max_partition_count: u64,
+}
+
+impl Storage {
+    pub async fn new(fw: &Framework, params: &Params) -> Result<Self, String> {
+        let client = ClientBuilder::new_from_connection_string(&fw.config.connection_string)
+            .map_err(|err| err.to_string())?
+            .client()
+            .map_err(|err| err.to_string())?;
+
+        client.wait().await.map_err(|err| err.to_string())?;
+
+        Ok(Self {
+            query_client: client.query_client(),
+            table_path: params.table_path.clone(),
+            read_timeout: params.read_timeout,
+            write_timeout: params.write_timeout,
+            partition_size: params.partition_size,
+            min_partition_count: params.min_partition_count,
+            max_partition_count: params.max_partition_count,
+        })
+    }
+
+    fn idempotent_client(&self) -> QueryClient {
+        self.query_client.clone_with_idempotent_operations(true)
+    }
+}
+
+#[async_trait]
+impl Database for Storage {
+    async fn create_table(&self) -> Result<(), String> {
+        let query = format!(
+            "CREATE TABLE IF NOT EXISTS `{table}` (
+                hash Uint64,
+                id Uint64,
+                payload_str Text?,
+                payload_double Double?,
+                payload_timestamp Timestamp?,
+                payload_hash Uint64?,
+                PRIMARY KEY (hash, id)
+            ) WITH (
+                UNIFORM_PARTITIONS = {min_partition_count},
+                AUTO_PARTITIONING_BY_SIZE = ENABLED,
+                AUTO_PARTITIONING_PARTITION_SIZE_MB = {partition_size},
+                AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = {min_partition_count},
+                AUTO_PARTITIONING_MAX_PARTITIONS_COUNT = {max_partition_count}
+            )",
+            table = self.table_path,
+            min_partition_count = self.min_partition_count,
+            max_partition_count = self.max_partition_count,
+            partition_size = self.partition_size,
+        );
+
+        let mut qc = self.idempotent_client();
+        tokio::time::timeout(self.write_timeout, async move { qc.exec(query).await })
+            .await
+            .map_err(|_| "create table timeout".to_string())?
+            .map_err(|err| err.to_string())
+    }
+
+    async fn drop_table(&self) -> Result<(), String> {
+        let query = format!("DROP TABLE `{table}`", table = self.table_path);
+        let mut qc = self.idempotent_client();
+        tokio::time::timeout(self.write_timeout, async move { qc.exec(query).await })
+            .await
+            .map_err(|_| "drop table timeout".to_string())?
+            .map_err(|err| err.to_string())
+    }
+
+    async fn read(&self, id: RowID) -> Result<(TestRow, u64), String> {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let select_sql = format!(
+            r#"
+            DECLARE $id AS Uint64;
+
+            SELECT id, payload_str, payload_double, payload_timestamp, payload_hash
+            FROM `{table}`
+            WHERE id = $id AND hash = Digest::NumericHash($id);
+            "#,
+            table = self.table_path
+        );
+
+        let attempts_for_op = attempts.clone();
+        let mut qc = self.idempotent_client();
+        let row = tokio::time::timeout(self.read_timeout, async move {
+            attempts_for_op.fetch_add(1, Ordering::Relaxed);
+            qc.query_row(select_sql).param("$id", id).await
+        })
+        .await
+        .map_err(|_| "read timeout".to_string())?
+        .map_err(|err| err.to_string())?;
+
+        Ok((row_to_test_row(row)?, attempts.load(Ordering::Relaxed) as u64))
+    }
+
+    async fn write(&self, row: TestRow) -> Result<u64, String> {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let upsert_sql = format!(
+            r#"
+            DECLARE $id AS Uint64;
+            DECLARE $payload_str AS Utf8;
+            DECLARE $payload_double AS Double;
+            DECLARE $payload_timestamp AS Timestamp;
+
+            UPSERT INTO `{table}` (
+                id,
+                hash,
+                payload_str,
+                payload_double,
+                payload_timestamp
+            ) VALUES (
+                $id,
+                Digest::NumericHash($id),
+                $payload_str,
+                $payload_double,
+                $payload_timestamp
+            );
+            "#,
+            table = self.table_path,
+        );
+
+        let attempts_for_op = attempts.clone();
+        let mut qc = self.idempotent_client();
+        tokio::time::timeout(self.write_timeout, async move {
+            attempts_for_op.fetch_add(1, Ordering::Relaxed);
+            qc.exec(upsert_sql)
+                .param("$id", row.id)
+                .param("$payload_str", row.payload_str)
+                .param("$payload_double", row.payload_double)
+                .param("$payload_timestamp", row.payload_timestamp)
+                .await
+        })
+        .await
+        .map_err(|_| "write timeout".to_string())?
+        .map_err(|err| err.to_string())?;
+
+        Ok(attempts.load(Ordering::Relaxed) as u64)
+    }
+
+    async fn close(&self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+fn row_to_test_row(mut row: ydb::Row) -> Result<TestRow, String> {
+    let id: u64 = row
+        .remove_field_by_name("id")
+        .map_err(|err: ydb::YdbError| err.to_string())?
+        .try_into()
+        .map_err(|err: ydb::YdbError| err.to_string())?;
+    let payload_str: String = row
+        .remove_field_by_name("payload_str")
+        .map_err(|err: ydb::YdbError| err.to_string())?
+        .try_into()
+        .map_err(|err: ydb::YdbError| err.to_string())?;
+    let payload_double: f64 = row
+        .remove_field_by_name("payload_double")
+        .map_err(|err: ydb::YdbError| err.to_string())?
+        .try_into()
+        .map_err(|err: ydb::YdbError| err.to_string())?;
+    let payload_timestamp: std::time::SystemTime = row
+        .remove_field_by_name("payload_timestamp")
+        .map_err(|err: ydb::YdbError| err.to_string())?
+        .try_into()
+        .map_err(|err: ydb::YdbError| err.to_string())?;
+
+    Ok(TestRow::new(
+        id,
+        payload_str,
+        payload_double,
+        payload_timestamp,
+    ))
+}
+
+pub async fn new_workload(fw: Framework) -> Result<Box<dyn Workload>, String> {
+    let params = slo_framework::kv::parse_params(&fw);
+    let storage = Storage::new(&fw, &params).await?;
+    Ok(Box::new(KvWorkload::new(fw, params, storage)))
+}


### PR DESCRIPTION
## Summary
- Add `slo-native-query` workload package mirroring the existing table KV SLO (`tests/slo/native/table`) but using `QueryClient` (`exec` / `query_row` with idempotent retries).
- Wire the workload into SLO CI (`native-query` matrix entry), Docker image build script, and README.
- Exclude `slo-native-query` from llvm-cov workspace run (same as table workload).

Closes #453.

## Test plan
- [x] `cargo build --release -p slo-native-query`
- [ ] Run SLO locally against a YDB instance with `WORKLOAD_NAME=native-query`
- [ ] Verify `slo.yml` matrix builds the `native-query` image


Made with [Cursor](https://cursor.com)