### PR TITLE
Fix SLO workloads: OTLP HTTP client and ratelimiter

### DIFF
--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -130,6 +130,12 @@ jobs:
             --tag "ydb-app-current" \
             --src-path "${{ matrix.sdk.path }}"
 
+          # slo-framework is shared by all workloads; keep it in sync with current
+          # so baseline images pick up framework fixes (e.g. OTLP client features).
+          rm -rf "$GITHUB_WORKSPACE/baseline/tests/slo/slo-framework"
+          cp -r "$GITHUB_WORKSPACE/current/tests/slo/slo-framework" \
+            "$GITHUB_WORKSPACE/baseline/tests/slo/slo-framework"
+
           bash "$SCRIPT" \
             --context "$GITHUB_WORKSPACE/baseline" \
             --tag "ydb-app-baseline" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,28 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,45 +121,18 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.2",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core 0.5.5",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -189,26 +140,6 @@ dependencies = [
  "serde_core",
  "sync_wrapper 1.0.2",
  "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -748,7 +679,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.4",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -767,18 +698,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.4",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1148,22 +1073,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1285,12 +1200,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -1582,9 +1491,6 @@ dependencies = [
  "prost 0.13.5",
  "reqwest 0.12.28",
  "thiserror 1.0.69",
- "tokio",
- "tonic 0.12.3",
- "tracing",
 ]
 
 [[package]]
@@ -1709,7 +1615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.4",
+ "indexmap",
 ]
 
 [[package]]
@@ -2858,7 +2764,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -2869,25 +2775,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
- "hyper-timeout",
- "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
  "tokio-stream",
- "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2900,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
- "axum 0.8.6",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.12",
@@ -2970,15 +2867,6 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2992,7 +2880,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.11.4",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper 1.0.2",

--- a/tests/slo/slo-framework/Cargo.toml
+++ b/tests/slo/slo-framework/Cargo.toml
@@ -11,11 +11,7 @@ base64 = "0.22.1"
 clap = { version = "=4.2.7", features = ["derive"] }
 hdrhistogram = "7.5.4"
 opentelemetry = "0.27"
-opentelemetry-otlp = {
-    version = "0.27",
-    default-features = false,
-    features = ["http-proto", "metrics", "reqwest-client", "reqwest-rustls"],
-}
+opentelemetry-otlp = { version = "0.27", default-features = false, features = ["http-proto", "metrics", "reqwest-client", "reqwest-rustls"] }
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.27"
 rand = "0.8.5"

--- a/tests/slo/slo-framework/Cargo.toml
+++ b/tests/slo/slo-framework/Cargo.toml
@@ -11,7 +11,11 @@ base64 = "0.22.1"
 clap = { version = "=4.2.7", features = ["derive"] }
 hdrhistogram = "7.5.4"
 opentelemetry = "0.27"
-opentelemetry-otlp = { version = "0.27", features = ["http-proto", "reqwest-rustls"] }
+opentelemetry-otlp = {
+    version = "0.27",
+    default-features = false,
+    features = ["http-proto", "metrics", "reqwest-client", "reqwest-rustls"],
+}
 opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.27"
 rand = "0.8.5"

--- a/tests/slo/slo-framework/src/helpers.rs
+++ b/tests/slo/slo-framework/src/helpers.rs
@@ -6,7 +6,9 @@ use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
 pub fn new_rate_limiter(rps: u32) -> Ratelimiter {
-    Ratelimiter::builder(rps as u64, Duration::from_secs(1))
+    let rps = rps.max(1) as u64;
+    Ratelimiter::builder(rps, Duration::from_secs(1))
+        .max_tokens(rps)
         .build()
         .expect("valid ratelimiter")
 }
@@ -39,5 +41,16 @@ pub async fn run_workers<F, Fut>(
 
     for handle in handles {
         let _ = handle.await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limiter_supports_default_slo_rps() {
+        new_rate_limiter(1000);
+        new_rate_limiter(100);
     }
 }

--- a/tests/slo/slo-framework/src/metrics.rs
+++ b/tests/slo/slo-framework/src/metrics.rs
@@ -311,3 +311,22 @@ fn attrs_from_key(key: &str) -> Vec<KeyValue> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn otlp_metric_exporter_has_http_client() {
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_endpoint("http://localhost:4318/v1/metrics")
+            .with_temporality(Temporality::Cumulative)
+            .build();
+        assert!(
+            exporter.is_ok(),
+            "OTLP metrics exporter must build with reqwest HTTP client features: {}",
+            exporter.err().map(|e| e.to_string()).unwrap_or_default()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fix OTLP metrics exporter `NoHttpClient` by enabling `reqwest-client` with `reqwest-rustls` on `opentelemetry-otlp` (rustls alone does not select an HTTP client in 0.27).
- Fix workload panic `MaxTokensTooLow` when `--read-rps` / `--write-rps` are above 1: set `max_tokens` to match the per-second refill rate.
- Copy `tests/slo/slo-framework` from current to baseline before building the baseline Docker image so both containers use the same framework code in CI comparisons.

## Root causes (from CI logs)
1. **Baseline:** `create metrics failed: ... no http client` — baseline image built from `master` without OTLP feature fix.
2. **Current:** `valid ratelimiter: MaxTokensTooLow` after successful setup — `ratelimit` crate defaults `max_tokens=1` while refill amount is RPS (e.g. 1000).

## Test plan
- [x] `cargo test -p slo-framework`
- [x] `cargo build --release -p slo-native-table`
- [ ] Re-run SLO workflow on this PR