### PR TITLE
Query Service client: supported ExecuteScript and FetchScriptResults (#327, #328)

### DIFF
--- a/ydb/examples/query-service-script.rs
+++ b/ydb/examples/query-service-script.rs
@@ -1,0 +1,69 @@
+//! Query Service script execution — start a long-running operation, poll until
+//! ready, then paginate results with `FetchScriptResults`.
+
+use std::time::Duration;
+
+use tokio::time::sleep;
+use ydb::{ClientBuilder, YdbResult};
+
+#[tokio::main]
+async fn main() -> YdbResult<()> {
+    let connection_string = std::env::var("YDB_CONNECTION_STRING")
+        .unwrap_or_else(|_| "grpc://localhost:2136?database=local".to_string());
+
+    let client = ClientBuilder::new_from_connection_string(connection_string)?.client()?;
+    client.wait().await?;
+
+    let mut qc = client.query_client().clone_with_idempotent_operations(true);
+    let op_client = client.operation_client();
+
+    qc.exec("CREATE TABLE IF NOT EXISTS script_example (id Uint64, msg Utf8, PRIMARY KEY(id))")
+        .await?;
+    qc.exec("DELETE FROM script_example").await?;
+    qc.exec("UPSERT INTO script_example (id, msg) VALUES (123, \"hello from script\");")
+        .await?;
+
+    let op = qc
+        .execute_script(
+            "DECLARE $id AS Uint64; \
+             SELECT id, msg FROM script_example WHERE id = $id;",
+        )
+        .param("$id", 123_u64)
+        .results_ttl(Duration::from_secs(3600))
+        .await?;
+
+    println!("script operation id={}", op.id);
+
+    loop {
+        let status = op_client.get_operation(&op.id).await?;
+        if status.ready {
+            println!("operation ready, status={}", status.status);
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    let mut next_token = String::new();
+    loop {
+        let page = qc
+            .fetch_script_results(&op.id)
+            .result_set_index(0)
+            .rows_limit(1000)
+            .fetch_token(&next_token)
+            .await?;
+        next_token = page.next_fetch_token.clone();
+
+        for mut row in page.result_set {
+            let id: u64 = row.remove_field_by_name("id")?.try_into()?;
+            let msg: String = row.remove_field_by_name("msg")?.try_into()?;
+            println!("id={id}, msg={msg:?}");
+        }
+
+        if next_token.is_empty() {
+            break;
+        }
+    }
+
+    op_client.forget_operation(&op.id).await?;
+    Ok(())
+}

--- a/ydb/examples/query-service-script.rs
+++ b/ydb/examples/query-service-script.rs
@@ -54,9 +54,9 @@ async fn main() -> YdbResult<()> {
         next_token = page.next_fetch_token.clone();
 
         for mut row in page.result_set {
-            let id: u64 = row.remove_field_by_name("id")?.try_into()?;
-            let msg: String = row.remove_field_by_name("msg")?.try_into()?;
-            println!("id={id}, msg={msg:?}");
+            let id: Option<u64> = row.remove_field_by_name("id")?.try_into()?;
+            let msg: Option<String> = row.remove_field_by_name("msg")?.try_into()?;
+            println!("id={}, msg={msg:?}", id.unwrap_or(0));
         }
 
         if next_token.is_empty() {

--- a/ydb/examples/query-service-script.rs
+++ b/ydb/examples/query-service-script.rs
@@ -1,10 +1,10 @@
 //! Query Service script execution — start a long-running operation, poll until
 //! ready, then paginate results with `FetchScriptResults`.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::time::sleep;
-use ydb::{ClientBuilder, YdbResult};
+use ydb::{ClientBuilder, YdbError, YdbResult};
 
 #[tokio::main]
 async fn main() -> YdbResult<()> {
@@ -34,7 +34,13 @@ async fn main() -> YdbResult<()> {
 
     println!("script operation id={}", op.id);
 
+    let poll_deadline = Instant::now() + Duration::from_secs(120);
     loop {
+        if Instant::now() >= poll_deadline {
+            return Err(YdbError::Custom(
+                "script operation polling timed out after 120s".into(),
+            ));
+        }
         let status = op_client.get_operation(&op.id).await?;
         if status.ready {
             println!("operation ready, status={}", status.status);
@@ -51,7 +57,7 @@ async fn main() -> YdbResult<()> {
             .rows_limit(1000)
             .fetch_token(&next_token)
             .await?;
-        next_token = page.next_fetch_token.clone();
+        next_token = page.next_fetch_token;
 
         for mut row in page.result_set {
             let id: Option<u64> = row.remove_field_by_name("id")?.try_into()?;

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -120,6 +120,10 @@ impl TimeoutSettings {
     pub(crate) fn operation_params(&self) -> RawOperationParams {
         RawOperationParams::new_with_timeouts(self.operation_timeout, self.operation_timeout)
     }
+
+    pub(crate) fn execute_script_operation_params(&self) -> RawOperationParams {
+        RawOperationParams::for_execute_script(self.operation_timeout, self.operation_timeout)
+    }
 }
 
 impl Default for TimeoutSettings {

--- a/ydb/src/client_operation/script_test_support.rs
+++ b/ydb/src/client_operation/script_test_support.rs
@@ -19,19 +19,13 @@ pub(crate) async fn start_execute_script_operation(
         yql_text: "$items = ListFromRange(1, 50000000); SELECT ListSum($items);".to_string(),
         parameters: Default::default(),
         results_ttl: Duration::from_secs(3600),
-        operation_params: RawOperationParams::new_async(
+        operation_params: RawOperationParams::for_execute_script(
             Duration::from_secs(3600),
             Duration::from_secs(3600),
         ),
         collect_stats: false,
     };
 
-    let operation = client.execute_script(req).await?;
-    if operation.id.is_empty() {
-        return Err(RawError::custom(
-            "execute script returned empty operation id",
-        ));
-    }
-
-    Ok(operation.id)
+    let (operation_id, _) = client.execute_script(req).await?;
+    Ok(operation_id)
 }

--- a/ydb/src/client_operation/script_test_support.rs
+++ b/ydb/src/client_operation/script_test_support.rs
@@ -1,68 +1,32 @@
+use std::time::Duration;
+
 use crate::grpc_connection_manager::GrpcConnectionManager;
-use crate::grpc_wrapper::grpc_limits::WithGrpcMaxMessageSize;
 use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
-use crate::grpc_wrapper::raw_services::{GrpcServiceForDiscovery, Service};
-use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
-use ydb_grpc::ydb_proto::operations::operation_params::OperationMode;
-use ydb_grpc::ydb_proto::operations::OperationParams;
-use ydb_grpc::ydb_proto::query::v1::query_service_client::QueryServiceClient;
-use ydb_grpc::ydb_proto::query::{ExecMode, ExecuteScriptRequest, QueryContent, Syntax};
-
-struct RawQueryScriptClient {
-    service: QueryServiceClient<InterceptedChannel>,
-}
-
-impl WithGrpcMaxMessageSize for RawQueryScriptClient {
-    fn with_grpc_max_message_size(mut self, bytes: usize) -> Self {
-        self.service = self
-            .service
-            .max_decoding_message_size(bytes)
-            .max_encoding_message_size(bytes);
-        self
-    }
-}
-
-impl GrpcServiceForDiscovery for RawQueryScriptClient {
-    fn get_grpc_discovery_service() -> Service {
-        // Query service shares endpoints with table service in discovery.
-        Service::Table
-    }
-}
+use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
+use crate::grpc_wrapper::raw_query_service::execute_script::RawExecuteScriptRequest;
+use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
 
 /// Start a long-running ExecuteScript operation (for integration tests).
 pub(crate) async fn start_execute_script_operation(
     connection_manager: &GrpcConnectionManager,
 ) -> RawResult<String> {
     let mut client = connection_manager
-        .get_auth_service(|ch| RawQueryScriptClient {
-            service: QueryServiceClient::new(ch),
-        })
+        .get_auth_service(RawQueryClient::new)
         .await
         .map_err(|e| RawError::custom(e.to_string()))?;
 
-    let response = client
-        .service
-        .execute_script(ExecuteScriptRequest {
-            operation_params: Some(OperationParams {
-                operation_mode: OperationMode::Async as i32,
-                operation_timeout: None,
-                cancel_after: None,
-                labels: Default::default(),
-                report_cost_info: ydb_grpc::ydb_proto::feature_flag::Status::Unspecified.into(),
-            }),
-            exec_mode: ExecMode::Execute as i32,
-            script_content: Some(QueryContent {
-                syntax: Syntax::YqlV1 as i32,
-                text: "$items = ListFromRange(1, 50000000); SELECT ListSum($items);".to_string(),
-            }),
-            parameters: Default::default(),
-            stats_mode: 0,
-            results_ttl: None,
-            pool_id: String::new(),
-        })
-        .await?;
+    let req = RawExecuteScriptRequest {
+        yql_text: "$items = ListFromRange(1, 50000000); SELECT ListSum($items);".to_string(),
+        parameters: Default::default(),
+        results_ttl: Duration::from_secs(3600),
+        operation_params: RawOperationParams::new_async(
+            Duration::from_secs(3600),
+            Duration::from_secs(3600),
+        ),
+        collect_stats: false,
+    };
 
-    let operation = response.into_inner();
+    let operation = client.execute_script(req).await?;
     if operation.id.is_empty() {
         return Err(RawError::custom(
             "execute script returned empty operation id",

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -75,6 +75,18 @@ async fn query_client(ctx: &ClientExecContext) -> YdbResult<RawQueryClient> {
         .await
 }
 
+pub(crate) async fn run_idempotent<T, F, Fut>(
+    ctx: &ClientExecContext,
+    idempotent: bool,
+    attempt_fn: F,
+) -> YdbResult<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = YdbResult<T>>,
+{
+    retry_with_budget(idempotent, ctx.retry_budget, attempt_fn).await
+}
+
 async fn query_client_from_tx(tx: &TransactionExecContext) -> YdbResult<RawQueryClient> {
     if let Some(uri) = &tx.query_node {
         tx.connection_manager

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -57,7 +57,14 @@ fn operation_timeout(opts: &CallOptions, defaults: &TimeoutSettings) -> Duration
     opts.timeout.unwrap_or(defaults.operation_timeout)
 }
 
-async fn with_operation_timeout<T, F>(timeout_duration: Duration, operation: F) -> YdbResult<T>
+pub(crate) fn call_operation_timeout(opts: &CallOptions, defaults: &TimeoutSettings) -> Duration {
+    operation_timeout(opts, defaults)
+}
+
+pub(crate) async fn with_operation_timeout<T, F>(
+    timeout_duration: Duration,
+    operation: F,
+) -> YdbResult<T>
 where
     F: Future<Output = YdbResult<T>>,
 {
@@ -75,7 +82,7 @@ async fn query_client(ctx: &ClientExecContext) -> YdbResult<RawQueryClient> {
         .await
 }
 
-pub(crate) async fn run_idempotent<T, F, Fut>(
+pub(crate) async fn run_with_retry<T, F, Fut>(
     ctx: &ClientExecContext,
     idempotent: bool,
     attempt_fn: F,

--- a/ydb/src/client_query/integration_test.rs
+++ b/ydb/src/client_query/integration_test.rs
@@ -185,20 +185,16 @@ async fn query_execute_script() -> YdbResult<()> {
     assert_eq!(upserted, UPSERT_ROWS_COUNT as u32);
 
     let mut row = qc
-        .query_row(format!(
-            "SELECT CAST(COUNT(*) AS Uint64) AS cnt FROM {table_name};"
-        ))
+        .query_row(format!("SELECT COUNT(*) AS cnt FROM {table_name}"))
         .await?;
     let rows_from_db: u64 = row.remove_field_by_name("cnt")?.try_into()?;
     assert_eq!(rows_from_db, UPSERT_ROWS_COUNT as u64);
 
     let mut row = qc
-        .query_row(format!(
-            "SELECT CAST(SUM(val) AS Uint64) AS s FROM {table_name};"
-        ))
+        .query_row(format!("SELECT SUM(val) AS s FROM {table_name}"))
         .await?;
-    let checksum_from_db: u64 = row.remove_field_by_name("s")?.try_into()?;
-    assert_eq!(checksum_from_db, EXPECTED_CHECKSUM);
+    let checksum_from_db: i64 = row.remove_field_by_name("s")?.try_into()?;
+    assert_eq!(checksum_from_db as u64, EXPECTED_CHECKSUM);
 
     let op = qc
         .execute_script(format!("SELECT val FROM {table_name};"))

--- a/ydb/src/client_query/integration_test.rs
+++ b/ydb/src/client_query/integration_test.rs
@@ -187,14 +187,14 @@ async fn query_execute_script() -> YdbResult<()> {
     let mut row = qc
         .query_row(format!("SELECT COUNT(*) AS cnt FROM {table_name}"))
         .await?;
-    let rows_from_db: u64 = row.remove_field_by_name("cnt")?.try_into()?;
-    assert_eq!(rows_from_db, UPSERT_ROWS_COUNT as u64);
+    let rows_from_db: Option<u64> = row.remove_field_by_name("cnt")?.try_into()?;
+    assert_eq!(rows_from_db.unwrap_or(0), UPSERT_ROWS_COUNT as u64);
 
     let mut row = qc
         .query_row(format!("SELECT SUM(val) AS s FROM {table_name}"))
         .await?;
-    let checksum_from_db: i64 = row.remove_field_by_name("s")?.try_into()?;
-    assert_eq!(checksum_from_db as u64, EXPECTED_CHECKSUM);
+    let checksum_from_db: Option<i64> = row.remove_field_by_name("s")?.try_into()?;
+    assert_eq!(checksum_from_db.unwrap_or(0) as u64, EXPECTED_CHECKSUM);
 
     let op = qc
         .execute_script(format!("SELECT val FROM {table_name};"))
@@ -225,8 +225,8 @@ async fn query_execute_script() -> YdbResult<()> {
 
         for mut row in page.result_set {
             rows_count += 1;
-            let val: i64 = row.remove_field_by_name("val")?.try_into()?;
-            checksum += val as u64;
+            let val: Option<i64> = row.remove_field_by_name("val")?.try_into()?;
+            checksum += val.unwrap_or(0) as u64;
         }
 
         if next_token.is_empty() {

--- a/ydb/src/client_query/integration_test.rs
+++ b/ydb/src/client_query/integration_test.rs
@@ -1,7 +1,10 @@
 use super::{QuerySessionMode, QueryTransactionOptions, QueryTxMode};
 use crate::errors::YdbResult;
 use crate::test_integration_helper::create_client;
-use std::time::{SystemTime, UNIX_EPOCH};
+use crate::types::Value;
+use crate::ydb_struct;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::time::sleep;
 use tracing_test::traced_test;
 
 fn unique_table_name(prefix: &str) -> String {
@@ -140,5 +143,105 @@ async fn query_client_snapshot_read_only_tx() -> YdbResult<()> {
         .await?;
 
     assert_eq!(value, 42);
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn query_execute_script() -> YdbResult<()> {
+    let client = create_client().await?;
+    let mut qc = client.query_client().clone_with_idempotent_operations(true);
+    let op_client = client.operation_client();
+    let table_name = unique_table_name("query_execute_script");
+
+    const UPSERT_ROWS_COUNT: i32 = 100_000;
+    const BATCH_SIZE: i32 = 10_000;
+    const EXPECTED_CHECKSUM: u64 = 4_999_950_000;
+
+    assert_eq!(UPSERT_ROWS_COUNT % BATCH_SIZE, 0);
+
+    let _ = qc.exec(format!("DROP TABLE IF EXISTS {table_name}")).await;
+    qc.exec(format!(
+        "CREATE TABLE {table_name} (val Int64, PRIMARY KEY (val))"
+    ))
+    .await?;
+
+    let upsert_query = format!(
+        "DECLARE $values AS List<Struct<val: Int32>>; \
+         UPSERT INTO {table_name} SELECT val FROM AS_TABLE($values);"
+    );
+
+    let mut upserted = 0_u32;
+    for batch in 0..(UPSERT_ROWS_COUNT / BATCH_SIZE) {
+        let from = batch * BATCH_SIZE;
+        let to = from + BATCH_SIZE;
+        let example = ydb_struct!("val" => 0_i32);
+        let values: Vec<Value> = (from..to).map(|j| ydb_struct!("val" => j)).collect();
+        let list = Value::list_from(example, values)?;
+        qc.exec(&upsert_query).param("$values", list).await?;
+        upserted += (to - from) as u32;
+    }
+    assert_eq!(upserted, UPSERT_ROWS_COUNT as u32);
+
+    let mut row = qc
+        .query_row(format!(
+            "SELECT CAST(COUNT(*) AS Uint64) AS cnt FROM {table_name};"
+        ))
+        .await?;
+    let rows_from_db: u64 = row.remove_field_by_name("cnt")?.try_into()?;
+    assert_eq!(rows_from_db, UPSERT_ROWS_COUNT as u64);
+
+    let mut row = qc
+        .query_row(format!(
+            "SELECT CAST(SUM(val) AS Uint64) AS s FROM {table_name};"
+        ))
+        .await?;
+    let checksum_from_db: u64 = row.remove_field_by_name("s")?.try_into()?;
+    assert_eq!(checksum_from_db, EXPECTED_CHECKSUM);
+
+    let op = qc
+        .execute_script(format!("SELECT val FROM {table_name};"))
+        .results_ttl(Duration::from_secs(3600))
+        .await?;
+
+    loop {
+        let status = op_client.get_operation(&op.id).await?;
+        if status.ready {
+            break;
+        }
+        sleep(Duration::from_secs(1)).await;
+    }
+
+    let mut next_token = String::new();
+    let mut rows_count = 0_usize;
+    let mut checksum = 0_u64;
+
+    loop {
+        let page = qc
+            .fetch_script_results(&op.id)
+            .result_set_index(0)
+            .rows_limit(1000)
+            .fetch_token(&next_token)
+            .await?;
+        next_token = page.next_fetch_token;
+        assert_eq!(page.result_set_index, 0);
+
+        for mut row in page.result_set {
+            rows_count += 1;
+            let val: i64 = row.remove_field_by_name("val")?.try_into()?;
+            checksum += val as u64;
+        }
+
+        if next_token.is_empty() {
+            break;
+        }
+    }
+
+    assert_eq!(rows_count, UPSERT_ROWS_COUNT as usize);
+    assert_eq!(checksum, EXPECTED_CHECKSUM);
+
+    op_client.forget_operation(&op.id).await?;
+    qc.exec(format!("DROP TABLE {table_name}")).await?;
     Ok(())
 }

--- a/ydb/src/client_query/integration_test.rs
+++ b/ydb/src/client_query/integration_test.rs
@@ -3,7 +3,7 @@ use crate::errors::YdbResult;
 use crate::test_integration_helper::create_client;
 use crate::types::Value;
 use crate::ydb_struct;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
 use tracing_test::traced_test;
 
@@ -201,7 +201,12 @@ async fn query_execute_script() -> YdbResult<()> {
         .results_ttl(Duration::from_secs(3600))
         .await?;
 
+    let poll_deadline = Instant::now() + Duration::from_secs(120);
     loop {
+        assert!(
+            Instant::now() < poll_deadline,
+            "script operation did not become ready within 120s"
+        );
         let status = op_client.get_operation(&op.id).await?;
         if status.ready {
             break;

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -168,13 +168,13 @@ impl QueryClient {
     /// Start a long-running script operation. Poll completion via
     /// [`crate::OperationClient::get_operation`], then read rows with
     /// [`Self::fetch_script_results`].
-    pub fn execute_script(&mut self, text: impl Into<String>) -> script::ExecuteScriptBuilder<'_> {
+    pub fn execute_script(&self, text: impl Into<String>) -> script::ExecuteScriptBuilder<'_> {
         script::ExecuteScriptBuilder::new(&self.ctx, text.into())
     }
 
     /// Fetch a page of script results for a completed operation.
     pub fn fetch_script_results(
-        &mut self,
+        &self,
         operation_id: impl Into<String>,
     ) -> script::FetchScriptResultsBuilder<'_> {
         script::FetchScriptResultsBuilder::new(&self.ctx, operation_id.into())

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -5,6 +5,7 @@
 mod builders;
 mod exec;
 mod internal;
+mod script;
 mod stream_facade;
 
 #[cfg(test)]
@@ -164,6 +165,21 @@ impl QueryClient {
         }
     }
 
+    /// Start a long-running script operation. Poll completion via
+    /// [`crate::OperationClient::get_operation`], then read rows with
+    /// [`Self::fetch_script_results`].
+    pub fn execute_script(&mut self, text: impl Into<String>) -> script::ExecuteScriptBuilder<'_> {
+        script::ExecuteScriptBuilder::new(&self.ctx, text.into())
+    }
+
+    /// Fetch a page of script results for a completed operation.
+    pub fn fetch_script_results(
+        &mut self,
+        operation_id: impl Into<String>,
+    ) -> script::FetchScriptResultsBuilder<'_> {
+        script::FetchScriptResultsBuilder::new(&self.ctx, operation_id.into())
+    }
+
     pub async fn retry_transaction<T>(
         &self,
         mut callback: impl AsyncFnMut(&mut QueryTransaction) -> YdbResultWithCustomerErr<T>,
@@ -293,6 +309,8 @@ pub use builders::{
     CallBuilder, ExecBuilder, ExecCall, OneResultSet, OneRow, OptionalRow, OptionalRowBuilder,
     QueryExecutor, QueryRowBuilder, QueryStreamBuilder, ResultSetBuilder, Streamed,
 };
+pub use script::{ExecuteScriptBuilder, FetchScriptResultsBuilder};
+pub use script::{ExecuteScriptOperation, FetchScriptResult};
 pub use stream_facade::{QueryStats, QueryStream};
 
 fn panic_message(payload: Box<dyn Any + Send>) -> String {

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -182,11 +182,11 @@ async fn client_execute_script_once(
         yql_text: text.to_string(),
         parameters: params.clone(),
         results_ttl,
-        operation_params: ctx.timeouts.operation_params(),
+        operation_params: ctx.timeouts.execute_script_operation_params(),
         collect_stats: opts.collect_stats,
     };
     let timeout_duration = opts.timeout.unwrap_or(ctx.timeouts.operation_timeout);
-    let operation = tokio::time::timeout(timeout_duration, async {
+    let (id, consumed_units) = tokio::time::timeout(timeout_duration, async {
         let mut client = ctx
             .connection_manager
             .get_auth_service(RawQueryClient::new)
@@ -198,15 +198,7 @@ async fn client_execute_script_once(
         YdbError::Transport(format!("operation timed out after {timeout_duration:?}"))
     })??;
 
-    if operation.id.is_empty() {
-        return Err(YdbError::Custom(
-            "execute script returned empty operation id".into(),
-        ));
-    }
-    Ok(ExecuteScriptOperation {
-        id: operation.id,
-        consumed_units: operation.cost_info.map(|info| info.consumed_units),
-    })
+    Ok(ExecuteScriptOperation { id, consumed_units })
 }
 
 async fn client_fetch_script_results(

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -10,7 +10,9 @@ use crate::grpc_wrapper::raw_query_service::fetch_script_results::RawFetchScript
 use crate::result::ResultSet;
 use crate::types::Value;
 
-use super::exec::{run_idempotent, CallOptions, ClientExecContext};
+use super::exec::{
+    call_operation_timeout, run_with_retry, with_operation_timeout, CallOptions, ClientExecContext,
+};
 
 type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
@@ -178,18 +180,26 @@ async fn client_execute_script_once(
         operation_params: ctx.timeouts.execute_script_operation_params(),
         collect_stats: opts.collect_stats,
     };
-    let timeout_duration = opts.timeout.unwrap_or(ctx.timeouts.operation_timeout);
-    let (id, consumed_units) = tokio::time::timeout(timeout_duration, async {
-        let mut client = ctx
-            .connection_manager
-            .get_auth_service(RawQueryClient::new)
-            .await?;
+    let timeout_duration = call_operation_timeout(opts, &ctx.timeouts);
+    let mut client = ctx
+        .connection_manager
+        .get_auth_service(RawQueryClient::new)
+        .await?;
+    let (id, consumed_units) = match with_operation_timeout(timeout_duration, async {
         client.execute_script(req).await.map_err(YdbError::from)
     })
     .await
-    .map_err(|_| {
-        YdbError::Transport(format!("operation timed out after {timeout_duration:?}"))
-    })??;
+    {
+        Ok(value) => value,
+        Err(err) => {
+            tracing::warn!(
+                ?timeout_duration,
+                "execute_script timed out waiting for RPC response; \
+                 a server-side operation may still be running until cancel_after"
+            );
+            return Err(err);
+        }
+    };
 
     Ok(ExecuteScriptOperation { id, consumed_units })
 }
@@ -203,7 +213,7 @@ async fn client_fetch_script_results(
     opts: CallOptions,
 ) -> YdbResult<FetchScriptResult> {
     // FetchScriptResults is always safe to retry (aligned with Go SDK).
-    run_idempotent(ctx, true, || {
+    run_with_retry(ctx, true, || {
         client_fetch_script_results_once(
             ctx,
             &operation_id,
@@ -230,21 +240,18 @@ async fn client_fetch_script_results_once(
         fetch_token: fetch_token.to_string(),
         rows_limit,
     };
-    let timeout_duration = opts.timeout.unwrap_or(ctx.timeouts.operation_timeout);
-    let (index, raw_set, next_token) = tokio::time::timeout(timeout_duration, async {
-        let mut client = ctx
-            .connection_manager
-            .get_auth_service(RawQueryClient::new)
-            .await?;
+    let timeout_duration = call_operation_timeout(opts, &ctx.timeouts);
+    let mut client = ctx
+        .connection_manager
+        .get_auth_service(RawQueryClient::new)
+        .await?;
+    let (index, raw_set, next_token) = with_operation_timeout(timeout_duration, async {
         client
             .fetch_script_results(req)
             .await
             .map_err(YdbError::from)
     })
-    .await
-    .map_err(|_| {
-        YdbError::Transport(format!("operation timed out after {timeout_duration:?}"))
-    })??;
+    .await?;
 
     Ok(FetchScriptResult {
         result_set_index: index,

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -1,0 +1,269 @@
+use std::collections::HashMap;
+use std::future::{Future, IntoFuture};
+use std::pin::Pin;
+use std::time::Duration;
+
+use crate::errors::{YdbError, YdbResult};
+use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
+use crate::grpc_wrapper::raw_query_service::execute_script::RawExecuteScriptRequest;
+use crate::grpc_wrapper::raw_query_service::fetch_script_results::RawFetchScriptResultsRequest;
+use crate::result::ResultSet;
+use crate::types::Value;
+
+use super::exec::{run_idempotent, CallOptions, ClientExecContext};
+
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Long-running script operation started by [`QueryClient::execute_script`].
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
+pub struct ExecuteScriptOperation {
+    pub id: String,
+    pub consumed_units: Option<f64>,
+}
+
+/// One page of script results from [`QueryClient::fetch_script_results`].
+#[derive(Debug)]
+#[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
+pub struct FetchScriptResult {
+    pub result_set_index: i64,
+    pub result_set: ResultSet,
+    pub next_fetch_token: String,
+}
+
+pub struct ExecuteScriptBuilder<'a> {
+    ctx: &'a ClientExecContext,
+    text: String,
+    params: HashMap<String, Value>,
+    opts: CallOptions,
+    results_ttl: Option<Duration>,
+}
+
+impl<'a> ExecuteScriptBuilder<'a> {
+    pub(crate) fn new(ctx: &'a ClientExecContext, text: String) -> Self {
+        Self {
+            ctx,
+            text,
+            params: HashMap::new(),
+            opts: CallOptions::default(),
+            results_ttl: None,
+        }
+    }
+
+    /// TTL for script results on the server after execution completes.
+    pub fn results_ttl(mut self, ttl: Duration) -> Self {
+        self.results_ttl = Some(ttl);
+        self
+    }
+
+    pub fn param(mut self, name: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.params.insert(name.into(), value.into());
+        self
+    }
+
+    pub fn params(mut self, params: HashMap<String, Value>) -> Self {
+        self.params.extend(params);
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.opts.timeout = Some(timeout);
+        self
+    }
+
+    pub fn idempotent(mut self, idempotent: bool) -> Self {
+        self.opts.idempotent = Some(idempotent);
+        self
+    }
+
+    pub fn collect_stats(mut self) -> Self {
+        self.opts.collect_stats = true;
+        self
+    }
+}
+
+impl<'a> IntoFuture for ExecuteScriptBuilder<'a> {
+    type Output = YdbResult<ExecuteScriptOperation>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let results_ttl = self.results_ttl.ok_or_else(|| {
+                YdbError::Custom("execute_script requires `.results_ttl(...)`".into())
+            })?;
+            client_execute_script(self.ctx, self.text, self.params, self.opts, results_ttl).await
+        })
+    }
+}
+
+pub struct FetchScriptResultsBuilder<'a> {
+    ctx: &'a ClientExecContext,
+    operation_id: String,
+    result_set_index: i64,
+    fetch_token: String,
+    rows_limit: i64,
+    opts: CallOptions,
+}
+
+impl<'a> FetchScriptResultsBuilder<'a> {
+    pub(crate) fn new(ctx: &'a ClientExecContext, operation_id: String) -> Self {
+        Self {
+            ctx,
+            operation_id,
+            result_set_index: 0,
+            fetch_token: String::new(),
+            rows_limit: 0,
+            opts: CallOptions::default(),
+        }
+    }
+
+    pub fn result_set_index(mut self, index: i64) -> Self {
+        self.result_set_index = index;
+        self
+    }
+
+    pub fn fetch_token(mut self, token: impl Into<String>) -> Self {
+        self.fetch_token = token.into();
+        self
+    }
+
+    pub fn rows_limit(mut self, limit: i64) -> Self {
+        self.rows_limit = limit;
+        self
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.opts.timeout = Some(timeout);
+        self
+    }
+}
+
+impl<'a> IntoFuture for FetchScriptResultsBuilder<'a> {
+    type Output = YdbResult<FetchScriptResult>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            client_fetch_script_results(
+                self.ctx,
+                self.operation_id,
+                self.result_set_index,
+                self.fetch_token,
+                self.rows_limit,
+                self.opts,
+            )
+            .await
+        })
+    }
+}
+
+async fn client_execute_script(
+    ctx: &ClientExecContext,
+    text: String,
+    params: HashMap<String, Value>,
+    opts: CallOptions,
+    results_ttl: Duration,
+) -> YdbResult<ExecuteScriptOperation> {
+    let idempotent = opts.idempotent.unwrap_or(ctx.idempotent_operation);
+    run_idempotent(ctx, idempotent, || {
+        client_execute_script_once(ctx, &text, &params, &opts, results_ttl)
+    })
+    .await
+}
+
+async fn client_execute_script_once(
+    ctx: &ClientExecContext,
+    text: &str,
+    params: &HashMap<String, Value>,
+    opts: &CallOptions,
+    results_ttl: Duration,
+) -> YdbResult<ExecuteScriptOperation> {
+    let req = RawExecuteScriptRequest {
+        yql_text: text.to_string(),
+        parameters: params.clone(),
+        results_ttl,
+        operation_params: ctx.timeouts.operation_params(),
+        collect_stats: opts.collect_stats,
+    };
+    let timeout_duration = opts.timeout.unwrap_or(ctx.timeouts.operation_timeout);
+    let operation = tokio::time::timeout(timeout_duration, async {
+        let mut client = ctx
+            .connection_manager
+            .get_auth_service(RawQueryClient::new)
+            .await?;
+        client.execute_script(req).await.map_err(YdbError::from)
+    })
+    .await
+    .map_err(|_| {
+        YdbError::Transport(format!("operation timed out after {timeout_duration:?}"))
+    })??;
+
+    if operation.id.is_empty() {
+        return Err(YdbError::Custom(
+            "execute script returned empty operation id".into(),
+        ));
+    }
+    Ok(ExecuteScriptOperation {
+        id: operation.id,
+        consumed_units: operation.cost_info.map(|info| info.consumed_units),
+    })
+}
+
+async fn client_fetch_script_results(
+    ctx: &ClientExecContext,
+    operation_id: String,
+    result_set_index: i64,
+    fetch_token: String,
+    rows_limit: i64,
+    opts: CallOptions,
+) -> YdbResult<FetchScriptResult> {
+    // FetchScriptResults is always safe to retry (aligned with Go SDK).
+    run_idempotent(ctx, true, || {
+        client_fetch_script_results_once(
+            ctx,
+            &operation_id,
+            result_set_index,
+            &fetch_token,
+            rows_limit,
+            &opts,
+        )
+    })
+    .await
+}
+
+async fn client_fetch_script_results_once(
+    ctx: &ClientExecContext,
+    operation_id: &str,
+    result_set_index: i64,
+    fetch_token: &str,
+    rows_limit: i64,
+    opts: &CallOptions,
+) -> YdbResult<FetchScriptResult> {
+    let req = RawFetchScriptResultsRequest {
+        operation_id: operation_id.to_string(),
+        result_set_index,
+        fetch_token: fetch_token.to_string(),
+        rows_limit,
+    };
+    let timeout_duration = opts.timeout.unwrap_or(ctx.timeouts.operation_timeout);
+    let (index, raw_set, next_token) = tokio::time::timeout(timeout_duration, async {
+        let mut client = ctx
+            .connection_manager
+            .get_auth_service(RawQueryClient::new)
+            .await?;
+        client
+            .fetch_script_results(req)
+            .await
+            .map_err(YdbError::from)
+    })
+    .await
+    .map_err(|_| {
+        YdbError::Transport(format!("operation timed out after {timeout_duration:?}"))
+    })??;
+
+    Ok(FetchScriptResult {
+        result_set_index: index,
+        result_set: raw_set.try_into()?,
+        next_fetch_token: next_token,
+    })
+}

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -71,11 +71,6 @@ impl<'a> ExecuteScriptBuilder<'a> {
         self
     }
 
-    pub fn idempotent(mut self, idempotent: bool) -> Self {
-        self.opts.idempotent = Some(idempotent);
-        self
-    }
-
     pub fn collect_stats(mut self) -> Self {
         self.opts.collect_stats = true;
         self
@@ -164,11 +159,9 @@ async fn client_execute_script(
     opts: CallOptions,
     results_ttl: Duration,
 ) -> YdbResult<ExecuteScriptOperation> {
-    let idempotent = opts.idempotent.unwrap_or(ctx.idempotent_operation);
-    run_idempotent(ctx, idempotent, || {
-        client_execute_script_once(ctx, &text, &params, &opts, results_ttl)
-    })
-    .await
+    // Unlike FetchScriptResults, ExecuteScript is not retried: a server-side start
+    // followed by a client transport error would spawn duplicate long-running ops.
+    client_execute_script_once(ctx, &text, &params, &opts, results_ttl).await
 }
 
 async fn client_execute_script_once(

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -72,11 +72,6 @@ impl<'a> ExecuteScriptBuilder<'a> {
         self.opts.timeout = Some(timeout);
         self
     }
-
-    pub fn collect_stats(mut self) -> Self {
-        self.opts.collect_stats = true;
-        self
-    }
 }
 
 impl<'a> IntoFuture for ExecuteScriptBuilder<'a> {
@@ -178,7 +173,7 @@ async fn client_execute_script_once(
         parameters: params.clone(),
         results_ttl,
         operation_params: ctx.timeouts.execute_script_operation_params(),
-        collect_stats: opts.collect_stats,
+        collect_stats: false,
     };
     let timeout_duration = call_operation_timeout(opts, &ctx.timeouts);
     let mut client = ctx
@@ -192,11 +187,13 @@ async fn client_execute_script_once(
     {
         Ok(value) => value,
         Err(err) => {
-            tracing::warn!(
-                ?timeout_duration,
-                "execute_script timed out waiting for RPC response; \
-                 a server-side operation may still be running until cancel_after"
-            );
+            if matches!(&err, YdbError::Transport(msg) if msg.contains("timed out")) {
+                tracing::warn!(
+                    ?timeout_duration,
+                    "execute_script timed out waiting for RPC response; \
+                     a server-side operation may still be running until cancel_after"
+                );
+            }
             return Err(err);
         }
     };

--- a/ydb/src/grpc_wrapper/raw_query_service/client.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/client.rs
@@ -1,7 +1,9 @@
 use crate::grpc_wrapper::grpc_limits::WithGrpcMaxMessageSize;
 use crate::grpc_wrapper::raw_errors::RawResult;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
-use crate::grpc_wrapper::raw_query_service::execute_script::RawExecuteScriptRequest;
+use crate::grpc_wrapper::raw_query_service::execute_script::{
+    parse_execute_script_operation, RawExecuteScriptRequest,
+};
 use crate::grpc_wrapper::raw_query_service::fetch_script_results::{
     parse_response, RawFetchScriptResultsRequest,
 };
@@ -53,10 +55,10 @@ impl RawQueryClient {
     pub async fn execute_script(
         &mut self,
         req: RawExecuteScriptRequest,
-    ) -> RawResult<ydb_grpc::ydb_proto::operations::Operation> {
+    ) -> RawResult<(String, Option<f64>)> {
         let proto = req.into_proto()?;
         let response = self.service.execute_script(proto).await?;
-        Ok(response.into_inner())
+        parse_execute_script_operation(response.into_inner())
     }
 
     pub async fn fetch_script_results(

--- a/ydb/src/grpc_wrapper/raw_query_service/client.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/client.rs
@@ -1,6 +1,10 @@
 use crate::grpc_wrapper::grpc_limits::WithGrpcMaxMessageSize;
 use crate::grpc_wrapper::raw_errors::RawResult;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
+use crate::grpc_wrapper::raw_query_service::execute_script::RawExecuteScriptRequest;
+use crate::grpc_wrapper::raw_query_service::fetch_script_results::{
+    parse_response, RawFetchScriptResultsRequest,
+};
 use crate::grpc_wrapper::raw_query_service::status::check_status;
 use crate::grpc_wrapper::raw_services::{GrpcServiceForDiscovery, Service};
 use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
@@ -44,6 +48,28 @@ impl RawQueryClient {
         let proto = req.into_proto()?;
         let response = self.service.execute_query(proto).await?;
         Ok(response.into_inner())
+    }
+
+    pub async fn execute_script(
+        &mut self,
+        req: RawExecuteScriptRequest,
+    ) -> RawResult<ydb_grpc::ydb_proto::operations::Operation> {
+        let proto = req.into_proto()?;
+        let response = self.service.execute_script(proto).await?;
+        Ok(response.into_inner())
+    }
+
+    pub async fn fetch_script_results(
+        &mut self,
+        req: RawFetchScriptResultsRequest,
+    ) -> RawResult<(
+        i64,
+        crate::grpc_wrapper::raw_table_service::value::RawResultSet,
+        String,
+    )> {
+        let proto = req.into_proto();
+        let response = self.service.fetch_script_results(proto).await?;
+        parse_response(response.into_inner())
     }
 
     pub async fn create_session(&mut self) -> RawResult<String> {

--- a/ydb/src/grpc_wrapper/raw_query_service/execute_script.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/execute_script.rs
@@ -2,11 +2,15 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::grpc_wrapper::raw_common_types::Duration as RawDuration;
-use crate::grpc_wrapper::raw_errors::RawResult;
+use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
+use crate::grpc_wrapper::raw_query_service::status::check_status;
 use crate::grpc_wrapper::raw_table_service::value::RawTypedValue;
 use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
 use crate::types::Value;
-use ydb_grpc::ydb_proto::query::{ExecMode, ExecuteScriptRequest, QueryContent, StatsMode, Syntax};
+use prost::Message;
+use ydb_grpc::ydb_proto::query::{
+    ExecMode, ExecuteScriptMetadata, ExecuteScriptRequest, QueryContent, StatsMode, Syntax,
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct RawExecuteScriptRequest {
@@ -42,4 +46,29 @@ impl RawExecuteScriptRequest {
             pool_id: String::new(),
         })
     }
+}
+
+pub(crate) fn parse_execute_script_operation(
+    operation: ydb_grpc::ydb_proto::operations::Operation,
+) -> RawResult<(String, Option<f64>)> {
+    check_status(operation.status, &operation.issues)?;
+    if !operation.id.is_empty() {
+        return Ok((
+            operation.id,
+            operation.cost_info.map(|info| info.consumed_units),
+        ));
+    }
+    if let Some(any) = operation.metadata {
+        if let Ok(meta) = ExecuteScriptMetadata::decode(&*any.value) {
+            if !meta.execution_id.is_empty() {
+                return Ok((
+                    meta.execution_id,
+                    operation.cost_info.map(|info| info.consumed_units),
+                ));
+            }
+        }
+    }
+    Err(RawError::custom(
+        "execute script returned empty operation id",
+    ))
 }

--- a/ydb/src/grpc_wrapper/raw_query_service/execute_script.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/execute_script.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::grpc_wrapper::raw_common_types::Duration as RawDuration;
+use crate::grpc_wrapper::raw_errors::RawResult;
+use crate::grpc_wrapper::raw_table_service::value::RawTypedValue;
+use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
+use crate::types::Value;
+use ydb_grpc::ydb_proto::query::{ExecMode, ExecuteScriptRequest, QueryContent, StatsMode, Syntax};
+
+#[derive(Clone, Debug)]
+pub(crate) struct RawExecuteScriptRequest {
+    pub yql_text: String,
+    pub parameters: HashMap<String, Value>,
+    pub results_ttl: Duration,
+    pub operation_params: RawOperationParams,
+    pub collect_stats: bool,
+}
+
+impl RawExecuteScriptRequest {
+    pub(crate) fn into_proto(self) -> RawResult<ExecuteScriptRequest> {
+        let mut parameters = HashMap::with_capacity(self.parameters.len());
+        for (name, val) in self.parameters {
+            let raw: RawTypedValue = val.try_into()?;
+            parameters.insert(name, raw.into());
+        }
+
+        Ok(ExecuteScriptRequest {
+            operation_params: Some(self.operation_params.into()),
+            exec_mode: ExecMode::Execute as i32,
+            script_content: Some(QueryContent {
+                syntax: Syntax::YqlV1 as i32,
+                text: self.yql_text,
+            }),
+            parameters,
+            stats_mode: if self.collect_stats {
+                StatsMode::Basic as i32
+            } else {
+                StatsMode::None as i32
+            },
+            results_ttl: Some(RawDuration::from(self.results_ttl).into()),
+            pool_id: String::new(),
+        })
+    }
+}

--- a/ydb/src/grpc_wrapper/raw_query_service/execute_script.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/execute_script.rs
@@ -59,13 +59,19 @@ pub(crate) fn parse_execute_script_operation(
         ));
     }
     if let Some(any) = operation.metadata {
-        if let Ok(meta) = ExecuteScriptMetadata::decode(&*any.value) {
-            if !meta.execution_id.is_empty() {
+        match ExecuteScriptMetadata::decode(&*any.value) {
+            Ok(meta) if !meta.execution_id.is_empty() => {
                 return Ok((
                     meta.execution_id,
                     operation.cost_info.map(|info| info.consumed_units),
                 ));
             }
+            Err(e) => {
+                return Err(RawError::custom(format!(
+                    "execute script returned empty operation id and metadata decode failed: {e}"
+                )));
+            }
+            _ => {}
         }
     }
     Err(RawError::custom(

--- a/ydb/src/grpc_wrapper/raw_query_service/fetch_script_results.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/fetch_script_results.rs
@@ -1,0 +1,38 @@
+use crate::grpc_wrapper::raw_errors::RawResult;
+use crate::grpc_wrapper::raw_query_service::status::check_status;
+use crate::grpc_wrapper::raw_table_service::value::RawResultSet;
+use ydb_grpc::ydb_proto::query::{FetchScriptResultsRequest, FetchScriptResultsResponse};
+
+#[derive(Clone, Debug)]
+pub(crate) struct RawFetchScriptResultsRequest {
+    pub operation_id: String,
+    pub result_set_index: i64,
+    pub fetch_token: String,
+    pub rows_limit: i64,
+}
+
+impl RawFetchScriptResultsRequest {
+    pub(crate) fn into_proto(self) -> FetchScriptResultsRequest {
+        FetchScriptResultsRequest {
+            operation_id: self.operation_id,
+            result_set_index: self.result_set_index,
+            fetch_token: self.fetch_token,
+            rows_limit: self.rows_limit,
+        }
+    }
+}
+
+pub(crate) fn parse_response(
+    response: FetchScriptResultsResponse,
+) -> RawResult<(i64, RawResultSet, String)> {
+    check_status(response.status, &response.issues)?;
+    let result_set = match response.result_set {
+        Some(proto) => RawResultSet::try_from(proto)?,
+        None => RawResultSet::default(),
+    };
+    Ok((
+        response.result_set_index,
+        result_set,
+        response.next_fetch_token,
+    ))
+}

--- a/ydb/src/grpc_wrapper/raw_query_service/mod.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) mod client;
 pub(crate) mod execute_query;
+pub(crate) mod execute_script;
+pub(crate) mod fetch_script_results;
 pub(crate) mod session;
 pub(crate) mod status;
 pub(crate) mod stream;

--- a/ydb/src/grpc_wrapper/raw_ydb_operation.rs
+++ b/ydb/src/grpc_wrapper/raw_ydb_operation.rs
@@ -21,8 +21,8 @@ impl RawOperationParams {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn new_async(
+    /// ExecuteScript must run asynchronously (YDB rejects SYNC mode).
+    pub(crate) fn for_execute_script(
         operation_timeout: std::time::Duration,
         cancel_after: std::time::Duration,
     ) -> Self {

--- a/ydb/src/grpc_wrapper/raw_ydb_operation.rs
+++ b/ydb/src/grpc_wrapper/raw_ydb_operation.rs
@@ -21,6 +21,7 @@ impl RawOperationParams {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn new_async(
         operation_timeout: std::time::Duration,
         cancel_after: std::time::Duration,

--- a/ydb/src/grpc_wrapper/raw_ydb_operation.rs
+++ b/ydb/src/grpc_wrapper/raw_ydb_operation.rs
@@ -20,6 +20,18 @@ impl RawOperationParams {
             labels: Default::default(),
         }
     }
+
+    pub(crate) fn new_async(
+        operation_timeout: std::time::Duration,
+        cancel_after: std::time::Duration,
+    ) -> Self {
+        Self {
+            operation_mode: OperationMode::_Async,
+            operation_timeout: Some(operation_timeout.into()),
+            cancel_after: Some(cancel_after.into()),
+            labels: Default::default(),
+        }
+    }
 }
 
 impl From<RawOperationParams> for ydb_grpc::ydb_proto::operations::OperationParams {

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -154,7 +154,8 @@ pub use client_builder::ClientBuilder;
 
 // full enum pub types
 pub use client_query::{
-    CallBuilder, ExecBuilder, ExecCall, FromYdbRow, OneResultSet, OneRow, OptionalRow,
+    CallBuilder, ExecBuilder, ExecCall, ExecuteScriptBuilder, ExecuteScriptOperation,
+    FetchScriptResult, FetchScriptResultsBuilder, FromYdbRow, OneResultSet, OneRow, OptionalRow,
     OptionalRowBuilder, QueryClient, QueryExecutor, QueryRowBuilder, QuerySessionMode, QueryStats,
     QueryStream, QueryStreamBuilder, QueryTransaction, QueryTransactionOptions, QueryTxMode,
     ResultSetBuilder, Streamed,


### PR DESCRIPTION
## Summary
- Add `QueryClient::execute_script()` and `QueryClient::fetch_script_results()` with builder-style API (results TTL, params, pagination options).
- Wire raw gRPC wrappers for `ExecuteScript` and `FetchScriptResults` on `RawQueryClient`.
- Add Go SDK–aligned integration test `query_execute_script` (100k rows, paginated fetch, checksum verification).
- Add `ydb/examples/query-service-script.rs` demonstrating poll + paginate flow.

Closes #327
Closes #328

## Test plan
- [x] `cargo clippy -p ydb --all-targets`
- [x] `cargo test -p ydb query_execute_script -- --include-ignored` (requires YDB)
- [x] `cargo run -p ydb --example query-service-script` (requires YDB)


Made with [Cursor](https://cursor.com)