### PR TITLE
Operation Service client (get/list/forget/cancel)

### DIFF
--- a/ydb/examples/operation-service-example.rs
+++ b/ydb/examples/operation-service-example.rs
@@ -1,0 +1,54 @@
+use std::time::Duration;
+
+use tokio::time::sleep;
+use ydb::{ClientBuilder, ListOperationsRequest, OperationKind, YdbError, YdbResult};
+
+#[tokio::main]
+async fn main() -> YdbResult<()> {
+    let connection_string = std::env::var("YDB_CONNECTION_STRING")
+        .unwrap_or_else(|_| "grpc://localhost:2136/local".to_string());
+
+    let client = ClientBuilder::new_from_connection_string(connection_string)?.client()?;
+
+    if let Ok(res) = tokio::time::timeout(Duration::from_secs(10), client.wait()).await {
+        res?
+    } else {
+        return Err(YdbError::from("connection timeout"));
+    }
+
+    let op_client = client.operation_client();
+
+    let listed = op_client
+        .list_operations(ListOperationsRequest::new(OperationKind::EXECUTE_QUERY))
+        .await?;
+
+    println!(
+        "script operations listed: {} (next_page_token len={})",
+        listed.operations.len(),
+        listed.next_page_token.len()
+    );
+
+    for op in &listed.operations {
+        println!(
+            "operation id={} ready={} status={}",
+            op.id, op.ready, op.status
+        );
+        if !op.ready {
+            op_client.cancel_operation(&op.id).await?;
+            println!("cancel requested for {}", op.id);
+
+            for _ in 0..30 {
+                let status = op_client.get_operation(&op.id).await?;
+                if status.ready {
+                    println!("operation {} finished with status {}", op.id, status.status);
+                    op_client.forget_operation(&op.id).await?;
+                    println!("operation {} forgotten", op.id);
+                    break;
+                }
+                sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/ydb/examples/operation-service-example.rs
+++ b/ydb/examples/operation-service-example.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use tokio::time::sleep;
-use ydb::{ClientBuilder, ListOperationsRequest, OperationKind, YdbError, YdbResult};
+use ydb::{ClientBuilder, ListOperationsRequest, OperationKind, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
@@ -9,12 +9,7 @@ async fn main() -> YdbResult<()> {
         .unwrap_or_else(|_| "grpc://localhost:2136/local".to_string());
 
     let client = ClientBuilder::new_from_connection_string(connection_string)?.client()?;
-
-    if let Ok(res) = tokio::time::timeout(Duration::from_secs(10), client.wait()).await {
-        res?
-    } else {
-        return Err(YdbError::from("connection timeout"));
-    }
+    client.wait().await?;
 
     let op_client = client.operation_client();
 
@@ -37,15 +32,23 @@ async fn main() -> YdbResult<()> {
             op_client.cancel_operation(&op.id).await?;
             println!("cancel requested for {}", op.id);
 
+            let mut finished = false;
             for _ in 0..30 {
                 let status = op_client.get_operation(&op.id).await?;
                 if status.ready {
                     println!("operation {} finished with status {}", op.id, status.status);
                     op_client.forget_operation(&op.id).await?;
                     println!("operation {} forgotten", op.id);
+                    finished = true;
                     break;
                 }
                 sleep(Duration::from_millis(500)).await;
+            }
+            if !finished {
+                eprintln!(
+                    "operation {} did not become ready within 15s; left on server (not forgotten)",
+                    op.id
+                );
             }
         }
     }

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -1,5 +1,6 @@
 use crate::client_common::DBCredentials;
 use crate::client_coordination::client::CoordinationClient;
+use crate::client_operation::OperationClient;
 use crate::client_scheme::client::SchemeClient;
 use crate::client_table::TableClient;
 use crate::discovery::Discovery;
@@ -68,6 +69,11 @@ impl Client {
         CoordinationClient::new(self.timeouts, self.connection_manager.clone())
     }
 
+    /// Create instance of client for operation service (list/get/forget long-running operations).
+    pub fn operation_client(&self) -> OperationClient {
+        OperationClient::new(self.timeouts, self.connection_manager.clone())
+    }
+
     pub fn with_timeouts(mut self, timeouts: TimeoutSettings) -> Self {
         self.timeouts = timeouts;
         self
@@ -86,6 +92,13 @@ impl Client {
         trace!("wait balancer");
         self.load_balancer.wait().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+impl Client {
+    pub(crate) fn connection_manager_for_test(&self) -> GrpcConnectionManager {
+        self.connection_manager.clone()
     }
 }
 

--- a/ydb/src/client_operation/client.rs
+++ b/ydb/src/client_operation/client.rs
@@ -1,0 +1,203 @@
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use rand::Rng;
+use tokio::time::sleep;
+
+use crate::client::TimeoutSettings;
+use crate::errors::{NeedRetry, YdbError, YdbResult};
+use crate::grpc_connection_manager::GrpcConnectionManager;
+use crate::grpc_wrapper::raw_operation_service::client::RawOperationClient;
+use crate::grpc_wrapper::raw_operation_service::types::{
+    RawListOperationsRequest, RawListOperationsResult, RawOperation,
+};
+
+use super::types::{ListOperationsRequest, ListOperationsResult, OperationInfo};
+
+const DEFAULT_RETRY_BUDGET: Duration = Duration::from_secs(5);
+const INITIAL_RETRY_BACKOFF_MILLISECONDS: u64 = 1;
+const MAX_RETRY_BACKOFF_MILLISECONDS: u64 = 1_000;
+
+#[derive(Clone)]
+pub struct OperationClient {
+    connection_manager: GrpcConnectionManager,
+    retry_budget: Duration,
+}
+
+impl OperationClient {
+    pub(crate) fn new(
+        _timeouts: TimeoutSettings,
+        connection_manager: GrpcConnectionManager,
+    ) -> Self {
+        Self {
+            connection_manager,
+            retry_budget: DEFAULT_RETRY_BUDGET,
+        }
+    }
+
+    /// Total wall-clock budget for automatic retries (aligned with [`crate::TableClient::clone_with_retry_timeout`]).
+    pub fn clone_with_retry_timeout(&self, timeout: Duration) -> Self {
+        Self {
+            retry_budget: timeout,
+            ..self.clone()
+        }
+    }
+
+    pub fn clone_with_no_retry(&self) -> Self {
+        Self {
+            retry_budget: Duration::ZERO,
+            ..self.clone()
+        }
+    }
+
+    pub async fn get_operation(&self, id: impl Into<String>) -> YdbResult<OperationInfo> {
+        let id = id.into();
+        self.retry(|| async {
+            let mut client = self.raw_client().await?;
+            let op = client.get_operation(&id).await.map_err(YdbError::from)?;
+            Ok(raw_to_operation_info(op))
+        })
+        .await
+    }
+
+    pub async fn list_operations(
+        &self,
+        request: ListOperationsRequest,
+    ) -> YdbResult<ListOperationsResult> {
+        let raw_req = RawListOperationsRequest {
+            kind: request.kind,
+            page_size: request.page_size,
+            page_token: request.page_token,
+        };
+        self.retry(|| async {
+            let mut client = self.raw_client().await?;
+            let result = client
+                .list_operations(raw_req.clone())
+                .await
+                .map_err(YdbError::from)?;
+            Ok(raw_to_list_result(result))
+        })
+        .await
+    }
+
+    pub async fn forget_operation(&self, id: impl Into<String>) -> YdbResult<()> {
+        let id = id.into();
+        self.retry(|| async {
+            let mut client = self.raw_client().await?;
+            client.forget_operation(&id).await.map_err(YdbError::from)?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn cancel_operation(&self, id: impl Into<String>) -> YdbResult<()> {
+        let id = id.into();
+        self.retry(|| async {
+            let mut client = self.raw_client().await?;
+            client.cancel_operation(&id).await.map_err(YdbError::from)?;
+            Ok(())
+        })
+        .await
+    }
+
+    async fn raw_client(&self) -> YdbResult<RawOperationClient> {
+        self.connection_manager
+            .get_auth_service(RawOperationClient::new)
+            .await
+    }
+
+    async fn retry<T, F, Fut>(&self, mut attempt_fn: F) -> YdbResult<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = YdbResult<T>>,
+    {
+        let start = Instant::now();
+        let mut attempt = 0usize;
+        loop {
+            attempt += 1;
+            match attempt_fn().await {
+                Ok(value) => return Ok(value),
+                Err(err) => {
+                    if !should_retry(&err) {
+                        return Err(err);
+                    }
+                    match retry_wait(attempt, start.elapsed(), self.retry_budget) {
+                        Some(wait) if wait > Duration::ZERO => sleep(wait).await,
+                        Some(_) => {}
+                        None => return Err(err),
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn should_retry(err: &YdbError) -> bool {
+    match err.need_retry() {
+        NeedRetry::True | NeedRetry::IdempotentOnly => true,
+        NeedRetry::False => false,
+    }
+}
+
+fn retry_wait(
+    attempt: usize,
+    time_from_start: Duration,
+    retry_budget: Duration,
+) -> Option<Duration> {
+    if time_from_start >= retry_budget {
+        return None;
+    }
+    let wait = if attempt > 0 {
+        let exp_shift = (attempt - 1).min(63) as u32;
+        let base_ms = INITIAL_RETRY_BACKOFF_MILLISECONDS
+            .saturating_mul(1u64 << exp_shift)
+            .min(MAX_RETRY_BACKOFF_MILLISECONDS);
+        let base = Duration::from_millis(base_ms);
+        let half = base / 2;
+        if half.is_zero() {
+            base
+        } else {
+            half + Duration::from_millis(rand::thread_rng().gen_range(0..=half.as_millis() as u64))
+        }
+    } else {
+        Duration::ZERO
+    };
+    if time_from_start + wait < retry_budget {
+        Some(wait)
+    } else {
+        None
+    }
+}
+
+fn raw_to_operation_info(raw: RawOperation) -> OperationInfo {
+    OperationInfo {
+        id: raw.id,
+        ready: raw.ready,
+        status: raw.status,
+        issues: raw.issues,
+        consumed_units: raw.consumed_units,
+    }
+}
+
+fn raw_to_list_result(raw: RawListOperationsResult) -> ListOperationsResult {
+    ListOperationsResult {
+        operations: raw
+            .operations
+            .into_iter()
+            .map(raw_to_operation_info)
+            .collect(),
+        next_page_token: raw.next_page_token,
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn retry_wait_bounded_by_budget() {
+        let budget = Duration::from_millis(100);
+        assert!(retry_wait(1, Duration::ZERO, budget).is_some());
+        assert!(retry_wait(10, budget, budget).is_none());
+    }
+}

--- a/ydb/src/client_operation/client.rs
+++ b/ydb/src/client_operation/client.rs
@@ -2,11 +2,13 @@ use std::future::Future;
 use std::time::{Duration, Instant};
 
 use rand::Rng;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
+use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
 use crate::client::TimeoutSettings;
 use crate::errors::{NeedRetry, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
+use crate::grpc_wrapper::raw_errors::RawError;
 use crate::grpc_wrapper::raw_operation_service::client::RawOperationClient;
 use crate::grpc_wrapper::raw_operation_service::types::{
     RawListOperationsRequest, RawListOperationsResult, RawOperation,
@@ -21,16 +23,18 @@ const MAX_RETRY_BACKOFF_MILLISECONDS: u64 = 1_000;
 #[derive(Clone)]
 pub struct OperationClient {
     connection_manager: GrpcConnectionManager,
+    operation_timeout: Duration,
     retry_budget: Duration,
 }
 
 impl OperationClient {
     pub(crate) fn new(
-        _timeouts: TimeoutSettings,
+        timeouts: TimeoutSettings,
         connection_manager: GrpcConnectionManager,
     ) -> Self {
         Self {
             connection_manager,
+            operation_timeout: timeouts.operation_timeout,
             retry_budget: DEFAULT_RETRY_BUDGET,
         }
     }
@@ -54,7 +58,10 @@ impl OperationClient {
         let id = id.into();
         self.retry(|| async {
             let mut client = self.raw_client().await?;
-            let op = client.get_operation(&id).await.map_err(YdbError::from)?;
+            let op = self
+                .with_rpc_timeout(|| client.get_operation(&id))
+                .await
+                .map_err(YdbError::from)?;
             Ok(raw_to_operation_info(op))
         })
         .await
@@ -71,8 +78,8 @@ impl OperationClient {
         };
         self.retry(|| async {
             let mut client = self.raw_client().await?;
-            let result = client
-                .list_operations(raw_req.clone())
+            let result = self
+                .with_rpc_timeout(|| client.list_operations(raw_req.clone()))
                 .await
                 .map_err(YdbError::from)?;
             Ok(raw_to_list_result(result))
@@ -80,12 +87,23 @@ impl OperationClient {
         .await
     }
 
+    /// Forgets a completed operation on the server.
+    ///
+    /// If the operation was already forgotten (e.g. a retry after a successful first attempt
+    /// that lost the response), `NOT_FOUND` is treated as success.
     pub async fn forget_operation(&self, id: impl Into<String>) -> YdbResult<()> {
         let id = id.into();
         self.retry(|| async {
             let mut client = self.raw_client().await?;
-            client.forget_operation(&id).await.map_err(YdbError::from)?;
-            Ok(())
+            match self.with_rpc_timeout(|| client.forget_operation(&id)).await {
+                Ok(()) => Ok(()),
+                Err(RawError::YdbStatus(status))
+                    if status.operation_status == StatusCode::NotFound as i32 =>
+                {
+                    Ok(())
+                }
+                Err(err) => Err(YdbError::from(err)),
+            }
         })
         .await
     }
@@ -94,7 +112,9 @@ impl OperationClient {
         let id = id.into();
         self.retry(|| async {
             let mut client = self.raw_client().await?;
-            client.cancel_operation(&id).await.map_err(YdbError::from)?;
+            self.with_rpc_timeout(|| client.cancel_operation(&id))
+                .await
+                .map_err(YdbError::from)?;
             Ok(())
         })
         .await
@@ -104,6 +124,20 @@ impl OperationClient {
         self.connection_manager
             .get_auth_service(RawOperationClient::new)
             .await
+    }
+
+    async fn with_rpc_timeout<T, F, Fut>(&self, operation: F) -> Result<T, RawError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T, RawError>>,
+    {
+        match timeout(self.operation_timeout, operation()).await {
+            Ok(result) => result,
+            Err(_) => Err(RawError::custom(format!(
+                "operation service rpc timed out after {:?}",
+                self.operation_timeout
+            ))),
+        }
     }
 
     async fn retry<T, F, Fut>(&self, mut attempt_fn: F) -> YdbResult<T>

--- a/ydb/src/client_operation/integration_test.rs
+++ b/ydb/src/client_operation/integration_test.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use tokio::time::sleep;
+use tracing_test::traced_test;
+use ydb_grpc::ydb_proto::status_ids::StatusCode;
+
+use crate::client_operation::script_test_support::start_execute_script_operation;
+use crate::client_operation::{ListOperationsRequest, OperationInfo, OperationKind};
+use crate::errors::YdbResult;
+use crate::test_integration_helper::create_client;
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn list_operations_execute_query_kind() -> YdbResult<()> {
+    let client = create_client().await?;
+    let op_client = client.operation_client();
+
+    let result = op_client
+        .list_operations(ListOperationsRequest::new(OperationKind::EXECUTE_QUERY))
+        .await?;
+
+    assert!(result.next_page_token.is_empty() || !result.next_page_token.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn get_operation_unknown_id_returns_non_success() -> YdbResult<()> {
+    let client = create_client().await?;
+    let op_client = client.operation_client();
+
+    let op = op_client.get_operation("nonexistent-operation-id").await?;
+    assert!(op.id.is_empty());
+    assert_ne!(op.status, StatusCode::Success as i32);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn cancel_get_forget_script_operation() -> YdbResult<()> {
+    let client = create_client().await?;
+    let connection_manager = client.connection_manager_for_test();
+    let op_client = client.operation_client();
+
+    let operation_id = start_execute_script_operation(&connection_manager)
+        .await
+        .map_err(crate::errors::YdbError::from)?;
+
+    let first = op_client.get_operation(&operation_id).await?;
+    if !first.ready {
+        op_client.cancel_operation(&operation_id).await?;
+    }
+
+    let mut last: Option<OperationInfo> = None;
+    for _ in 0..60 {
+        let op = op_client.get_operation(&operation_id).await?;
+        if op.ready {
+            last = Some(op);
+            break;
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+
+    let op = last.expect("operation did not become ready within timeout");
+    assert!(op.ready);
+
+    op_client.forget_operation(&operation_id).await?;
+
+    let listed = op_client
+        .list_operations(ListOperationsRequest::new(OperationKind::EXECUTE_QUERY))
+        .await?;
+    assert!(!listed.operations.iter().any(|item| item.id == operation_id));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn cancel_unknown_operation_id_errors() -> YdbResult<()> {
+    let client = create_client().await?;
+    let op_client = client.operation_client();
+
+    let err = op_client
+        .cancel_operation("nonexistent-operation-id")
+        .await
+        .unwrap_err();
+
+    match &err {
+        crate::errors::YdbError::YdbStatusError(status) => {
+            assert_ne!(status.operation_status, StatusCode::Success as i32);
+        }
+        other => panic!("expected YdbStatusError, got {:?}", other),
+    }
+
+    Ok(())
+}

--- a/ydb/src/client_operation/integration_test.rs
+++ b/ydb/src/client_operation/integration_test.rs
@@ -16,11 +16,10 @@ async fn list_operations_execute_query_kind() -> YdbResult<()> {
     let client = create_client().await?;
     let op_client = client.operation_client();
 
-    let result = op_client
+    op_client
         .list_operations(ListOperationsRequest::new(OperationKind::EXECUTE_QUERY))
         .await?;
 
-    assert!(result.next_page_token.is_empty() || !result.next_page_token.is_empty());
     Ok(())
 }
 
@@ -33,7 +32,7 @@ async fn get_operation_unknown_id_returns_non_success() -> YdbResult<()> {
 
     let op = op_client.get_operation("nonexistent-operation-id").await?;
     assert!(op.id.is_empty());
-    assert_ne!(op.status, StatusCode::Success as i32);
+    assert!(!op.is_success());
 
     Ok(())
 }

--- a/ydb/src/client_operation/mod.rs
+++ b/ydb/src/client_operation/mod.rs
@@ -1,0 +1,10 @@
+mod client;
+mod types;
+
+#[cfg(test)]
+mod integration_test;
+#[cfg(test)]
+mod script_test_support;
+
+pub use client::OperationClient;
+pub use types::{ListOperationsRequest, ListOperationsResult, OperationInfo, OperationKind};

--- a/ydb/src/client_operation/script_test_support.rs
+++ b/ydb/src/client_operation/script_test_support.rs
@@ -64,7 +64,9 @@ pub(crate) async fn start_execute_script_operation(
 
     let operation = response.into_inner();
     if operation.id.is_empty() {
-        return Err(RawError::custom("execute script returned empty operation id"));
+        return Err(RawError::custom(
+            "execute script returned empty operation id",
+        ));
     }
 
     Ok(operation.id)

--- a/ydb/src/client_operation/script_test_support.rs
+++ b/ydb/src/client_operation/script_test_support.rs
@@ -1,0 +1,71 @@
+use crate::grpc_connection_manager::GrpcConnectionManager;
+use crate::grpc_wrapper::grpc_limits::WithGrpcMaxMessageSize;
+use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
+use crate::grpc_wrapper::raw_services::{GrpcServiceForDiscovery, Service};
+use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
+use ydb_grpc::ydb_proto::operations::operation_params::OperationMode;
+use ydb_grpc::ydb_proto::operations::OperationParams;
+use ydb_grpc::ydb_proto::query::v1::query_service_client::QueryServiceClient;
+use ydb_grpc::ydb_proto::query::{ExecMode, ExecuteScriptRequest, QueryContent, Syntax};
+
+struct RawQueryScriptClient {
+    service: QueryServiceClient<InterceptedChannel>,
+}
+
+impl WithGrpcMaxMessageSize for RawQueryScriptClient {
+    fn with_grpc_max_message_size(mut self, bytes: usize) -> Self {
+        self.service = self
+            .service
+            .max_decoding_message_size(bytes)
+            .max_encoding_message_size(bytes);
+        self
+    }
+}
+
+impl GrpcServiceForDiscovery for RawQueryScriptClient {
+    fn get_grpc_discovery_service() -> Service {
+        // Query service shares endpoints with table service in discovery.
+        Service::Table
+    }
+}
+
+/// Start a long-running ExecuteScript operation (for integration tests).
+pub(crate) async fn start_execute_script_operation(
+    connection_manager: &GrpcConnectionManager,
+) -> RawResult<String> {
+    let mut client = connection_manager
+        .get_auth_service(|ch| RawQueryScriptClient {
+            service: QueryServiceClient::new(ch),
+        })
+        .await
+        .map_err(|e| RawError::custom(e.to_string()))?;
+
+    let response = client
+        .service
+        .execute_script(ExecuteScriptRequest {
+            operation_params: Some(OperationParams {
+                operation_mode: OperationMode::Async as i32,
+                operation_timeout: None,
+                cancel_after: None,
+                labels: Default::default(),
+                report_cost_info: ydb_grpc::ydb_proto::feature_flag::Status::Unspecified.into(),
+            }),
+            exec_mode: ExecMode::Execute as i32,
+            script_content: Some(QueryContent {
+                syntax: Syntax::YqlV1 as i32,
+                text: "$items = ListFromRange(1, 50000000); SELECT ListSum($items);".to_string(),
+            }),
+            parameters: Default::default(),
+            stats_mode: 0,
+            results_ttl: None,
+            pool_id: String::new(),
+        })
+        .await?;
+
+    let operation = response.into_inner();
+    if operation.id.is_empty() {
+        return Err(RawError::custom("execute script returned empty operation id"));
+    }
+
+    Ok(operation.id)
+}

--- a/ydb/src/client_operation/types.rs
+++ b/ydb/src/client_operation/types.rs
@@ -1,0 +1,62 @@
+use crate::YdbIssue;
+
+/// Long-running operation snapshot returned by Operation Service.
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
+pub struct OperationInfo {
+    pub id: String,
+    pub ready: bool,
+    /// YDB status code (`Ydb.StatusIds.StatusCode` protobuf value).
+    pub status: i32,
+    pub issues: Vec<YdbIssue>,
+    /// Consumed units from `cost_info`, when reported by the server.
+    pub consumed_units: Option<f64>,
+}
+
+/// Filter and pagination parameters for [`OperationClient::list_operations`].
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
+pub struct ListOperationsRequest {
+    pub kind: String,
+    pub page_size: u64,
+    pub page_token: String,
+}
+
+impl ListOperationsRequest {
+    pub fn new(kind: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            page_size: 0,
+            page_token: String::new(),
+        }
+    }
+
+    pub fn with_page_size(mut self, page_size: u64) -> Self {
+        self.page_size = page_size;
+        self
+    }
+
+    pub fn with_page_token(mut self, page_token: impl Into<String>) -> Self {
+        self.page_token = page_token.into();
+        self
+    }
+}
+
+/// Page of operations from [`OperationClient::list_operations`].
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
+pub struct ListOperationsResult {
+    pub operations: Vec<OperationInfo>,
+    pub next_page_token: String,
+}
+
+/// Well-known `kind` values for [`ListOperationsRequest`].
+pub struct OperationKind;
+
+impl OperationKind {
+    pub const EXECUTE_QUERY: &'static str = "scriptexec";
+    pub const BUILD_INDEX: &'static str = "buildindex";
+    pub const IMPORT_FROM_S3: &'static str = "import/s3";
+    pub const EXPORT_TO_S3: &'static str = "export/s3";
+    pub const EXPORT_TO_YT: &'static str = "export/yt";
+}

--- a/ydb/src/client_operation/types.rs
+++ b/ydb/src/client_operation/types.rs
@@ -1,4 +1,5 @@
 use crate::YdbIssue;
+use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
 /// Long-running operation snapshot returned by Operation Service.
 #[derive(Debug, Clone)]
@@ -11,6 +12,16 @@ pub struct OperationInfo {
     pub issues: Vec<YdbIssue>,
     /// Consumed units from `cost_info`, when reported by the server.
     pub consumed_units: Option<f64>,
+}
+
+impl OperationInfo {
+    pub fn status_code(&self) -> Option<StatusCode> {
+        StatusCode::try_from(self.status).ok()
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.status_code() == Some(StatusCode::Success)
+    }
 }
 
 /// Filter and pagination parameters for [`OperationClient::list_operations`].

--- a/ydb/src/grpc_wrapper/mod.rs
+++ b/ydb/src/grpc_wrapper/mod.rs
@@ -28,5 +28,7 @@ pub(crate) mod raw_topic_service;
 #[allow(dead_code)]
 pub(crate) mod raw_coordination_service;
 
+pub(crate) mod raw_operation_service;
+
 pub(crate) mod raw_ydb_operation;
 pub(crate) mod runtime_interceptors;

--- a/ydb/src/grpc_wrapper/raw_operation_service/client.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/client.rs
@@ -47,7 +47,7 @@ impl RawOperationClient {
         let operation = inner
             .operation
             .ok_or_else(|| RawError::custom("get operation response has no operation field"))?;
-        RawOperation::try_from(operation)
+        Ok(RawOperation::from(operation))
     }
 
     pub async fn list_operations(
@@ -67,8 +67,8 @@ impl RawOperationClient {
         let operations = inner
             .operations
             .into_iter()
-            .map(RawOperation::try_from)
-            .collect::<RawResult<Vec<_>>>()?;
+            .map(RawOperation::from)
+            .collect();
         Ok(RawListOperationsResult {
             operations,
             next_page_token: inner.next_page_token,

--- a/ydb/src/grpc_wrapper/raw_operation_service/client.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/client.rs
@@ -1,0 +1,95 @@
+use crate::grpc_wrapper::grpc_limits::WithGrpcMaxMessageSize;
+use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
+use crate::grpc_wrapper::raw_operation_service::status::check_status;
+use crate::grpc_wrapper::raw_services::{GrpcServiceForDiscovery, Service};
+use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
+
+use super::types::{RawListOperationsRequest, RawListOperationsResult, RawOperation};
+
+use ydb_grpc::ydb_proto::operation::v1::operation_service_client::OperationServiceClient;
+use ydb_grpc::ydb_proto::operations::{
+    CancelOperationRequest, ForgetOperationRequest, GetOperationRequest, ListOperationsRequest,
+};
+
+pub(crate) struct RawOperationClient {
+    service: OperationServiceClient<InterceptedChannel>,
+}
+
+impl WithGrpcMaxMessageSize for RawOperationClient {
+    fn with_grpc_max_message_size(mut self, bytes: usize) -> Self {
+        self.service = self
+            .service
+            .max_decoding_message_size(bytes)
+            .max_encoding_message_size(bytes);
+        self
+    }
+}
+
+impl GrpcServiceForDiscovery for RawOperationClient {
+    fn get_grpc_discovery_service() -> Service {
+        Service::Operation
+    }
+}
+
+impl RawOperationClient {
+    pub fn new(service: InterceptedChannel) -> Self {
+        Self {
+            service: OperationServiceClient::new(service),
+        }
+    }
+
+    pub async fn get_operation(&mut self, id: &str) -> RawResult<RawOperation> {
+        let response = self
+            .service
+            .get_operation(GetOperationRequest { id: id.to_string() })
+            .await?;
+        let inner = response.into_inner();
+        let operation = inner
+            .operation
+            .ok_or_else(|| RawError::custom("get operation response has no operation field"))?;
+        RawOperation::try_from(operation)
+    }
+
+    pub async fn list_operations(
+        &mut self,
+        req: RawListOperationsRequest,
+    ) -> RawResult<RawListOperationsResult> {
+        let response = self
+            .service
+            .list_operations(ListOperationsRequest {
+                kind: req.kind,
+                page_size: req.page_size,
+                page_token: req.page_token,
+            })
+            .await?;
+        let inner = response.into_inner();
+        check_status(inner.status, &inner.issues)?;
+        let operations = inner
+            .operations
+            .into_iter()
+            .map(RawOperation::try_from)
+            .collect::<RawResult<Vec<_>>>()?;
+        Ok(RawListOperationsResult {
+            operations,
+            next_page_token: inner.next_page_token,
+        })
+    }
+
+    pub async fn forget_operation(&mut self, id: &str) -> RawResult<()> {
+        let response = self
+            .service
+            .forget_operation(ForgetOperationRequest { id: id.to_string() })
+            .await?;
+        let inner = response.into_inner();
+        check_status(inner.status, &inner.issues)
+    }
+
+    pub async fn cancel_operation(&mut self, id: &str) -> RawResult<()> {
+        let response = self
+            .service
+            .cancel_operation(CancelOperationRequest { id: id.to_string() })
+            .await?;
+        let inner = response.into_inner();
+        check_status(inner.status, &inner.issues)
+    }
+}

--- a/ydb/src/grpc_wrapper/raw_operation_service/mod.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod client;
+pub(crate) mod status;
+pub(crate) mod types;

--- a/ydb/src/grpc_wrapper/raw_operation_service/status.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/status.rs
@@ -1,0 +1,18 @@
+use crate::errors::YdbStatusError;
+use crate::grpc_wrapper::grpc::proto_issues_to_ydb_issues;
+use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
+use ydb_grpc::ydb_proto::issue::IssueMessage;
+use ydb_grpc::ydb_proto::status_ids::StatusCode;
+
+pub(crate) fn check_status(status: i32, issues: &[IssueMessage]) -> RawResult<()> {
+    let code = StatusCode::try_from(status)
+        .map_err(|e| RawError::custom(format!("unknown status code: {e}")))?;
+    if code != StatusCode::Success {
+        return Err(RawError::YdbStatus(YdbStatusError {
+            message: format!("operation service status: {code:?}"),
+            operation_status: status,
+            issues: proto_issues_to_ydb_issues(issues.to_vec()),
+        }));
+    }
+    Ok(())
+}

--- a/ydb/src/grpc_wrapper/raw_operation_service/types.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/types.rs
@@ -1,0 +1,40 @@
+use crate::grpc_wrapper::grpc::proto_issues_to_ydb_issues;
+use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
+use crate::YdbIssue;
+use ydb_grpc::ydb_proto::operations::Operation;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RawOperation {
+    pub id: String,
+    pub ready: bool,
+    pub status: i32,
+    pub issues: Vec<YdbIssue>,
+    pub consumed_units: Option<f64>,
+}
+
+impl TryFrom<Operation> for RawOperation {
+    type Error = RawError;
+
+    fn try_from(op: Operation) -> RawResult<Self> {
+        Ok(Self {
+            id: op.id,
+            ready: op.ready,
+            status: op.status,
+            issues: proto_issues_to_ydb_issues(op.issues),
+            consumed_units: op.cost_info.map(|c| c.consumed_units),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RawListOperationsRequest {
+    pub kind: String,
+    pub page_size: u64,
+    pub page_token: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RawListOperationsResult {
+    pub operations: Vec<RawOperation>,
+    pub next_page_token: String,
+}

--- a/ydb/src/grpc_wrapper/raw_operation_service/types.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/types.rs
@@ -1,5 +1,4 @@
 use crate::grpc_wrapper::grpc::proto_issues_to_ydb_issues;
-use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
 use crate::YdbIssue;
 use ydb_grpc::ydb_proto::operations::Operation;
 
@@ -12,17 +11,15 @@ pub(crate) struct RawOperation {
     pub consumed_units: Option<f64>,
 }
 
-impl TryFrom<Operation> for RawOperation {
-    type Error = RawError;
-
-    fn try_from(op: Operation) -> RawResult<Self> {
-        Ok(Self {
+impl From<Operation> for RawOperation {
+    fn from(op: Operation) -> Self {
+        Self {
             id: op.id,
             ready: op.ready,
             status: op.status,
             issues: proto_issues_to_ydb_issues(op.issues),
             consumed_units: op.cost_info.map(|c| c.consumed_units),
-        })
+        }
     }
 }
 

--- a/ydb/src/grpc_wrapper/raw_services.rs
+++ b/ydb/src/grpc_wrapper/raw_services.rs
@@ -38,6 +38,9 @@ pub(crate) enum Service {
     #[strum(serialize = "coordination_service")]
     Coordination,
 
+    #[strum(serialize = "operation_service")]
+    Operation,
+
     #[strum(serialize = "auth_service")]
     Auth,
 }

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -50,6 +50,7 @@ pub(crate) mod client_common;
 pub(crate) mod client_coordination;
 #[cfg(test)]
 mod client_directory_test_integration;
+pub(crate) mod client_operation;
 pub(crate) mod client_scheme;
 pub(crate) mod client_table;
 #[cfg(test)]
@@ -162,6 +163,10 @@ pub use table_service_types::{
 // full enum pub types
 pub use client_scheme::client::SchemeClient;
 pub use client_scheme::list_types::{SchemeEntry, SchemeEntryType, SchemePermissions};
+
+pub use client_operation::{
+    ListOperationsRequest, ListOperationsResult, OperationClient, OperationInfo, OperationKind,
+};
 
 // full enum pub types
 pub use discovery::{Discovery, DiscoveryState, StaticDiscovery};


### PR DESCRIPTION
## Summary
- Add `OperationClient` via `Client::operation_client()` with `get_operation`, `list_operations`, `cancel_operation`, and `forget_operation`.
- Unary calls are automatically retried as idempotent operations (default 5s budget; `clone_with_retry_timeout` / `clone_with_no_retry`).
- Integration tests and `operation-service-example`.

Closes #461, closes #462, closes #463, closes #466.

**Depends on:** OperationService gRPC stubs (#465, merged).

## API sketch
```rust
let op_client = client.operation_client();
let op = op_client.get_operation("operation-id").await?;
op_client.cancel_operation(&op.id).await?;
let page = op_client
    .list_operations(ListOperationsRequest::new(OperationKind::EXECUTE_QUERY))
    .await?;
op_client.forget_operation("operation-id").await?;
```

## Test plan
- [x] `cargo check -p ydb`
- [x] `cargo test -p ydb client_operation::client::unit_tests`
- [x] `cargo test -p ydb -- --ignored client_operation::integration_test` with `YDB_CONNECTION_STRING=grpc://localhost:2136/local`
- [x] `cargo run --example operation-service-example -p ydb`