### PR TITLE
Enable concurrent result sets for materialized query calls

### DIFF
--- a/ydb/src/client_query/builders.rs
+++ b/ydb/src/client_query/builders.rs
@@ -140,15 +140,6 @@ impl<'a, K> CallBuilder<'a, K> {
     pub fn pooled_session(self) -> Self {
         self.session_mode(QuerySessionMode::Pool)
     }
-
-    /// Deprecated: has no effect. Materialized query methods (`exec`, `query_row`, `query_result_set`)
-    /// always enable concurrent result sets internally.
-    #[deprecated(
-        note = "with_concurrent_result_sets has no effect; materialized query methods always enable concurrent result sets internally"
-    )]
-    pub fn with_concurrent_result_sets(self, _enabled: bool) -> Self {
-        self
-    }
 }
 
 impl<'a, T> CallBuilder<'a, OneRow<T>> {

--- a/ydb/src/client_query/builders.rs
+++ b/ydb/src/client_query/builders.rs
@@ -140,6 +140,15 @@ impl<'a, K> CallBuilder<'a, K> {
     pub fn pooled_session(self) -> Self {
         self.session_mode(QuerySessionMode::Pool)
     }
+
+    /// Deprecated: has no effect. Materialized query methods (`exec`, `query_row`, `query_result_set`)
+    /// always enable concurrent result sets internally.
+    #[deprecated(
+        note = "with_concurrent_result_sets has no effect; materialized query methods always enable concurrent result sets internally"
+    )]
+    pub fn with_concurrent_result_sets(self, _enabled: bool) -> Self {
+        self
+    }
 }
 
 impl<'a, T> CallBuilder<'a, OneRow<T>> {

--- a/ydb/src/client_query/builders.rs
+++ b/ydb/src/client_query/builders.rs
@@ -236,7 +236,7 @@ impl<'a> IntoFuture for CallBuilder<'a, Streamed> {
             let commit_tx = resolve_commit_tx(&self.core, &self.opts);
             let stream = self
                 .core
-                .begin_stream(self.text, self.params, self.opts)
+                .begin_stream(self.text, self.params, self.opts, false)
                 .await?;
             Ok(QueryStream {
                 core: self.core,

--- a/ydb/src/client_query/concurrent_result_sets_test.rs
+++ b/ydb/src/client_query/concurrent_result_sets_test.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
+
+use super::exec::{build_client_execute_request_for_test, CallOptions};
+
+fn sample_request() -> RawExecuteQueryRequest {
+    RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false)
+}
+
+#[test]
+fn new_execute_request_defaults_concurrent_result_sets_to_false() {
+    let req = sample_request();
+    assert!(!req.concurrent_result_sets);
+    let proto = req.into_proto().expect("valid proto");
+    assert!(!proto.concurrent_result_sets);
+}
+
+#[test]
+fn finish_execute_request_sets_concurrent_result_sets_on_request_and_proto() {
+    for want in [true, false] {
+        let req = build_client_execute_request_for_test(&CallOptions::default(), want);
+        assert_eq!(req.concurrent_result_sets, want);
+        let proto = req.into_proto().expect("valid proto");
+        assert_eq!(proto.concurrent_result_sets, want);
+    }
+}
+
+/// Materialized client calls (`exec`, `query_row`, `query_result_set`) pass `true`.
+#[test]
+fn materialized_client_query_sets_concurrent_result_sets() {
+    let req = build_client_execute_request_for_test(&CallOptions::default(), true);
+    assert!(req.concurrent_result_sets);
+    let proto = req.into_proto().expect("valid proto");
+    assert!(proto.concurrent_result_sets);
+}
+
+/// Streaming [`QueryExecutor::query`] passes `false`.
+#[test]
+fn streaming_client_query_clears_concurrent_result_sets() {
+    let req = build_client_execute_request_for_test(&CallOptions::default(), false);
+    assert!(!req.concurrent_result_sets);
+    let proto = req.into_proto().expect("valid proto");
+    assert!(!proto.concurrent_result_sets);
+}

--- a/ydb/src/client_query/concurrent_result_sets_test.rs
+++ b/ydb/src/client_query/concurrent_result_sets_test.rs
@@ -13,7 +13,7 @@ fn new_execute_request_defaults_concurrent_result_sets_to_false() {
 }
 
 #[test]
-fn finish_execute_request_sets_concurrent_result_sets_on_request_and_proto() {
+fn build_execute_request_sets_concurrent_result_sets_on_request_and_proto() {
     for want in [true, false] {
         let req = build_client_execute_request_for_test(&CallOptions::default(), want);
         assert_eq!(req.concurrent_result_sets, want);

--- a/ydb/src/client_query/concurrent_result_sets_test.rs
+++ b/ydb/src/client_query/concurrent_result_sets_test.rs
@@ -4,13 +4,9 @@ use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryReques
 
 use super::exec::{build_client_execute_request_for_test, CallOptions};
 
-fn sample_request() -> RawExecuteQueryRequest {
-    RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false)
-}
-
 #[test]
 fn new_execute_request_defaults_concurrent_result_sets_to_false() {
-    let req = sample_request();
+    let req = RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false);
     assert!(!req.concurrent_result_sets);
     let proto = req.into_proto().expect("valid proto");
     assert!(!proto.concurrent_result_sets);
@@ -24,22 +20,4 @@ fn finish_execute_request_sets_concurrent_result_sets_on_request_and_proto() {
         let proto = req.into_proto().expect("valid proto");
         assert_eq!(proto.concurrent_result_sets, want);
     }
-}
-
-/// Materialized client calls (`exec`, `query_row`, `query_result_set`) pass `true`.
-#[test]
-fn materialized_client_query_sets_concurrent_result_sets() {
-    let req = build_client_execute_request_for_test(&CallOptions::default(), true);
-    assert!(req.concurrent_result_sets);
-    let proto = req.into_proto().expect("valid proto");
-    assert!(proto.concurrent_result_sets);
-}
-
-/// Streaming [`QueryExecutor::query`] passes `false`.
-#[test]
-fn streaming_client_query_clears_concurrent_result_sets() {
-    let req = build_client_execute_request_for_test(&CallOptions::default(), false);
-    assert!(!req.concurrent_result_sets);
-    let proto = req.into_proto().expect("valid proto");
-    assert!(!proto.concurrent_result_sets);
 }

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -41,6 +41,8 @@ pub(crate) struct CallOptions {
     /// Per-call isolation override. `None` → [`QueryTxMode::Implicit`] on client,
     /// [`TransactionExecContext::tx_mode`] in interactive transactions.
     pub tx_mode: Option<QueryTxMode>,
+    /// When true, YDB may deliver result set parts out of order (faster for multi-statement queries).
+    pub(crate) concurrent_result_sets: bool,
 }
 
 #[derive(Clone)]
@@ -288,6 +290,14 @@ fn tx_control_for_client(
     Some(begin_tx_control(tx_mode_to_raw(mode), commit_tx))
 }
 
+fn finish_execute_request(
+    mut req: RawExecuteQueryRequest,
+    opts: &CallOptions,
+) -> RawExecuteQueryRequest {
+    req.concurrent_result_sets = opts.concurrent_result_sets;
+    req
+}
+
 async fn client_implicit_request(
     ctx: &ClientExecContext,
     text: &str,
@@ -297,12 +307,15 @@ async fn client_implicit_request(
     let mode = effective_session_mode(ctx.session_mode, opts);
     let session_id = session_id_for_mode(mode)?;
     let client = query_client(ctx).await?;
-    let req = RawExecuteQueryRequest::new(
-        session_id,
-        text,
-        params.clone(),
-        tx_control_for_client(opts),
-        opts.collect_stats,
+    let req = finish_execute_request(
+        RawExecuteQueryRequest::new(
+            session_id,
+            text,
+            params.clone(),
+            tx_control_for_client(opts),
+            opts.collect_stats,
+        ),
+        opts,
     );
     Ok((client, req))
 }
@@ -321,12 +334,15 @@ async fn client_pooled_explicit_request(
         .connection_manager
         .get_auth_service_to_node(RawQueryClient::new, &node_uri)
         .await?;
-    let req = RawExecuteQueryRequest::new(
-        lease.session_id(),
-        text,
-        params.clone(),
-        tx_control_for_client(opts),
-        opts.collect_stats,
+    let req = finish_execute_request(
+        RawExecuteQueryRequest::new(
+            lease.session_id(),
+            text,
+            params.clone(),
+            tx_control_for_client(opts),
+            opts.collect_stats,
+        ),
+        opts,
     );
     Ok((client, req))
 }
@@ -340,12 +356,15 @@ async fn client_pooled_implicit_request(
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
     lease.begin_use();
     let client = query_client(ctx).await?;
-    let req = RawExecuteQueryRequest::new(
-        lease.session_id(),
-        text,
-        params.clone(),
-        tx_control_for_client(opts),
-        opts.collect_stats,
+    let req = finish_execute_request(
+        RawExecuteQueryRequest::new(
+            lease.session_id(),
+            text,
+            params.clone(),
+            tx_control_for_client(opts),
+            opts.collect_stats,
+        ),
+        opts,
     );
     Ok((client, req))
 }
@@ -492,12 +511,15 @@ async fn transaction_execute_request(
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
     let session_id = tx_session_id(tx)?.to_string();
     let client = query_client_from_tx(tx).await?;
-    let req = RawExecuteQueryRequest::new(
-        session_id,
-        yql_text,
-        parameters,
-        tx_control_for_transaction(tx, opts)?,
-        opts.collect_stats,
+    let req = finish_execute_request(
+        RawExecuteQueryRequest::new(
+            session_id,
+            yql_text,
+            parameters,
+            tx_control_for_transaction(tx, opts)?,
+            opts.collect_stats,
+        ),
+        opts,
     );
     Ok((client, req))
 }

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -43,42 +43,6 @@ pub(crate) struct CallOptions {
     pub tx_mode: Option<QueryTxMode>,
 }
 
-/// Wraps [`CallOptions`] and forces `concurrent_result_sets=true` for materialized queries.
-pub(crate) struct CallOptionsWithConcurrentResultSets<'a> {
-    inner: &'a CallOptions,
-}
-
-impl<'a> CallOptionsWithConcurrentResultSets<'a> {
-    pub(crate) fn wrap(inner: &'a CallOptions) -> Self {
-        Self { inner }
-    }
-
-    pub(crate) fn concurrent_result_sets(&self) -> bool {
-        true
-    }
-}
-
-pub(crate) enum ExecuteQueryCallOptions<'a> {
-    Sequential(&'a CallOptions),
-    Concurrent(CallOptionsWithConcurrentResultSets<'a>),
-}
-
-impl ExecuteQueryCallOptions<'_> {
-    fn inner(&self) -> &CallOptions {
-        match self {
-            Self::Sequential(opts) => opts,
-            Self::Concurrent(wrapper) => wrapper.inner,
-        }
-    }
-
-    fn concurrent_result_sets(&self) -> bool {
-        match self {
-            Self::Sequential(_) => false,
-            Self::Concurrent(wrapper) => wrapper.concurrent_result_sets(),
-        }
-    }
-}
-
 #[derive(Clone)]
 pub(crate) struct ClientExecContext {
     pub connection_manager: GrpcConnectionManager,
@@ -326,9 +290,9 @@ fn tx_control_for_client(
 
 fn finish_execute_request(
     mut req: RawExecuteQueryRequest,
-    execute_opts: ExecuteQueryCallOptions<'_>,
+    concurrent_result_sets: bool,
 ) -> RawExecuteQueryRequest {
-    req.concurrent_result_sets = execute_opts.concurrent_result_sets();
+    req.concurrent_result_sets = concurrent_result_sets;
     req
 }
 
@@ -336,9 +300,9 @@ async fn client_implicit_request(
     ctx: &ClientExecContext,
     text: &str,
     params: &HashMap<String, Value>,
-    execute_opts: ExecuteQueryCallOptions<'_>,
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
-    let opts = execute_opts.inner();
     let mode = effective_session_mode(ctx.session_mode, opts);
     let session_id = session_id_for_mode(mode)?;
     let client = query_client(ctx).await?;
@@ -350,7 +314,7 @@ async fn client_implicit_request(
             tx_control_for_client(opts),
             opts.collect_stats,
         ),
-        execute_opts,
+        concurrent_result_sets,
     );
     Ok((client, req))
 }
@@ -360,9 +324,9 @@ async fn client_pooled_explicit_request(
     lease: &mut QuerySessionLease,
     text: &str,
     params: &HashMap<String, Value>,
-    execute_opts: ExecuteQueryCallOptions<'_>,
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
-    let opts = execute_opts.inner();
     lease.ensure_alive()?;
     lease.begin_use();
     let node_uri = lease.node_uri().clone();
@@ -378,7 +342,7 @@ async fn client_pooled_explicit_request(
             tx_control_for_client(opts),
             opts.collect_stats,
         ),
-        execute_opts,
+        concurrent_result_sets,
     );
     Ok((client, req))
 }
@@ -388,9 +352,9 @@ async fn client_pooled_implicit_request(
     lease: &mut ImplicitSessionLease,
     text: &str,
     params: &HashMap<String, Value>,
-    execute_opts: ExecuteQueryCallOptions<'_>,
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
-    let opts = execute_opts.inner();
     lease.begin_use();
     let client = query_client(ctx).await?;
     let req = finish_execute_request(
@@ -401,7 +365,7 @@ async fn client_pooled_implicit_request(
             tx_control_for_client(opts),
             opts.collect_stats,
         ),
-        execute_opts,
+        concurrent_result_sets,
     );
     Ok((client, req))
 }
@@ -410,9 +374,9 @@ async fn client_begin_stream_once(
     ctx: &ClientExecContext,
     text: &str,
     params: &HashMap<String, Value>,
-    execute_opts: ExecuteQueryCallOptions<'_>,
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
 ) -> YdbResult<ExecuteQueryStream> {
-    let opts = execute_opts.inner();
     let mode = effective_session_mode(ctx.session_mode, opts);
     let timeout_duration = operation_timeout(opts, &ctx.timeouts);
 
@@ -431,7 +395,8 @@ async fn client_begin_stream_once(
                     &mut lease,
                     text,
                     params,
-                    execute_opts,
+                    opts,
+                    concurrent_result_sets,
                 )
                 .await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
@@ -445,15 +410,22 @@ async fn client_begin_stream_once(
                     &mut lease,
                     text,
                     params,
-                    execute_opts,
+                    opts,
+                    concurrent_result_sets,
                 )
                 .await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
                 Ok(ExecuteQueryStream::new(stream).with_session_guard(lease))
             }
             QuerySessionMode::Implicit => {
-                let (mut client, req) =
-                    client_implicit_request(ctx, text, params, execute_opts).await?;
+                let (mut client, req) = client_implicit_request(
+                    ctx,
+                    text,
+                    params,
+                    opts,
+                    concurrent_result_sets,
+                )
+                .await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
                 Ok(ExecuteQueryStream::new(stream))
             }
@@ -467,33 +439,11 @@ pub(crate) async fn client_begin_stream(
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
+    concurrent_result_sets: bool,
 ) -> YdbResult<ExecuteQueryStream> {
     let idempotent = opts.idempotent.unwrap_or(ctx.idempotent_operation);
     retry_with_budget(idempotent, ctx.retry_budget, || {
-        client_begin_stream_once(
-            ctx,
-            &text,
-            &params,
-            ExecuteQueryCallOptions::Sequential(&opts),
-        )
-    })
-    .await
-}
-
-pub(crate) async fn client_begin_materialized_stream(
-    ctx: &ClientExecContext,
-    text: String,
-    params: HashMap<String, Value>,
-    opts: CallOptions,
-) -> YdbResult<ExecuteQueryStream> {
-    let idempotent = opts.idempotent.unwrap_or(ctx.idempotent_operation);
-    retry_with_budget(idempotent, ctx.retry_budget, || {
-        client_begin_stream_once(
-            ctx,
-            &text,
-            &params,
-            ExecuteQueryCallOptions::Concurrent(CallOptionsWithConcurrentResultSets::wrap(&opts)),
-        )
+        client_begin_stream_once(ctx, &text, &params, &opts, concurrent_result_sets)
     })
     .await
 }
@@ -581,9 +531,9 @@ async fn transaction_execute_request(
     tx: &TransactionExecContext,
     yql_text: String,
     parameters: HashMap<String, Value>,
-    execute_opts: ExecuteQueryCallOptions<'_>,
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
-    let opts = execute_opts.inner();
     let session_id = tx_session_id(tx)?.to_string();
     let client = query_client_from_tx(tx).await?;
     let req = finish_execute_request(
@@ -594,7 +544,7 @@ async fn transaction_execute_request(
             tx_control_for_transaction(tx, opts)?,
             opts.collect_stats,
         ),
-        execute_opts,
+        concurrent_result_sets,
     );
     Ok((client, req))
 }
@@ -642,25 +592,7 @@ pub(crate) async fn transaction_begin_stream(
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
-) -> YdbResult<ExecuteQueryStream> {
-    transaction_begin_stream_inner(tx, text, params, opts, false).await
-}
-
-pub(crate) async fn transaction_begin_materialized_stream(
-    tx: &mut TransactionExecContext,
-    text: String,
-    params: HashMap<String, Value>,
-    opts: CallOptions,
-) -> YdbResult<ExecuteQueryStream> {
-    transaction_begin_stream_inner(tx, text, params, opts, true).await
-}
-
-async fn transaction_begin_stream_inner(
-    tx: &mut TransactionExecContext,
-    text: String,
-    params: HashMap<String, Value>,
-    opts: CallOptions,
-    materialized: bool,
+    concurrent_result_sets: bool,
 ) -> YdbResult<ExecuteQueryStream> {
     if tx.finished {
         return Err(YdbError::Custom(
@@ -668,11 +600,6 @@ async fn transaction_begin_stream_inner(
         ));
     }
     let timeout_duration = operation_timeout(&opts, &tx.timeouts);
-    let execute_opts = if materialized {
-        ExecuteQueryCallOptions::Concurrent(CallOptionsWithConcurrentResultSets::wrap(&opts))
-    } else {
-        ExecuteQueryCallOptions::Sequential(&opts)
-    };
     let result: YdbResult<ExecuteQueryStream> = with_operation_timeout(timeout_duration, async {
         ensure_tx_session(tx).await?;
         if let Some(lease) = &mut tx.pooled_lease {
@@ -682,7 +609,7 @@ async fn transaction_begin_stream_inner(
             transaction_ensure_begin(tx, true).await?;
         }
         let (mut client, req) =
-            transaction_execute_request(tx, text, params, execute_opts).await?;
+            transaction_execute_request(tx, text, params, &opts, concurrent_result_sets).await?;
         let stream = client.execute_query(req).await.map_err(YdbError::from)?;
         let mut stream = ExecuteQueryStream::new(stream);
         stream.prime_first_part().await?;
@@ -845,6 +772,23 @@ pub(crate) fn retry_wait(
 }
 
 pub(crate) const DEFAULT_QUERY_RETRY_BUDGET: Duration = DEFAULT_RETRY_BUDGET;
+
+#[cfg(test)]
+pub(super) fn build_client_execute_request_for_test(
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
+) -> RawExecuteQueryRequest {
+    finish_execute_request(
+        RawExecuteQueryRequest::new(
+            String::new(),
+            "SELECT 1".to_string(),
+            HashMap::new(),
+            tx_control_for_client(opts),
+            opts.collect_stats,
+        ),
+        concurrent_result_sets,
+    )
+}
 
 #[cfg(test)]
 mod unit_tests {

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -288,14 +288,6 @@ fn tx_control_for_client(
     Some(begin_tx_control(tx_mode_to_raw(mode), commit_tx))
 }
 
-fn finish_execute_request(
-    mut req: RawExecuteQueryRequest,
-    concurrent_result_sets: bool,
-) -> RawExecuteQueryRequest {
-    req.concurrent_result_sets = concurrent_result_sets;
-    req
-}
-
 async fn client_implicit_request(
     ctx: &ClientExecContext,
     text: &str,
@@ -306,16 +298,14 @@ async fn client_implicit_request(
     let mode = effective_session_mode(ctx.session_mode, opts);
     let session_id = session_id_for_mode(mode)?;
     let client = query_client(ctx).await?;
-    let req = finish_execute_request(
-        RawExecuteQueryRequest::new(
-            session_id,
-            text,
-            params.clone(),
-            tx_control_for_client(opts),
-            opts.collect_stats,
-        ),
-        concurrent_result_sets,
+    let mut req = RawExecuteQueryRequest::new(
+        session_id,
+        text,
+        params.clone(),
+        tx_control_for_client(opts),
+        opts.collect_stats,
     );
+    req.concurrent_result_sets = concurrent_result_sets;
     Ok((client, req))
 }
 
@@ -334,16 +324,14 @@ async fn client_pooled_explicit_request(
         .connection_manager
         .get_auth_service_to_node(RawQueryClient::new, &node_uri)
         .await?;
-    let req = finish_execute_request(
-        RawExecuteQueryRequest::new(
-            lease.session_id(),
-            text,
-            params.clone(),
-            tx_control_for_client(opts),
-            opts.collect_stats,
-        ),
-        concurrent_result_sets,
+    let mut req = RawExecuteQueryRequest::new(
+        lease.session_id(),
+        text,
+        params.clone(),
+        tx_control_for_client(opts),
+        opts.collect_stats,
     );
+    req.concurrent_result_sets = concurrent_result_sets;
     Ok((client, req))
 }
 
@@ -357,16 +345,14 @@ async fn client_pooled_implicit_request(
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
     lease.begin_use();
     let client = query_client(ctx).await?;
-    let req = finish_execute_request(
-        RawExecuteQueryRequest::new(
-            lease.session_id(),
-            text,
-            params.clone(),
-            tx_control_for_client(opts),
-            opts.collect_stats,
-        ),
-        concurrent_result_sets,
+    let mut req = RawExecuteQueryRequest::new(
+        lease.session_id(),
+        text,
+        params.clone(),
+        tx_control_for_client(opts),
+        opts.collect_stats,
     );
+    req.concurrent_result_sets = concurrent_result_sets;
     Ok((client, req))
 }
 
@@ -531,16 +517,14 @@ async fn transaction_execute_request(
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
     let session_id = tx_session_id(tx)?.to_string();
     let client = query_client_from_tx(tx).await?;
-    let req = finish_execute_request(
-        RawExecuteQueryRequest::new(
-            session_id,
-            yql_text,
-            parameters,
-            tx_control_for_transaction(tx, opts)?,
-            opts.collect_stats,
-        ),
-        concurrent_result_sets,
+    let mut req = RawExecuteQueryRequest::new(
+        session_id,
+        yql_text,
+        parameters,
+        tx_control_for_transaction(tx, opts)?,
+        opts.collect_stats,
     );
+    req.concurrent_result_sets = concurrent_result_sets;
     Ok((client, req))
 }
 
@@ -773,16 +757,15 @@ pub(super) fn build_client_execute_request_for_test(
     opts: &CallOptions,
     concurrent_result_sets: bool,
 ) -> RawExecuteQueryRequest {
-    finish_execute_request(
-        RawExecuteQueryRequest::new(
-            String::new(),
-            "SELECT 1".to_string(),
-            HashMap::new(),
-            tx_control_for_client(opts),
-            opts.collect_stats,
-        ),
-        concurrent_result_sets,
-    )
+    let mut req = RawExecuteQueryRequest::new(
+        String::new(),
+        "SELECT 1".to_string(),
+        HashMap::new(),
+        tx_control_for_client(opts),
+        opts.collect_stats,
+    );
+    req.concurrent_result_sets = concurrent_result_sets;
+    req
 }
 
 #[cfg(test)]

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -41,8 +41,42 @@ pub(crate) struct CallOptions {
     /// Per-call isolation override. `None` → [`QueryTxMode::Implicit`] on client,
     /// [`TransactionExecContext::tx_mode`] in interactive transactions.
     pub tx_mode: Option<QueryTxMode>,
-    /// When true, YDB may deliver result set parts out of order (faster for multi-statement queries).
-    pub(crate) concurrent_result_sets: bool,
+}
+
+/// Wraps [`CallOptions`] and forces `concurrent_result_sets=true` for materialized queries.
+pub(crate) struct CallOptionsWithConcurrentResultSets<'a> {
+    inner: &'a CallOptions,
+}
+
+impl<'a> CallOptionsWithConcurrentResultSets<'a> {
+    pub(crate) fn wrap(inner: &'a CallOptions) -> Self {
+        Self { inner }
+    }
+
+    pub(crate) fn concurrent_result_sets(&self) -> bool {
+        true
+    }
+}
+
+pub(crate) enum ExecuteQueryCallOptions<'a> {
+    Sequential(&'a CallOptions),
+    Concurrent(CallOptionsWithConcurrentResultSets<'a>),
+}
+
+impl ExecuteQueryCallOptions<'_> {
+    fn inner(&self) -> &CallOptions {
+        match self {
+            Self::Sequential(opts) => opts,
+            Self::Concurrent(wrapper) => wrapper.inner,
+        }
+    }
+
+    fn concurrent_result_sets(&self) -> bool {
+        match self {
+            Self::Sequential(_) => false,
+            Self::Concurrent(wrapper) => wrapper.concurrent_result_sets(),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -292,9 +326,9 @@ fn tx_control_for_client(
 
 fn finish_execute_request(
     mut req: RawExecuteQueryRequest,
-    opts: &CallOptions,
+    execute_opts: ExecuteQueryCallOptions<'_>,
 ) -> RawExecuteQueryRequest {
-    req.concurrent_result_sets = opts.concurrent_result_sets;
+    req.concurrent_result_sets = execute_opts.concurrent_result_sets();
     req
 }
 
@@ -302,8 +336,9 @@ async fn client_implicit_request(
     ctx: &ClientExecContext,
     text: &str,
     params: &HashMap<String, Value>,
-    opts: &CallOptions,
+    execute_opts: ExecuteQueryCallOptions<'_>,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
+    let opts = execute_opts.inner();
     let mode = effective_session_mode(ctx.session_mode, opts);
     let session_id = session_id_for_mode(mode)?;
     let client = query_client(ctx).await?;
@@ -315,7 +350,7 @@ async fn client_implicit_request(
             tx_control_for_client(opts),
             opts.collect_stats,
         ),
-        opts,
+        execute_opts,
     );
     Ok((client, req))
 }
@@ -325,8 +360,9 @@ async fn client_pooled_explicit_request(
     lease: &mut QuerySessionLease,
     text: &str,
     params: &HashMap<String, Value>,
-    opts: &CallOptions,
+    execute_opts: ExecuteQueryCallOptions<'_>,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
+    let opts = execute_opts.inner();
     lease.ensure_alive()?;
     lease.begin_use();
     let node_uri = lease.node_uri().clone();
@@ -342,7 +378,7 @@ async fn client_pooled_explicit_request(
             tx_control_for_client(opts),
             opts.collect_stats,
         ),
-        opts,
+        execute_opts,
     );
     Ok((client, req))
 }
@@ -352,8 +388,9 @@ async fn client_pooled_implicit_request(
     lease: &mut ImplicitSessionLease,
     text: &str,
     params: &HashMap<String, Value>,
-    opts: &CallOptions,
+    execute_opts: ExecuteQueryCallOptions<'_>,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
+    let opts = execute_opts.inner();
     lease.begin_use();
     let client = query_client(ctx).await?;
     let req = finish_execute_request(
@@ -364,7 +401,7 @@ async fn client_pooled_implicit_request(
             tx_control_for_client(opts),
             opts.collect_stats,
         ),
-        opts,
+        execute_opts,
     );
     Ok((client, req))
 }
@@ -373,8 +410,9 @@ async fn client_begin_stream_once(
     ctx: &ClientExecContext,
     text: &str,
     params: &HashMap<String, Value>,
-    opts: &CallOptions,
+    execute_opts: ExecuteQueryCallOptions<'_>,
 ) -> YdbResult<ExecuteQueryStream> {
+    let opts = execute_opts.inner();
     let mode = effective_session_mode(ctx.session_mode, opts);
     let timeout_duration = operation_timeout(opts, &ctx.timeouts);
 
@@ -388,21 +426,34 @@ async fn client_begin_stream_once(
                     )
                 })?;
                 let mut lease = pool.acquire_explicit().await?;
-                let (mut client, req) =
-                    client_pooled_explicit_request(ctx, &mut lease, text, params, opts).await?;
+                let (mut client, req) = client_pooled_explicit_request(
+                    ctx,
+                    &mut lease,
+                    text,
+                    params,
+                    execute_opts,
+                )
+                .await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
                 Ok(ExecuteQueryStream::new(stream).with_session_guard(lease))
             }
             QuerySessionMode::Implicit if ctx.implicit_session_pool.is_some() => {
                 let pool = ctx.implicit_session_pool.as_ref().expect("checked");
                 let mut lease = pool.acquire_implicit().await?;
-                let (mut client, req) =
-                    client_pooled_implicit_request(ctx, &mut lease, text, params, opts).await?;
+                let (mut client, req) = client_pooled_implicit_request(
+                    ctx,
+                    &mut lease,
+                    text,
+                    params,
+                    execute_opts,
+                )
+                .await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
                 Ok(ExecuteQueryStream::new(stream).with_session_guard(lease))
             }
             QuerySessionMode::Implicit => {
-                let (mut client, req) = client_implicit_request(ctx, text, params, opts).await?;
+                let (mut client, req) =
+                    client_implicit_request(ctx, text, params, execute_opts).await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
                 Ok(ExecuteQueryStream::new(stream))
             }
@@ -419,7 +470,30 @@ pub(crate) async fn client_begin_stream(
 ) -> YdbResult<ExecuteQueryStream> {
     let idempotent = opts.idempotent.unwrap_or(ctx.idempotent_operation);
     retry_with_budget(idempotent, ctx.retry_budget, || {
-        client_begin_stream_once(ctx, &text, &params, &opts)
+        client_begin_stream_once(
+            ctx,
+            &text,
+            &params,
+            ExecuteQueryCallOptions::Sequential(&opts),
+        )
+    })
+    .await
+}
+
+pub(crate) async fn client_begin_materialized_stream(
+    ctx: &ClientExecContext,
+    text: String,
+    params: HashMap<String, Value>,
+    opts: CallOptions,
+) -> YdbResult<ExecuteQueryStream> {
+    let idempotent = opts.idempotent.unwrap_or(ctx.idempotent_operation);
+    retry_with_budget(idempotent, ctx.retry_budget, || {
+        client_begin_stream_once(
+            ctx,
+            &text,
+            &params,
+            ExecuteQueryCallOptions::Concurrent(CallOptionsWithConcurrentResultSets::wrap(&opts)),
+        )
     })
     .await
 }
@@ -507,8 +581,9 @@ async fn transaction_execute_request(
     tx: &TransactionExecContext,
     yql_text: String,
     parameters: HashMap<String, Value>,
-    opts: &CallOptions,
+    execute_opts: ExecuteQueryCallOptions<'_>,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
+    let opts = execute_opts.inner();
     let session_id = tx_session_id(tx)?.to_string();
     let client = query_client_from_tx(tx).await?;
     let req = finish_execute_request(
@@ -519,7 +594,7 @@ async fn transaction_execute_request(
             tx_control_for_transaction(tx, opts)?,
             opts.collect_stats,
         ),
-        opts,
+        execute_opts,
     );
     Ok((client, req))
 }
@@ -568,12 +643,36 @@ pub(crate) async fn transaction_begin_stream(
     params: HashMap<String, Value>,
     opts: CallOptions,
 ) -> YdbResult<ExecuteQueryStream> {
+    transaction_begin_stream_inner(tx, text, params, opts, false).await
+}
+
+pub(crate) async fn transaction_begin_materialized_stream(
+    tx: &mut TransactionExecContext,
+    text: String,
+    params: HashMap<String, Value>,
+    opts: CallOptions,
+) -> YdbResult<ExecuteQueryStream> {
+    transaction_begin_stream_inner(tx, text, params, opts, true).await
+}
+
+async fn transaction_begin_stream_inner(
+    tx: &mut TransactionExecContext,
+    text: String,
+    params: HashMap<String, Value>,
+    opts: CallOptions,
+    materialized: bool,
+) -> YdbResult<ExecuteQueryStream> {
     if tx.finished {
         return Err(YdbError::Custom(
             "transaction already finished (committed or rolled back)".to_string(),
         ));
     }
     let timeout_duration = operation_timeout(&opts, &tx.timeouts);
+    let execute_opts = if materialized {
+        ExecuteQueryCallOptions::Concurrent(CallOptionsWithConcurrentResultSets::wrap(&opts))
+    } else {
+        ExecuteQueryCallOptions::Sequential(&opts)
+    };
     let result: YdbResult<ExecuteQueryStream> = with_operation_timeout(timeout_duration, async {
         ensure_tx_session(tx).await?;
         if let Some(lease) = &mut tx.pooled_lease {
@@ -582,7 +681,8 @@ pub(crate) async fn transaction_begin_stream(
         if tx.begin {
             transaction_ensure_begin(tx, true).await?;
         }
-        let (mut client, req) = transaction_execute_request(tx, text, params, &opts).await?;
+        let (mut client, req) =
+            transaction_execute_request(tx, text, params, execute_opts).await?;
         let stream = client.execute_query(req).await.map_err(YdbError::from)?;
         let mut stream = ExecuteQueryStream::new(stream);
         stream.prime_first_part().await?;

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -418,14 +418,9 @@ async fn client_begin_stream_once(
                 Ok(ExecuteQueryStream::new(stream).with_session_guard(lease))
             }
             QuerySessionMode::Implicit => {
-                let (mut client, req) = client_implicit_request(
-                    ctx,
-                    text,
-                    params,
-                    opts,
-                    concurrent_result_sets,
-                )
-                .await?;
+                let (mut client, req) =
+                    client_implicit_request(ctx, text, params, opts, concurrent_result_sets)
+                        .await?;
                 let stream = client.execute_query(req).await.map_err(YdbError::from)?;
                 Ok(ExecuteQueryStream::new(stream))
             }

--- a/ydb/src/client_query/internal.rs
+++ b/ydb/src/client_query/internal.rs
@@ -5,8 +5,8 @@ use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
 use crate::types::Value;
 
 use super::exec::{
-    client_begin_materialized_stream, client_begin_stream, transaction_begin_materialized_stream,
-    transaction_begin_stream, CallOptions, ClientExecContext, TransactionExecContext,
+    client_begin_stream, transaction_begin_stream, CallOptions, ClientExecContext,
+    TransactionExecContext,
 };
 
 pub(crate) enum ExecCoreRef<'a> {
@@ -20,27 +20,14 @@ impl ExecCoreRef<'_> {
         text: String,
         params: HashMap<String, Value>,
         opts: CallOptions,
-    ) -> YdbResult<ExecuteQueryStream> {
-        match self {
-            ExecCoreRef::Client(ctx) => client_begin_stream(ctx, text, params, opts).await,
-            ExecCoreRef::Transaction(ctx) => {
-                transaction_begin_stream(ctx, text, params, opts).await
-            }
-        }
-    }
-
-    pub(crate) async fn begin_materialized_stream(
-        &mut self,
-        text: String,
-        params: HashMap<String, Value>,
-        opts: CallOptions,
+        concurrent_result_sets: bool,
     ) -> YdbResult<ExecuteQueryStream> {
         match self {
             ExecCoreRef::Client(ctx) => {
-                client_begin_materialized_stream(ctx, text, params, opts).await
+                client_begin_stream(ctx, text, params, opts, concurrent_result_sets).await
             }
             ExecCoreRef::Transaction(ctx) => {
-                transaction_begin_materialized_stream(ctx, text, params, opts).await
+                transaction_begin_stream(ctx, text, params, opts, concurrent_result_sets).await
             }
         }
     }

--- a/ydb/src/client_query/internal.rs
+++ b/ydb/src/client_query/internal.rs
@@ -5,8 +5,8 @@ use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
 use crate::types::Value;
 
 use super::exec::{
-    client_begin_stream, transaction_begin_stream, CallOptions, ClientExecContext,
-    TransactionExecContext,
+    client_begin_materialized_stream, client_begin_stream, transaction_begin_materialized_stream,
+    transaction_begin_stream, CallOptions, ClientExecContext, TransactionExecContext,
 };
 
 pub(crate) enum ExecCoreRef<'a> {
@@ -25,6 +25,22 @@ impl ExecCoreRef<'_> {
             ExecCoreRef::Client(ctx) => client_begin_stream(ctx, text, params, opts).await,
             ExecCoreRef::Transaction(ctx) => {
                 transaction_begin_stream(ctx, text, params, opts).await
+            }
+        }
+    }
+
+    pub(crate) async fn begin_materialized_stream(
+        &mut self,
+        text: String,
+        params: HashMap<String, Value>,
+        opts: CallOptions,
+    ) -> YdbResult<ExecuteQueryStream> {
+        match self {
+            ExecCoreRef::Client(ctx) => {
+                client_begin_materialized_stream(ctx, text, params, opts).await
+            }
+            ExecCoreRef::Transaction(ctx) => {
+                transaction_begin_materialized_stream(ctx, text, params, opts).await
             }
         }
     }

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -21,6 +21,9 @@ mod session_pool_bench;
 #[cfg(test)]
 mod tx_modes_integration_test;
 
+#[cfg(test)]
+mod concurrent_result_sets_test;
+
 use std::any::Any;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -77,8 +77,9 @@ pub(crate) async fn materialize_query(
     core: &mut ExecCoreRef<'_>,
     text: String,
     params: HashMap<String, Value>,
-    opts: CallOptions,
+    mut opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
+    opts.concurrent_result_sets = true;
     let commit_tx = resolve_commit_tx(core, &opts);
     let mut stream = core.begin_stream(text, params, opts).await?;
     let mut sets = Vec::new();

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -80,9 +80,7 @@ pub(crate) async fn materialize_query(
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
     let commit_tx = resolve_commit_tx(core, &opts);
-    let mut stream = core
-        .begin_stream(text, params, opts, true)
-        .await?;
+    let mut stream = core.begin_stream(text, params, opts, true).await?;
     let mut sets = Vec::new();
     let mut drain_err: Option<YdbError> = None;
     while drain_err.is_none() {

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -80,26 +80,34 @@ pub(crate) async fn materialize_query(
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
     let commit_tx = resolve_commit_tx(core, &opts);
-    let mut stream = core.begin_stream(text, params, opts, true).await?;
-    let raw_sets = stream
-        .materialize_all_result_sets()
-        .await
-        .map_err(YdbError::from)?;
-    let mut sets = Vec::with_capacity(raw_sets.len());
-    for raw in raw_sets {
-        sets.push(ResultSet::try_from(raw)?);
-    }
-    let meta = stream.close().await.map_err(YdbError::from)?;
-    if let ExecCoreRef::Transaction(ctx) = core {
-        apply_stream_tx_id(ctx, meta.tx_id);
-        if commit_tx {
-            transaction_finish_committed_via_query(ctx).await;
+    let result: YdbResult<Vec<ResultSet>> = async {
+        let mut stream = core.begin_stream(text, params, opts, true).await?;
+        let raw_sets = stream
+            .materialize_all_result_sets()
+            .await
+            .map_err(YdbError::from)?;
+        let mut sets = Vec::with_capacity(raw_sets.len());
+        for raw in raw_sets {
+            sets.push(ResultSet::try_from(raw)?);
         }
+        let meta = stream.close().await.map_err(YdbError::from)?;
+        if let ExecCoreRef::Transaction(ctx) = core {
+            apply_stream_tx_id(ctx, meta.tx_id);
+            if commit_tx {
+                transaction_finish_committed_via_query(ctx).await;
+            }
+        }
+        Ok(sets)
+    }
+    .await;
+
+    if let ExecCoreRef::Transaction(ctx) = core {
         if let Some(lease) = &mut ctx.pooled_lease {
             lease.end_use();
         }
     }
-    Ok(sets)
+
+    result
 }
 
 #[derive(Debug, Default)]

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -81,43 +81,23 @@ pub(crate) async fn materialize_query(
 ) -> YdbResult<Vec<ResultSet>> {
     let commit_tx = resolve_commit_tx(core, &opts);
     let mut stream = core.begin_stream(text, params, opts, true).await?;
-    let mut sets = Vec::new();
-    let mut drain_err: Option<YdbError> = None;
-    while drain_err.is_none() {
-        match stream.next_result_set().await {
-            Ok(Some((raw, tx_id))) => {
-                if let ExecCoreRef::Transaction(ctx) = core {
-                    apply_stream_tx_id(ctx, tx_id);
-                }
-                match ResultSet::try_from(raw) {
-                    Ok(set) => sets.push(set),
-                    Err(err) => drain_err = Some(err),
-                }
-            }
-            Ok(None) => break,
-            Err(err) => drain_err = Some(YdbError::from(err)),
-        }
+    let raw_sets = stream
+        .materialize_all_result_sets()
+        .await
+        .map_err(YdbError::from)?;
+    let mut sets = Vec::with_capacity(raw_sets.len());
+    for raw in raw_sets {
+        sets.push(ResultSet::try_from(raw)?);
     }
-    if drain_err.is_none() {
-        match stream.close().await {
-            Ok(meta) => {
-                if let ExecCoreRef::Transaction(ctx) = core {
-                    apply_stream_tx_id(ctx, meta.tx_id);
-                    if commit_tx {
-                        transaction_finish_committed_via_query(ctx).await;
-                    }
-                }
-            }
-            Err(err) => drain_err = Some(YdbError::from(err)),
-        }
-    }
+    let meta = stream.close().await.map_err(YdbError::from)?;
     if let ExecCoreRef::Transaction(ctx) = core {
+        apply_stream_tx_id(ctx, meta.tx_id);
+        if commit_tx {
+            transaction_finish_committed_via_query(ctx).await;
+        }
         if let Some(lease) = &mut ctx.pooled_lease {
             lease.end_use();
         }
-    }
-    if let Some(err) = drain_err {
-        return Err(err);
     }
     Ok(sets)
 }

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -80,7 +80,9 @@ pub(crate) async fn materialize_query(
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
     let commit_tx = resolve_commit_tx(core, &opts);
-    let mut stream = core.begin_materialized_stream(text, params, opts).await?;
+    let mut stream = core
+        .begin_stream(text, params, opts, true)
+        .await?;
     let mut sets = Vec::new();
     let mut drain_err: Option<YdbError> = None;
     while drain_err.is_none() {

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -77,11 +77,10 @@ pub(crate) async fn materialize_query(
     core: &mut ExecCoreRef<'_>,
     text: String,
     params: HashMap<String, Value>,
-    mut opts: CallOptions,
+    opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
-    opts.concurrent_result_sets = true;
     let commit_tx = resolve_commit_tx(core, &opts);
-    let mut stream = core.begin_stream(text, params, opts).await?;
+    let mut stream = core.begin_materialized_stream(text, params, opts).await?;
     let mut sets = Vec::new();
     let mut drain_err: Option<YdbError> = None;
     while drain_err.is_none() {

--- a/ydb/src/grpc_wrapper/raw_query_service/execute_query.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/execute_query.rs
@@ -20,6 +20,7 @@ pub(crate) struct RawExecuteQueryRequest {
     pub parameters: HashMap<String, Value>,
     pub tx_control: Option<ydb_grpc::ydb_proto::query::TransactionControl>,
     pub collect_stats: bool,
+    pub concurrent_result_sets: bool,
 }
 
 impl RawExecuteQueryRequest {
@@ -36,6 +37,7 @@ impl RawExecuteQueryRequest {
             parameters,
             tx_control,
             collect_stats,
+            concurrent_result_sets: false,
         }
     }
 
@@ -60,7 +62,7 @@ impl RawExecuteQueryRequest {
             } else {
                 StatsMode::None as i32
             },
-            concurrent_result_sets: false,
+            concurrent_result_sets: self.concurrent_result_sets,
             response_part_limit_bytes: 0,
             pool_id: String::new(),
             stats_period_ms: 0,

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -115,7 +115,13 @@ impl ExecuteQueryStream {
         }
         #[cfg(test)]
         if let Some(parts) = &mut self.test_parts {
-            return Ok(parts.pop());
+            return match parts.pop() {
+                Some(part) => Ok(Some(part)),
+                None => {
+                    self.finished = true;
+                    Ok(None)
+                }
+            };
         }
         match self.grpc.as_mut() {
             Some(stream) => match stream.message().await? {
@@ -125,7 +131,10 @@ impl ExecuteQueryStream {
                     Ok(None)
                 }
             },
-            None => Ok(None),
+            None => {
+                self.finished = true;
+                Ok(None)
+            }
         }
     }
 
@@ -149,22 +158,26 @@ impl ExecuteQueryStream {
     pub async fn materialize_all_result_sets(&mut self) -> RawResult<Vec<RawResultSet>> {
         let mut by_index: BTreeMap<i64, PartialResultSet> = BTreeMap::new();
 
-        while let Some(part) = self.recv_part().await? {
-            self.ingest_part(&part)?;
-            Self::append_part_to_index(&mut by_index, part)?;
+        let result: RawResult<Vec<RawResultSet>> = async {
+            while let Some(part) = self.recv_part().await? {
+                self.ingest_part(&part)?;
+                Self::append_part_to_index(&mut by_index, part)?;
+            }
+
+            Ok(by_index
+                .into_values()
+                .map(|partial| RawResultSet {
+                    columns: partial.columns,
+                    rows: partial.rows,
+                    truncated: partial.truncated,
+                })
+                .collect())
         }
+        .await;
 
         drop(self.grpc.take());
         self.finished = true;
-
-        Ok(by_index
-            .into_values()
-            .map(|partial| RawResultSet {
-                columns: partial.columns,
-                rows: partial.rows,
-                truncated: partial.truncated,
-            })
-            .collect())
+        result
     }
 
     /// Read the first response part so transaction `tx_id` is captured before iteration.
@@ -355,19 +368,38 @@ mod tests {
             items: vec![RawValue::Int64(value).into()],
             ..Default::default()
         };
+        part_with_rows(index, Some(vec![ydb_grpc::ydb_proto::Column {
+            name: column.to_string(),
+            r#type: Some(col_type),
+        }]), vec![row])
+    }
+
+    fn part_with_rows(
+        index: i64,
+        columns: Option<Vec<ydb_grpc::ydb_proto::Column>>,
+        rows: Vec<ydb_grpc::ydb_proto::Value>,
+    ) -> ExecuteQueryResponsePart {
         ExecuteQueryResponsePart {
             status: StatusCode::Success as i32,
             issues: vec![],
             result_set_index: index,
-            result_set: Some(ydb_grpc::ydb_proto::ResultSet {
-                columns: vec![ydb_grpc::ydb_proto::Column {
-                    name: column.to_string(),
-                    r#type: Some(col_type),
-                }],
-                rows: vec![row],
+            result_set: columns.map(|columns| ydb_grpc::ydb_proto::ResultSet {
+                columns,
+                rows,
                 truncated: false,
                 ..Default::default()
             }),
+            exec_stats: None,
+            tx_meta: None,
+        }
+    }
+
+    fn error_part(index: i64) -> ExecuteQueryResponsePart {
+        ExecuteQueryResponsePart {
+            status: StatusCode::BadRequest as i32,
+            issues: vec![],
+            result_set_index: index,
+            result_set: None,
             exec_stats: None,
             tx_meta: None,
         }
@@ -401,5 +433,54 @@ mod tests {
         assert_eq!(sets.len(), 2);
         assert_eq!(row_values(&sets[0]), vec![10, 11]);
         assert_eq!(row_values(&sets[1]), vec![20, 21]);
+    }
+
+    #[tokio::test]
+    async fn materialize_all_result_sets_accepts_empty_continuation_parts() {
+        let col_type = crate::grpc_wrapper::raw_table_service::value::r#type::RawType::Int64.into();
+        let row = |v: i64| ydb_grpc::ydb_proto::Value {
+            items: vec![RawValue::Int64(v).into()],
+            ..Default::default()
+        };
+        let columns = vec![ydb_grpc::ydb_proto::Column {
+            name: "a".to_string(),
+            r#type: Some(col_type),
+        }];
+
+        let mut stream = ExecuteQueryStream::from_test_parts(vec![
+            part_with_rows(0, Some(columns.clone()), vec![row(10)]),
+            part_with_rows(0, None, vec![]),
+            part_with_rows(0, Some(vec![]), vec![row(11)]),
+        ]);
+
+        let sets = stream
+            .materialize_all_result_sets()
+            .await
+            .expect("materialize stream");
+
+        assert_eq!(sets.len(), 1);
+        assert_eq!(row_values(&sets[0]), vec![10, 11]);
+        assert!(stream.finished);
+        assert!(stream.grpc.is_none());
+    }
+
+    #[tokio::test]
+    async fn materialize_all_result_sets_propagates_part_errors() {
+        let mut stream = ExecuteQueryStream::from_test_parts(vec![
+            part_with_row(0, "a", 10),
+            error_part(1),
+        ]);
+
+        let err = stream
+            .materialize_all_result_sets()
+            .await
+            .expect_err("expected part status error");
+
+        assert!(matches!(
+            err,
+            crate::grpc_wrapper::raw_errors::RawError::YdbStatus(_)
+        ));
+        assert!(stream.finished);
+        assert!(stream.grpc.is_none());
     }
 }

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use tracing::warn;
@@ -11,6 +12,13 @@ use ydb_grpc::ydb_proto::query::ExecuteQueryResponsePart;
 
 pub(crate) struct StreamCloseMeta {
     pub tx_id: Option<String>,
+}
+
+#[derive(Default)]
+struct PartialResultSet {
+    columns: Vec<crate::grpc_wrapper::raw_table_service::value::RawColumn>,
+    rows: Vec<Vec<crate::grpc_wrapper::raw_table_service::value::RawValue>>,
+    truncated: bool,
 }
 
 /// Holds a pooled session lease until the stream is finished.
@@ -32,6 +40,8 @@ pub(crate) struct ExecuteQueryStream {
     // Dropped last (after `grpc`) so the pooled lease outlives the stream.
     // `Drop` also calls `cancel()` before field destructors run.
     session_guard: SessionStreamGuard,
+    #[cfg(test)]
+    test_parts: Option<Vec<ExecuteQueryResponsePart>>,
 }
 
 impl Drop for ExecuteQueryStream {
@@ -50,6 +60,23 @@ impl ExecuteQueryStream {
             finished: false,
             stats: None,
             session_guard: SessionStreamGuard(None),
+            #[cfg(test)]
+            test_parts: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_parts(mut parts: Vec<ExecuteQueryResponsePart>) -> Self {
+        parts.reverse();
+        Self {
+            grpc: None,
+            next_index: 0,
+            pending_part: None,
+            captured_tx_id: None,
+            finished: false,
+            stats: None,
+            session_guard: SessionStreamGuard(None),
+            test_parts: Some(parts),
         }
     }
 
@@ -77,6 +104,67 @@ impl ExecuteQueryStream {
         let tx_id = self.absorb_part_metadata(part);
         check_part(part)?;
         Ok(tx_id)
+    }
+
+    async fn recv_part(&mut self) -> RawResult<Option<ExecuteQueryResponsePart>> {
+        if self.finished {
+            return Ok(None);
+        }
+        if let Some(part) = self.pending_part.take() {
+            return Ok(Some(part));
+        }
+        #[cfg(test)]
+        if let Some(parts) = &mut self.test_parts {
+            return Ok(parts.pop());
+        }
+        match self.grpc.as_mut() {
+            Some(stream) => match stream.message().await? {
+                Some(part) => Ok(Some(part)),
+                None => {
+                    self.finished = true;
+                    Ok(None)
+                }
+            },
+            None => Ok(None),
+        }
+    }
+
+    fn append_part_to_index(
+        by_index: &mut BTreeMap<i64, PartialResultSet>,
+        part: ExecuteQueryResponsePart,
+    ) -> RawResult<()> {
+        let index = part.result_set_index;
+        let partial = by_index.entry(index).or_default();
+        append_rows_from_part(
+            &mut partial.columns,
+            &mut partial.rows,
+            &mut partial.truncated,
+            part,
+        )
+    }
+
+    /// Drain the stream and assemble all result sets, buffering parts by
+    /// `result_set_index`. Required when `concurrent_result_sets=true` because
+    /// the server may interleave parts from different result sets.
+    pub async fn materialize_all_result_sets(&mut self) -> RawResult<Vec<RawResultSet>> {
+        let mut by_index: BTreeMap<i64, PartialResultSet> = BTreeMap::new();
+
+        while let Some(part) = self.recv_part().await? {
+            self.ingest_part(&part)?;
+            Self::append_part_to_index(&mut by_index, part)?;
+        }
+
+        drop(self.grpc.take());
+        self.finished = true;
+
+        Ok(by_index
+            .into_iter()
+            .map(|(_, partial)| RawResultSet {
+                columns: partial.columns,
+                rows: partial.rows,
+                truncated: partial.truncated,
+            })
+            .collect())
     }
 
     /// Read the first response part so transaction `tx_id` is captured before iteration.
@@ -251,5 +339,67 @@ impl ExecuteQueryStream {
         Ok(StreamCloseMeta {
             tx_id: self.captured_tx_id.take(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grpc_wrapper::raw_table_service::value::{RawResultSet, RawValue};
+    use ydb_grpc::ydb_proto::status_ids::StatusCode;
+    use ydb_grpc::ydb_proto::query::ExecuteQueryResponsePart;
+
+    fn part_with_row(index: i64, column: &str, value: i64) -> ExecuteQueryResponsePart {
+        let col_type = crate::grpc_wrapper::raw_table_service::value::r#type::RawType::Int64.into();
+        let row = ydb_grpc::ydb_proto::Value {
+            items: vec![RawValue::Int64(value).into()],
+            ..Default::default()
+        };
+        ExecuteQueryResponsePart {
+            status: StatusCode::Success as i32,
+            issues: vec![],
+            result_set_index: index,
+            result_set: Some(ydb_grpc::ydb_proto::ResultSet {
+                columns: vec![ydb_grpc::ydb_proto::Column {
+                    name: column.to_string(),
+                    r#type: Some(col_type),
+                }],
+                rows: vec![row],
+                truncated: false,
+                ..Default::default()
+            }),
+            exec_stats: None,
+            tx_meta: None,
+        }
+    }
+
+    fn row_values(set: &RawResultSet) -> Vec<i64> {
+        set.rows
+            .iter()
+            .map(|row| match row.first() {
+                Some(RawValue::Int64(v)) => *v,
+                other => panic!("unexpected cell: {other:?}"),
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn materialize_all_result_sets_reassembles_interleaved_parts() {
+        // Server may deliver RS0/RS1 parts out of order when concurrent_result_sets=true.
+        let mut stream = ExecuteQueryStream::from_test_parts(vec![
+            part_with_row(0, "a", 10),
+            part_with_row(1, "b", 20),
+            part_with_row(0, "a", 11),
+            part_with_row(1, "b", 21),
+        ]);
+
+        let sets = stream
+            .materialize_all_result_sets()
+            .await
+            .expect("materialize stream");
+
+        assert_eq!(sets.len(), 2);
+        assert_eq!(row_values(&sets[0]), vec![10, 11]);
+        assert_eq!(row_values(&sets[1]), vec![20, 21]);
     }
 }

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -346,8 +346,8 @@ impl ExecuteQueryStream {
 mod tests {
     use super::*;
     use crate::grpc_wrapper::raw_table_service::value::{RawResultSet, RawValue};
-    use ydb_grpc::ydb_proto::status_ids::StatusCode;
     use ydb_grpc::ydb_proto::query::ExecuteQueryResponsePart;
+    use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
     fn part_with_row(index: i64, column: &str, value: i64) -> ExecuteQueryResponsePart {
         let col_type = crate::grpc_wrapper::raw_table_service::value::r#type::RawType::Int64.into();

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -157,9 +157,7 @@ impl ExecuteQueryStream {
         drop(self.grpc.take());
         self.finished = true;
 
-        Ok(by_index
-            .into_iter()
-            .map(|(_, partial)| RawResultSet {
+        Ok(by_index.into_values().map(|partial| RawResultSet {
                 columns: partial.columns,
                 rows: partial.rows,
                 truncated: partial.truncated,

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -368,10 +368,14 @@ mod tests {
             items: vec![RawValue::Int64(value).into()],
             ..Default::default()
         };
-        part_with_rows(index, Some(vec![ydb_grpc::ydb_proto::Column {
-            name: column.to_string(),
-            r#type: Some(col_type),
-        }]), vec![row])
+        part_with_rows(
+            index,
+            Some(vec![ydb_grpc::ydb_proto::Column {
+                name: column.to_string(),
+                r#type: Some(col_type),
+            }]),
+            vec![row],
+        )
     }
 
     fn part_with_rows(
@@ -466,10 +470,8 @@ mod tests {
 
     #[tokio::test]
     async fn materialize_all_result_sets_propagates_part_errors() {
-        let mut stream = ExecuteQueryStream::from_test_parts(vec![
-            part_with_row(0, "a", 10),
-            error_part(1),
-        ]);
+        let mut stream =
+            ExecuteQueryStream::from_test_parts(vec![part_with_row(0, "a", 10), error_part(1)]);
 
         let err = stream
             .materialize_all_result_sets()

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -142,6 +142,9 @@ impl ExecuteQueryStream {
         by_index: &mut BTreeMap<i64, PartialResultSet>,
         part: ExecuteQueryResponsePart,
     ) -> RawResult<()> {
+        if part.result_set.is_none() {
+            return Ok(());
+        }
         let index = part.result_set_index;
         let partial = by_index.entry(index).or_default();
         append_rows_from_part(
@@ -409,6 +412,17 @@ mod tests {
         }
     }
 
+    fn metadata_only_part(index: i64) -> ExecuteQueryResponsePart {
+        ExecuteQueryResponsePart {
+            status: StatusCode::Success as i32,
+            issues: vec![],
+            result_set_index: index,
+            result_set: None,
+            exec_stats: None,
+            tx_meta: None,
+        }
+    }
+
     fn row_values(set: &RawResultSet) -> Vec<i64> {
         set.rows
             .iter()
@@ -484,5 +498,22 @@ mod tests {
         ));
         assert!(stream.finished);
         assert!(stream.grpc.is_none());
+    }
+
+    #[tokio::test]
+    async fn materialize_all_result_sets_skips_metadata_only_parts() {
+        let mut stream = ExecuteQueryStream::from_test_parts(vec![
+            metadata_only_part(0),
+            part_with_row(0, "a", 10),
+            metadata_only_part(1),
+        ]);
+
+        let sets = stream
+            .materialize_all_result_sets()
+            .await
+            .expect("materialize stream");
+
+        assert_eq!(sets.len(), 1);
+        assert_eq!(row_values(&sets[0]), vec![10]);
     }
 }

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -157,7 +157,9 @@ impl ExecuteQueryStream {
         drop(self.grpc.take());
         self.finished = true;
 
-        Ok(by_index.into_values().map(|partial| RawResultSet {
+        Ok(by_index
+            .into_values()
+            .map(|partial| RawResultSet {
                 columns: partial.columns,
                 rows: partial.rows,
                 truncated: partial.truncated,


### PR DESCRIPTION
## Summary
- Materialized query paths (`exec`, `query_row`, `query_result_set`) always send `concurrent_result_sets=true` in `ExecuteQuery`, improving latency for multi-statement queries.
- Streaming `query()` keeps the default (`false`) because the caller consumes parts incrementally.
- Add deprecated no-op `CallBuilder::with_concurrent_result_sets` for API compatibility.

## Test plan
- [x] `cargo test -p ydb --lib`


Made with [Cursor](https://cursor.com)