### PR TITLE
docs(agents): expand coding standards from PR review patterns

### DIFF
--- a/.agents/rules/coding-standards.md
+++ b/.agents/rules/coding-standards.md
@@ -1,12 +1,72 @@
 # Coding Standards
 
-Read when touching public API, module layout, dependencies, or error handling.
+Read when touching public API, module layout, dependencies, error handling, or anything non-trivial.
+
+## Priorities
+
+In order, highest first:
+
+1. **Correctness.**
+2. **Readability and maintainability for humans.** Simple constructs, consistent style, simple contracts, simple dependencies.
+3. **Ergonomics of the public API** — external users live with it; calling it must be pleasant.
+4. **Simplicity of internal code** — boring, straight-line, easy to follow.
+5. **Performance** — where it actually matters. Don't pessimize for no reason, but don't add complexity for speculative wins either.
+
+When two pull in opposite directions, the higher one wins.
 
 ## Style
 
 - Comments, doc comments, error messages, and logs: **English**.
 - Match naming and formatting in the touched module; do not reformat unrelated code.
 - Run `cargo fmt` on changed files before handoff.
+- No commented-out code and no debug `println!`/`dbg!` in committed code (including `examples/`).
+
+## Rust edition / version
+
+- MSRV is not pinned in policy: feel free to use recent language and `std` features when they meaningfully simplify the code.
+- CI compiles against Rust 1.82 and 1.91; if you use a newer feature, make sure it compiles on the latest of those — otherwise raise the question.
+
+## Visibility
+
+- Default is **private**.
+- Use `pub(crate)` when something must be shared inside the crate.
+- `pub` is reserved for items intended for SDK consumers.
+
+## Types
+
+- `Option<T>` only when "absent" is a real domain state. If a sensible default exists (e.g. `Codec::Raw`), make the field required and use the default.
+- Small `Copy` enums and scalars are passed by value, not by reference.
+- **In the public API**, do not introduce `type Alias = SomeStdType` just to attach one convenient method or shorten a name. Wrap it in a real `struct` with its own API so the implementation can change without breaking consumers. Inside the crate, type aliases are fine.
+
+## Public API (`ydb` crate)
+
+- `ydb-grpc` types are internal — do not leak `prost`/`tonic` types (`prost::Bytes`, tonic streams, raw gRPC futures) into public signatures. Wrap, or use `Vec<u8>` / `bytes::Bytes`.
+- New APIs follow the layered pattern in [`.agents/context/systemPatterns.md`](../context/systemPatterns.md).
+- Public API changes must be semver-aware and intentional.
+- Many enums are `#[non_exhaustive]`; respect this unless using `force-exhaustive-all` for downstream checks.
+- Mark experimental / non-production APIs in rustdoc.
+- Prefer ergonomic argument types where the caller has several natural forms: `impl Into<String>` / `impl AsRef<str>` for stringy inputs (see `retry_explain_data_query`).
+- Evolve additively: new behavior gets a new method (e.g. `commit_with_ack` alongside `commit`), not a changed signature on an existing one.
+- Raw-client (`grpc_wrapper/raw_*`) methods return the decoded response struct as-is, so newly added server fields propagate without code changes.
+
+## Errors
+
+- **No `unwrap` / `expect` / `panic!` / `unsafe`** in production code. If an invariant truly must hold, return `YdbError` with a diagnostic message. In tests, `unwrap`/`expect` are fine.
+- `unreachable!` is allowed **only with explicit human approval** when there is no other way to express the invariant. The comment next to it must explain what makes the branch impossible.
+- An internal invariant breaking is an error, not a silent fallback. No `.ok()` / `unwrap_or_default()` / empty-default returns to mask broken state.
+- Error messages must embed the offending identifier (column, table, topic, path, codec id, …) so a single log line is diagnosable.
+- Workarounds and hacks live behind a typed flag or named constant, with a comment linking to the tracking issue and explaining the removal condition.
+- When reacting to a failed RPC, classify by **gRPC error / status code** first. Matching on error text or YDB issue codes is a last resort, used only when nothing else works, and explicitly called out in a comment near the match.
+
+## Naming and readability
+
+- Names reflect semantics: `execute` means synchronous run; methods that only enqueue are `schedule`/`spawn`/`submit`. `get_*` does not mutate. Paired serialize/deserialize share a name root.
+- Prefer positive booleans (`fallback_enabled`) over negated ones (`!disabled_fallback`).
+- Magic numbers become named `const`s — and the same constant is reused at the producer and consumer of the value.
+- Flatten deeply nested `match`-on-`await` chains (especially in reader/writer paths) — extract or use early returns.
+- Return named `struct`s, not `(T, bool)` or anonymous tuples, in non-trivial code.
+- Examples in `ydb/examples/` must compile and run; strip debug noise before merge.
+- Manual `drop(self.field)` to "force" cleanup is an antipattern — `Drop` runs anyway.
 
 ## Dependencies and versions
 
