### PR TITLE
test(slo): no rate limiter control (PR B)

### DIFF
--- a/tests/slo/slo-framework/src/helpers.rs
+++ b/tests/slo/slo-framework/src/helpers.rs
@@ -44,6 +44,28 @@ pub async fn run_workers<F, Fut>(
     }
 }
 
+/// Workers fire operations as fast as the SDK allows (no shared rate limiter).
+pub async fn run_workers_unlimited<F, Fut>(ctx: &CancellationToken, workers: usize, f: F)
+where
+    F: Fn() -> Fut + Clone + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send,
+{
+    let mut handles = Vec::with_capacity(workers);
+    for _ in 0..workers {
+        let ctx = ctx.clone();
+        let f = f.clone();
+        handles.push(tokio::spawn(async move {
+            while !ctx.is_cancelled() {
+                f().await;
+            }
+        }));
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/slo/slo-framework/src/kv/params.rs
+++ b/tests/slo/slo-framework/src/kv/params.rs
@@ -23,6 +23,9 @@ pub struct KvFlags {
     pub min_partition_count: u64,
     #[arg(long, default_value_t = 1000)]
     pub max_partition_count: u64,
+    /// Skip shared rate limiter; workers run ops as fast as the SDK allows.
+    #[arg(long, default_value_t = true)]
+    pub no_rate_limit: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -36,6 +39,7 @@ pub struct Params {
     pub partition_size: u64,
     pub min_partition_count: u64,
     pub max_partition_count: u64,
+    pub no_rate_limit: bool,
 }
 
 impl Params {
@@ -63,5 +67,6 @@ pub fn parse_params(fw: &Framework) -> Params {
         partition_size: flags.partition_size,
         min_partition_count: flags.min_partition_count,
         max_partition_count: flags.max_partition_count,
+        no_rate_limit: flags.no_rate_limit,
     }
 }

--- a/tests/slo/slo-framework/src/kv/workload.rs
+++ b/tests/slo/slo-framework/src/kv/workload.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::framework::Workload;
 use crate::generator::Generator;
-use crate::helpers::{new_rate_limiter, run_workers};
+use crate::helpers::{new_rate_limiter, run_workers, run_workers_unlimited};
 use crate::metrics::{OPERATION_READ, OPERATION_WRITE};
 use crate::Framework;
 
@@ -55,10 +55,11 @@ impl<D: Database + 'static> Workload for KvWorkload<D> {
 
     async fn run(&self, ctx: &CancellationToken) -> Result<(), String> {
         let run_gen = Generator::new(self.params.prefill_count);
-        let read_limiter = new_rate_limiter(self.params.read_rps);
-        let write_limiter = new_rate_limiter(self.params.write_rps);
         let read_workers = self.params.read_rps as usize;
         let write_workers = self.params.write_rps as usize;
+        let read_rps = self.params.read_rps;
+        let write_rps = self.params.write_rps;
+        let no_rate_limit = self.params.no_rate_limit;
 
         let read_handle = {
             let ctx = ctx.clone();
@@ -69,7 +70,7 @@ impl<D: Database + 'static> Workload for KvWorkload<D> {
             let read_timeout = self.params.read_timeout;
 
             tokio::spawn(async move {
-                run_workers(&ctx, read_workers, read_limiter, move || {
+                let read_worker = move || {
                     let worker_ctx = worker_ctx.clone();
                     let db = db.clone();
                     let metrics = fw.metrics.clone();
@@ -97,8 +98,14 @@ impl<D: Database + 'static> Workload for KvWorkload<D> {
                             }
                         }
                     }
-                })
-                .await;
+                };
+
+                if no_rate_limit {
+                    run_workers_unlimited(&ctx, read_workers, read_worker).await;
+                } else {
+                    let read_limiter = new_rate_limiter(read_rps);
+                    run_workers(&ctx, read_workers, read_limiter, read_worker).await;
+                }
             })
         };
 
@@ -110,7 +117,7 @@ impl<D: Database + 'static> Workload for KvWorkload<D> {
             let write_timeout = self.params.write_timeout;
 
             tokio::spawn(async move {
-                run_workers(&ctx, write_workers, write_limiter, move || {
+                let write_worker = move || {
                     let worker_ctx = worker_ctx.clone();
                     let db = db.clone();
                     let gen = run_gen.clone();
@@ -139,8 +146,14 @@ impl<D: Database + 'static> Workload for KvWorkload<D> {
                             }
                         }
                     }
-                })
-                .await;
+                };
+
+                if no_rate_limit {
+                    run_workers_unlimited(&ctx, write_workers, write_worker).await;
+                } else {
+                    let write_limiter = new_rate_limiter(write_rps);
+                    run_workers(&ctx, write_workers, write_limiter, write_worker).await;
+                }
             })
         };
 


### PR DESCRIPTION
## Summary
- Add `--no-rate-limit` flag (default **true** on this branch) to skip shared rate limiter.
- Add `run_workers_unlimited`: 1000 read + 100 write workers fire ops as fast as SDK allows.

## Hypothesis
If rate limiter is the bottleneck, throughput should jump toward ~1000 read ops/s. If unchanged (~400–500), limiter is not binding and SDK latency is the root cause.

## Test plan
- [ ] Add `SLO` label to run ydb-slo-action
- [ ] Compare read/write throughput and P50 vs master baseline (~400 read ops/s, ~1.8s P50)
- [ ] Expect no significant improvement → confirms limiter is not root cause


Made with [Cursor](https://cursor.com)