### PR TITLE
SLO: SnapshotReadOnly reads (H3 parity with Go)

### DIFF
--- a/tests/slo/native/query/src/storage.rs
+++ b/tests/slo/native/query/src/storage.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use slo_framework::kv::{Database, KvWorkload, Params};
 use slo_framework::{test_row_from_row, Framework, RowID, TestRow, Workload};
 use ydb::ClientBuilder;
-use ydb::{QueryClient, QuerySessionPoolSettings};
+use ydb::{QueryClient, QuerySessionPoolSettings, QueryTxMode};
 
 pub struct Storage {
     query_client: QueryClient,
@@ -111,7 +111,10 @@ impl Database for Storage {
         // retries inside query_row — the one-shot API has no attempt callback (unlike table retry_transaction).
         let row = tokio::time::timeout(self.read_timeout, async move {
             attempts_for_op.fetch_add(1, Ordering::Relaxed);
-            qc.query_row(select_sql).param("$id", id).await
+            qc.query_row(select_sql)
+                .param("$id", id)
+                .with_tx_mode(QueryTxMode::SnapshotReadOnly)
+                .await
         })
         .await
         .map_err(|_| "read timeout".to_string())?


### PR DESCRIPTION
## Summary
- Runs SLO read queries with `QueryTxMode::SnapshotReadOnly` (auto-commit via SDK default for one-shot calls).
- Matches ydb-go-sdk native-query SLO: `BeginTx(SnapshotReadOnly) + CommitTx`.

## Purpose
Isolate whether default Implicit tx mode on reads affects SLO throughput/latency vs Go baseline.

## Test plan
- [ ] Add `SLO` label and compare read throughput/latency vs baseline/master
- [ ] Compare with Go native-query SLO run


Made with [Cursor](https://cursor.com)