@@ -14,13 +74,18 @@ Read when touching public API, module layout, dependencies, or error handling.
 - Do not run `cargo update` or bump workspace dependency versions unless asked.
 - Shared versions live in root `[workspace.dependencies]`; member crates use `workspace = true`.
 - Do not bump published crate versions unless the user requests a release.
+- **Test-only and dev-only code must not leak into production surface.** Helpers used only by tests live behind `#[cfg(test)]` or in dedicated test modules; test-only crates go in `[dev-dependencies]`. Public API must not depend on them, even transitively.
+- Before writing a new helper, search the workspace, `ydb-grpc`, and `tokio` APIs for an existing one — extend it rather than introducing a parallel implementation.
 
-## Public API (`ydb` crate)
+## Concurrency and performance
 
-- `ydb-grpc` types are internal — do not leak them in the public API without a stable wrapper.
-- New APIs follow the layered pattern in [`.agents/context/systemPatterns.md`](../context/systemPatterns.md).
-- Public API changes must be semver-aware and intentional.
-- Many enums are `#[non_exhaustive]`; respect this unless using `force-exhaustive-all` for downstream checks.
+Apply when the code path actually matters (hot loops, reader/writer pipelines, connection pool). Don't preemptively complicate cold paths.
+
+- Retries and timeouts are **deadline-based**: use `tokio::time::timeout`; cleanup happens via `Drop`. Do not introduce `max_retries` knobs.
+- CPU-heavy work (compression, hashing of large payloads) runs on a worker pool / `spawn_blocking` — never on the async task that owns the request.
+- Cap parallel-work chunks by message count, not only by byte size, so one large batch can't pin a worker.
+- In hot paths: no avoidable `String` allocations where `&str` / `bytes::Bytes` works; reserve `Vec`/`HashMap` capacity when the size is known; pre-resolve name → index in setup so the inner loop indexes.
+- Gate expensive `log!` argument construction behind `log_enabled!`.
 
 ## Architecture anti-patterns
 
@@ -29,3 +94,4 @@ See `systemPatterns.md` for layout. In short:
 - Bypassing the connection pool for production RPC paths.
 - Adding dependencies without workspace-level version alignment.
 - Exposing raw tonic/prost types as stable public types.
+- Reinventing a helper that already exists in the workspace.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -33,6 +33,19 @@ cargo test --workspace
 
 CI also runs `cargo test --workspace -- --include-ignored` against `ydbplatform/local-ydb:nightly` on Rust 1.82 and 1.91.0.
 
