### PR TITLE
SLO test: oversized session pool (H1)

### DIFF
--- a/tests/slo/native/query/src/storage.rs
+++ b/tests/slo/native/query/src/storage.rs
@@ -28,9 +28,14 @@ impl Storage {
         client.wait().await.map_err(|err| err.to_string())?;
 
         let pool_limit = params.pool_size() as usize;
+        // SLO experiment (H1): oversized pool + warm-up vs default pool_size=RPS.
         let query_client = client
             .query_client()
-            .with_session_pool(QuerySessionPoolSettings::new().with_limit(pool_limit))
+            .with_session_pool(
+                QuerySessionPoolSettings::new()
+                    .with_limit(pool_limit.saturating_mul(3))
+                    .with_warm_up(pool_limit),
+            )
             .await
             .map_err(|err| err.to_string())?
             .clone_with_idempotent_operations(true);


### PR DESCRIPTION
## Summary
- Sets explicit query session pool limit to `3 × (read_rps + write_rps)` with warm-up equal to the default pool size (`read_rps + write_rps`).
- Baseline SLO uses `pool_limit = read_rps + write_rps` without warm-up.

## Purpose
Validate whether Rust native-query SLO throughput is capped by session pool sizing (Little's law) vs Go SDK under the same runner/YDB chaos setup.

## Test plan
- [ ] Add `SLO` label and compare native-query graphs vs baseline/master
- [ ] Check read/write throughput and P50 latency vs Go (`ban_on_create_session` run)


Made with [Cursor](https://cursor.com)