### PR TITLE
SLO test: implicit session pool (H2)

### DIFF
--- a/tests/slo/native/query/src/storage.rs
+++ b/tests/slo/native/query/src/storage.rs
@@ -28,11 +28,10 @@ impl Storage {
         client.wait().await.map_err(|err| err.to_string())?;
 
         let pool_limit = params.pool_size() as usize;
+        // SLO experiment (H2): implicit session pool (no CreateSession/Attach) vs explicit pool.
         let query_client = client
             .query_client()
-            .with_session_pool(QuerySessionPoolSettings::new().with_limit(pool_limit))
-            .await
-            .map_err(|err| err.to_string())?
+            .with_implicit_session_pool(QuerySessionPoolSettings::new().with_limit(pool_limit))
             .clone_with_idempotent_operations(true);
 
         Ok(Self {


### PR DESCRIPTION
## Summary
- Replaces explicit query session pool with `with_implicit_session_pool` (same limit: `read_rps + write_rps`).
- One-shot queries use empty `session_id` without CreateSession/Attach per session.

## Purpose
Compare Rust SLO throughput/latency with implicit vs explicit session acquisition. Note: implicit sessions are generally not recommended for production workloads (higher server-side cost), but help isolate attach-stream / session lifecycle overhead.

## Test plan
- [ ] Add `SLO` label and compare native-query graphs vs baseline/master
- [ ] Compare with Go explicit pool run and with PR #476 (oversized explicit pool)


Made with [Cursor](https://cursor.com)