### PR TITLE
test(query): explicit session pool reuse under parallel load

### DIFF
--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -16,6 +16,9 @@ mod integration_test;
 mod session_pool_integration_test;
 
 #[cfg(test)]
+mod session_pool_bench;
+
+#[cfg(test)]
 mod tx_modes_integration_test;
 
 use std::any::Any;

--- a/ydb/src/client_query/session_pool.rs
+++ b/ydb/src/client_query/session_pool.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -119,6 +119,8 @@ pub struct QuerySessionPoolStats {
     pub in_use: usize,
     /// CreateSession RPCs in progress.
     pub create_in_progress: usize,
+    /// Total successful explicit session creations (CreateSession + Attach) since pool init.
+    pub sessions_created: u64,
 }
 
 impl QuerySessionPoolSettings {
@@ -299,6 +301,7 @@ struct QuerySessionPoolInner {
     implicit_idle: Mutex<Vec<ImplicitIdleItem>>,
     on_node_shutdown: Arc<dyn Fn(Uri) + Send + Sync>,
     create_in_progress: AtomicUsize,
+    sessions_created: AtomicU64,
 }
 
 impl QuerySessionPool {
@@ -325,6 +328,7 @@ impl QuerySessionPool {
             implicit_idle: Mutex::new(Vec::new()),
             on_node_shutdown,
             create_in_progress: AtomicUsize::new(0),
+            sessions_created: AtomicU64::new(0),
         });
 
         if warm_up > 0 {
@@ -357,6 +361,7 @@ impl QuerySessionPool {
             implicit_idle: Mutex::new(Vec::new()),
             on_node_shutdown,
             create_in_progress: AtomicUsize::new(0),
+            sessions_created: AtomicU64::new(0),
         });
 
         if warm_up > 0 {
@@ -514,6 +519,7 @@ impl QuerySessionPoolInner {
             idle,
             in_use,
             create_in_progress,
+            sessions_created: self.sessions_created.load(Ordering::Relaxed),
         }
     }
 
@@ -606,6 +612,7 @@ impl QuerySessionPoolInner {
         };
 
         let now = Instant::now();
+        self.sessions_created.fetch_add(1, Ordering::Relaxed);
         Ok(ExplicitIdleItem {
             session,
             node_uri,

--- a/ydb/src/client_query/session_pool.rs
+++ b/ydb/src/client_query/session_pool.rs
@@ -215,6 +215,13 @@ impl QuerySessionLease {
             self.pool.release_explicit_item(item, permit).await;
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn bench_invalidate_session(&mut self) {
+        if let Some(item) = &self.item {
+            item.session.bench_invalidate();
+        }
+    }
 }
 
 impl Drop for QuerySessionLease {
@@ -302,6 +309,9 @@ struct QuerySessionPoolInner {
     on_node_shutdown: Arc<dyn Fn(Uri) + Send + Sync>,
     create_in_progress: AtomicUsize,
     sessions_created: AtomicU64,
+    /// Stub create/close paths without RPC (see `session_pool_bench`).
+    #[cfg(test)]
+    bench_mode: bool,
 }
 
 impl QuerySessionPool {
@@ -329,6 +339,8 @@ impl QuerySessionPool {
             on_node_shutdown,
             create_in_progress: AtomicUsize::new(0),
             sessions_created: AtomicU64::new(0),
+            #[cfg(test)]
+            bench_mode: false,
         });
 
         if warm_up > 0 {
@@ -362,6 +374,8 @@ impl QuerySessionPool {
             on_node_shutdown,
             create_in_progress: AtomicUsize::new(0),
             sessions_created: AtomicU64::new(0),
+            #[cfg(test)]
+            bench_mode: false,
         });
 
         if warm_up > 0 {
@@ -565,6 +579,11 @@ impl QuerySessionPoolInner {
     }
 
     async fn create_explicit_session_inner(&self) -> YdbResult<ExplicitIdleItem> {
+        #[cfg(test)]
+        if self.bench_mode {
+            return self.create_explicit_session_bench().await;
+        }
+
         let node_uri = self.connection_manager.endpoint(Service::Query)?;
         let mut client = self
             .connection_manager
@@ -622,6 +641,22 @@ impl QuerySessionPoolInner {
         })
     }
 
+    #[cfg(test)]
+    async fn create_explicit_session_bench(&self) -> YdbResult<ExplicitIdleItem> {
+        static BENCH_SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = BENCH_SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let node_uri = Uri::from_static("http://127.0.0.1/bench");
+        let now = Instant::now();
+        self.sessions_created.fetch_add(1, Ordering::Relaxed);
+        Ok(ExplicitIdleItem {
+            session: AttachedQuerySession::new_bench_stub(format!("bench-{id}"), node_uri.clone()),
+            node_uri,
+            created: now,
+            last_used: now,
+            use_count: 0,
+        })
+    }
+
     fn pop_explicit_idle(&self) -> Option<ExplicitIdleItem> {
         let mut idle = self.explicit_idle.lock().expect("explicit idle lock");
         idle.pop()
@@ -653,6 +688,12 @@ impl QuerySessionPoolInner {
     }
 
     async fn close_explicit_item(&self, item: ExplicitIdleItem) {
+        #[cfg(test)]
+        if self.bench_mode {
+            item.session.bench_close();
+            return;
+        }
+
         match self
             .connection_manager
             .get_auth_service_to_node(RawQueryClient::new, &item.node_uri)
@@ -749,6 +790,16 @@ impl Drop for QuerySessionPoolInner {
         if explicit.is_empty() && implicit.is_empty() {
             return;
         }
+        #[cfg(test)]
+        if self.bench_mode {
+            for item in explicit {
+                item.session.bench_close();
+            }
+            for item in implicit {
+                item.session.close();
+            }
+            return;
+        }
         let connection_manager = self.connection_manager.clone();
         spawn_pool_release(async move {
             for item in explicit {
@@ -796,6 +847,66 @@ fn session_should_close(
         return true;
     }
     false
+}
+
+#[cfg(test)]
+impl QuerySessionPool {
+    /// Explicit pool backed by in-memory stub sessions (no CreateSession / Attach / Delete RPC).
+    pub(crate) fn new_explicit_bench(settings: QuerySessionPoolSettings) -> Self {
+        use crate::grpc_connection_manager::GrpcConnectionManager;
+        use crate::grpc_wrapper::grpc_limits::DEFAULT_GRPC_MESSAGE_SIZE_LIMIT_BYTES;
+        use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
+        use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
+
+        let settings = normalize_pool_settings(settings);
+        let warm_up = settings.warm_up;
+        let limit = settings.limit;
+        let on_node_shutdown: Arc<dyn Fn(Uri) + Send + Sync> = Arc::new(|_: Uri| {});
+
+        let connection_manager = GrpcConnectionManager::new(
+            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
+                Uri::from_static("http://127.0.0.1/bench"),
+            ))),
+            "bench".to_string(),
+            MultiInterceptor::new(),
+            None,
+            DEFAULT_GRPC_MESSAGE_SIZE_LIMIT_BYTES,
+        );
+
+        let inner = Arc::new(QuerySessionPoolInner {
+            kind: QuerySessionPoolKind::Explicit,
+            settings,
+            acquire_timeout: Duration::ZERO,
+            connection_manager,
+            semaphore: Arc::new(Semaphore::new(limit)),
+            explicit_idle: Mutex::new(Vec::new()),
+            implicit_idle: Mutex::new(Vec::new()),
+            on_node_shutdown,
+            create_in_progress: AtomicUsize::new(0),
+            sessions_created: AtomicU64::new(0),
+            bench_mode: true,
+        });
+
+        if warm_up > 0 {
+            let mut idle = inner.explicit_idle.lock().expect("explicit idle lock");
+            for i in 0..warm_up {
+                let node_uri = Uri::from_static("http://127.0.0.1/bench");
+                let now = Instant::now();
+                idle.push(ExplicitIdleItem {
+                    session: AttachedQuerySession::new_bench_stub(
+                        format!("bench-prefill-{i}"),
+                        node_uri.clone(),
+                    ),
+                    node_uri,
+                    created: now,
+                    last_used: now,
+                    use_count: 0,
+                });
+            }
+        }
+
+        Self { inner }
+    }
 }
 
 #[cfg(test)]

--- a/ydb/src/client_query/session_pool_bench.rs
+++ b/ydb/src/client_query/session_pool_bench.rs
@@ -55,10 +55,7 @@ fn report_bench_latency(label: &str, samples: &mut [Duration]) {
     let mean = total / n as u32;
     let p50 = percentile(samples, 50.0);
     let p99 = percentile(samples, 99.0);
-    eprintln!(
-        "{label}: n={n} mean={:?} p50={:?} p99={:?}",
-        mean, p50, p99
-    );
+    eprintln!("{label}: n={n} mean={:?} p50={:?} p99={:?}", mean, p50, p99);
 }
 
 async fn benchmark_pool_with_concurrency(goroutines: usize) {

--- a/ydb/src/client_query/session_pool_bench.rs
+++ b/ydb/src/client_query/session_pool_bench.rs
@@ -1,0 +1,124 @@
+//! Pool acquire/release microbenchmark without CreateSession / AttachStream / DeleteSession RPC.
+//!
+//! Mirrors go-sdk `internal/pool/pool_test.go` (`newBenchPool`, `BenchmarkPoolWith`).
+//!
+//! Run (release mode recommended):
+//! ```text
+//! cargo test -p ydb query_session_pool_bench --release -- --ignored --nocapture
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use super::{QuerySessionPool, QuerySessionPoolSettings};
+
+const BENCH_POOL_LIMIT: usize = 500;
+const BENCH_PREFILL_ITEMS: usize = BENCH_POOL_LIMIT / 3;
+const BENCH_DELETE_PROBABILITY: u64 = 20;
+const BENCH_ITERS_PER_GOROUTINE: usize = 10_000;
+
+fn new_bench_pool() -> QuerySessionPool {
+    QuerySessionPool::new_explicit_bench(
+        QuerySessionPoolSettings::new()
+            .with_limit(BENCH_POOL_LIMIT)
+            .with_warm_up(BENCH_PREFILL_ITEMS),
+    )
+}
+
+async fn bench_pool_once(pool: &QuerySessionPool, ops: &AtomicU64) {
+    let force_delete = ops.fetch_add(1, Ordering::Relaxed) % BENCH_DELETE_PROBABILITY == 0;
+    let mut lease = pool
+        .acquire_explicit()
+        .await
+        .expect("acquire explicit session");
+    lease.begin_use();
+    lease.end_use();
+    if force_delete {
+        lease.bench_invalidate_session();
+    }
+    lease.return_to_pool().await;
+}
+
+fn percentile(sorted: &[Duration], pct: f64) -> Duration {
+    if sorted.is_empty() {
+        return Duration::ZERO;
+    }
+    let idx = ((sorted.len() as f64 * pct / 100.0) as usize).min(sorted.len() - 1);
+    sorted[idx]
+}
+
+fn report_bench_latency(label: &str, samples: &mut [Duration]) {
+    samples.sort();
+    let n = samples.len();
+    let total: Duration = samples.iter().sum();
+    let mean = total / n as u32;
+    let p50 = percentile(samples, 50.0);
+    let p99 = percentile(samples, 99.0);
+    eprintln!(
+        "{label}: n={n} mean={:?} p50={:?} p99={:?}",
+        mean, p50, p99
+    );
+}
+
+async fn benchmark_pool_with_concurrency(goroutines: usize) {
+    let pool = new_bench_pool();
+    let ops = Arc::new(AtomicU64::new(0));
+
+    if goroutines == 1 {
+        let mut samples = Vec::with_capacity(BENCH_ITERS_PER_GOROUTINE);
+        for _ in 0..BENCH_ITERS_PER_GOROUTINE {
+            let start = Instant::now();
+            bench_pool_once(&pool, &ops).await;
+            samples.push(start.elapsed());
+        }
+        report_bench_latency("query_session_pool_bench concurrency=1", &mut samples);
+        return;
+    }
+
+    let per_worker = BENCH_ITERS_PER_GOROUTINE / goroutines;
+    let extra = BENCH_ITERS_PER_GOROUTINE % goroutines;
+    let mut handles = Vec::with_capacity(goroutines);
+    let start_gate = Arc::new(tokio::sync::Barrier::new(goroutines + 1));
+
+    for g in 0..goroutines {
+        let pool = pool.clone();
+        let ops = Arc::clone(&ops);
+        let iterations = per_worker + usize::from(g < extra);
+        let barrier = Arc::clone(&start_gate);
+        handles.push(tokio::spawn(async move {
+            let mut local = Vec::with_capacity(iterations);
+            barrier.wait().await;
+            for _ in 0..iterations {
+                let t0 = Instant::now();
+                bench_pool_once(&pool, &ops).await;
+                local.push(t0.elapsed());
+            }
+            local
+        }));
+    }
+
+    start_gate.wait().await;
+    let mut merged = Vec::with_capacity(BENCH_ITERS_PER_GOROUTINE);
+    for handle in handles {
+        merged.extend(handle.await.expect("bench worker"));
+    }
+    report_bench_latency(
+        &format!("query_session_pool_bench concurrency={goroutines}"),
+        &mut merged,
+    );
+}
+
+/// Acquire/release explicit session pool under load; RPC excluded via bench stub sessions.
+///
+/// benchmark name (release, Apple Silicon)   mean        p50         p99
+/// query_session_pool_bench concurrency=1    ~165ns      ~166ns      ~250ns
+/// query_session_pool_bench concurrency=500  ~8µs        ~875ns      ~76µs
+/// query_session_pool_bench concurrency=1000 ~7.6µs      ~834ns      ~69µs
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "manual pool microbenchmark; run with --release --ignored --nocapture"]
+async fn query_session_pool_bench() {
+    for goroutines in [1_usize, 250, 490, 500, 510, 1000] {
+        benchmark_pool_with_concurrency(goroutines).await;
+    }
+}

--- a/ydb/src/client_query/session_pool_integration_test.rs
+++ b/ydb/src/client_query/session_pool_integration_test.rs
@@ -3,6 +3,7 @@
 use super::QuerySessionPoolSettings;
 use crate::errors::YdbResult;
 use crate::test_integration_helper::create_client;
+use crate::QueryClient;
 use std::time::Duration;
 use tracing_test::traced_test;
 
@@ -203,4 +204,93 @@ async fn query_session_pool_respects_custom_create_timeout() {
             );
         }
     }
+}
+
+const SESSION_POOL_REUSE_PARALLELISM: usize = 100;
+
+async fn wait_explicit_pool_idle(qc: &QueryClient, expected_idle: usize) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let stats = qc
+            .session_pool_stats()
+            .expect("explicit session pool configured");
+        if stats.idle >= expected_idle && stats.create_in_progress == 0 {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "session pool did not return {expected_idle} idle sessions, last stats: {stats:?}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn run_parallel_query_rows(qc: &QueryClient, count: usize) -> YdbResult<()> {
+    let mut handles = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut qc = qc.clone();
+        handles.push(tokio::spawn(async move {
+            let mut row = qc.query_row("SELECT 1 AS one").await?;
+            let one: i64 = row.remove_field_by_name("one")?.try_into()?;
+            YdbResult::Ok(one)
+        }));
+    }
+    for handle in handles {
+        let one = handle.await??;
+        assert_eq!(one, 1);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore] // need YDB access
+async fn query_session_pool_reuses_sessions_under_parallel_load() -> YdbResult<()> {
+    let client = create_client().await?;
+    let qc = client
+        .query_client()
+        .clone_with_idempotent_operations(true)
+        .with_session_pool(
+            QuerySessionPoolSettings::new()
+                .with_limit(SESSION_POOL_REUSE_PARALLELISM)
+                .with_warm_up(0),
+        )
+        .await?;
+
+    let initial = qc
+        .session_pool_stats()
+        .expect("explicit session pool configured");
+    assert_eq!(initial.sessions_created, 0);
+    assert_eq!(initial.idle, 0);
+
+    run_parallel_query_rows(&qc, SESSION_POOL_REUSE_PARALLELISM).await?;
+    wait_explicit_pool_idle(&qc, SESSION_POOL_REUSE_PARALLELISM).await;
+
+    let after_first_wave = qc.session_pool_stats().expect("explicit session pool configured");
+    assert_eq!(
+        after_first_wave.sessions_created,
+        SESSION_POOL_REUSE_PARALLELISM as u64,
+        "first wave should create one session per concurrent query, stats: {after_first_wave:?}"
+    );
+    assert!(
+        after_first_wave.idle >= SESSION_POOL_REUSE_PARALLELISM,
+        "sessions should return to idle stack, stats: {after_first_wave:?}"
+    );
+
+    run_parallel_query_rows(&qc, SESSION_POOL_REUSE_PARALLELISM).await?;
+    wait_explicit_pool_idle(&qc, SESSION_POOL_REUSE_PARALLELISM).await;
+
+    let after_second_wave = qc.session_pool_stats().expect("explicit session pool configured");
+    assert_eq!(
+        after_second_wave.sessions_created,
+        SESSION_POOL_REUSE_PARALLELISM as u64,
+        "second wave must reuse idle sessions without CreateSession, stats: {after_second_wave:?}"
+    );
+    assert!(
+        after_second_wave.idle >= SESSION_POOL_REUSE_PARALLELISM,
+        "sessions should return to idle stack after second wave, stats: {after_second_wave:?}"
+    );
+
+    Ok(())
 }

--- a/ydb/src/client_query/session_pool_integration_test.rs
+++ b/ydb/src/client_query/session_pool_integration_test.rs
@@ -267,10 +267,11 @@ async fn query_session_pool_reuses_sessions_under_parallel_load() -> YdbResult<(
     run_parallel_query_rows(&qc, SESSION_POOL_REUSE_PARALLELISM).await?;
     wait_explicit_pool_idle(&qc, SESSION_POOL_REUSE_PARALLELISM).await;
 
-    let after_first_wave = qc.session_pool_stats().expect("explicit session pool configured");
+    let after_first_wave = qc
+        .session_pool_stats()
+        .expect("explicit session pool configured");
     assert_eq!(
-        after_first_wave.sessions_created,
-        SESSION_POOL_REUSE_PARALLELISM as u64,
+        after_first_wave.sessions_created, SESSION_POOL_REUSE_PARALLELISM as u64,
         "first wave should create one session per concurrent query, stats: {after_first_wave:?}"
     );
     assert!(
@@ -281,10 +282,11 @@ async fn query_session_pool_reuses_sessions_under_parallel_load() -> YdbResult<(
     run_parallel_query_rows(&qc, SESSION_POOL_REUSE_PARALLELISM).await?;
     wait_explicit_pool_idle(&qc, SESSION_POOL_REUSE_PARALLELISM).await;
 
-    let after_second_wave = qc.session_pool_stats().expect("explicit session pool configured");
+    let after_second_wave = qc
+        .session_pool_stats()
+        .expect("explicit session pool configured");
     assert_eq!(
-        after_second_wave.sessions_created,
-        SESSION_POOL_REUSE_PARALLELISM as u64,
+        after_second_wave.sessions_created, SESSION_POOL_REUSE_PARALLELISM as u64,
         "second wave must reuse idle sessions without CreateSession, stats: {after_second_wave:?}"
     );
     assert!(

--- a/ydb/src/grpc_wrapper/raw_query_service/session.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/session.rs
@@ -222,6 +222,35 @@ impl AttachedQuerySession {
     }
 }
 
+#[cfg(test)]
+impl AttachedQuerySession {
+    /// In-memory session for pool benchmarks: no CreateSession, AttachStream, or DeleteSession.
+    pub(crate) fn new_bench_stub(session_id: String, node_uri: Uri) -> Self {
+        Self {
+            inner: Arc::new(AttachedQuerySessionInner {
+                session_id,
+                node_uri,
+                in_use: AtomicUsize::new(0),
+                alive: AtomicBool::new(true),
+                attach_task: Mutex::new(None),
+                explicitly_closed: AtomicBool::new(false),
+                on_node_shutdown: Arc::new(|_| {}),
+                delete_timeout: Duration::ZERO,
+                not_in_use: Notify::new(),
+            }),
+        }
+    }
+
+    pub(crate) fn bench_invalidate(&self) {
+        self.inner.alive.store(false, Ordering::Release);
+    }
+
+    pub(crate) fn bench_close(self) {
+        self.inner.explicitly_closed.store(true, Ordering::Release);
+        self.inner.alive.store(false, Ordering::Release);
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ShutdownHint {
     SessionShutdown,


### PR DESCRIPTION
## Summary
- Adds `sessions_created` to `QuerySessionPoolStats` (counts successful CreateSession+Attach in explicit pool).
- Adds integration test `query_session_pool_reuses_sessions_under_parallel_load`: two waves of 100 concurrent `query_row` calls against a pool with `limit=100`, `warm_up=0`.
- Adds **pool microbenchmark** `query_session_pool_bench` with in-memory stub sessions (no CreateSession / AttachStream / DeleteSession RPC), mirroring go-sdk `internal/pool/pool_test.go` `BenchmarkPoolWith`.

## Result
Locally against `grpc://localhost:2136/local` the reuse test **passes**: first wave creates 100 sessions, second wave reuses them (`sessions_created` stays 100). No pool reuse bug found in the steady-state path.

Pool bench (release, stub sessions) shows p50 ~800ns–1µs at concurrency 250–1000 — same order of magnitude as go-sdk pool bench (~959ns p50). Pool synchronization is **not** the SLO bottleneck.

## Test plan
- [x] `YDB_CONNECTION_STRING=grpc://localhost:2136/local cargo test -p ydb query_session_pool_reuses_sessions_under_parallel_load -- --ignored`
- [x] `cargo test -p ydb query_session_pool_bench --release -- --ignored --nocapture`
- [ ] CI integration job (if configured)