+## What a test should assert
+
+Assert the specific fact the test is meant to defend — the concrete error type / status code or the concrete successful result — not a proxy symptom.
+
+Counting messages, sleeping for "a while", or matching on log output passes both when the code is correct and when an unrelated regression makes the proxy coincidentally match. The test is then green while the bug ships.
+
+Also cover paths the code explicitly rejects, so a future relaxation of those checks does not slip through unnoticed.
+
+## Integration test data
+
+- Use stable, deterministic table/topic names. Start the test with `DROP TABLE IF EXISTS …` → `CREATE …`.
+- Do **not** drop on teardown — a failed run is more debuggable if its data is still there.
+
 ## `ydb-grpc`
 
 Generated protobuf crate — clippy is excluded. Do not hand-edit generated files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,16 @@ On **"update memory bank"** — review all core files in [`.agents/context/READM
 
 ## Non-obvious rules (always on)
 
+- Priorities: correctness → readability → public-API ergonomics → simple internal code → performance only where it matters.
+- Visibility: private by default, `pub(crate)` to share inside the crate, `pub` only for SDK consumers.
+- No `unwrap` / `expect` / `panic!` / `unsafe` in production code; `unreachable!` only with explicit human approval. Tests may use `unwrap`/`expect`.
+- No silent error swallowing on a broken invariant (`.ok()`, `unwrap_or_default()`, empty fallbacks).
+- Deadline-based retries via `tokio::time::timeout`; do not introduce `max_retries`.
+- No commented-out code or debug prints in committed code (including `examples/`).
 - Comments, doc comments, error messages, logs: **English**.
 - Match style in the touched module; do not reformat unrelated code.
 - Do **not** change `Cargo.toml` / `Cargo.lock` unless the task requires it.
+- MSRV is not pinned in policy, but CI runs on Rust 1.82 and 1.91 — newer features are fine if they compile there.
 - Integration tests are `#[ignore]`; need `YDB_CONNECTION_STRING` and `--include-ignored`.
 - `ydb-grpc` is generated; clippy excludes it. Do not bump crate versions unless asked.
 - Non-trivial changes: discuss in a GitHub issue first ([`CONTRIBUTING.md`](CONTRIBUTING.md)).


### PR DESCRIPTION
## Summary

Codifies recurring code-review rules into the agent instructions so future contributors (and AI agents) get the same feedback up front instead of in review.

Distilled from human review comments across `ydb-platform/*` PRs (AI-bot reposts excluded) and the `ydb-pg-extension` agent rule set.

### Changes

- **`AGENTS.md`** — adds always-on bullets: priority order (correctness → readability → public-API ergonomics → simple internals → performance), visibility defaults, ban on `unwrap`/`panic!`/`unsafe` in production, no silent error swallowing, deadline-based retries, no committed debug code, MSRV note.
- **`.agents/rules/coding-standards.md`** — rewritten with sections:
  - Priorities
  - Rust edition / version (no pinned MSRV, CI on 1.82 / 1.91)
  - Visibility (private by default, `pub(crate)` to share, `pub` only for SDK consumers)
  - Types (`Option<T>` only for real domain states; no `type Alias` in public API)
  - Public API (no `prost`/`tonic` leaks; `impl Into<String>`; additive evolution; raw-client returns decoded structs as-is)
  - Errors (no `unwrap`/`panic!`/`unsafe`; `unreachable!` only with human approval; gRPC status codes first, text/issue-codes last resort; workarounds behind flags with tracker links)
  - Naming & readability (semantic names, no nested `match`-on-`await`, named structs over `(T, bool)`, examples must run)
  - Dependencies (test-only stays out of production surface; reuse-first)
  - Concurrency & performance (deadline-based timeouts via `tokio::time::timeout`; `spawn_blocking` for CPU-heavy work; hot-path allocation rules)
- **`.agents/rules/testing.md`** — adds:
  - *What a test should assert* — defend the concrete fact, not a proxy symptom
  - *Integration test data* — stable table names with `DROP IF EXISTS`, no teardown drop

No code changes; documentation only.

## Test plan

- [ ] Skim the new `coding-standards.md` end-to-end and confirm the priority ordering reads correctly
- [ ] Confirm nothing in the new bullets contradicts existing `.agents/context/` material