### PR TITLE
fix: Discovery deadlock

### DIFF
--- a/ydb/src/discovery.rs
+++ b/ydb/src/discovery.rs
@@ -74,9 +74,13 @@ impl DiscoveryState {
         self.nodes.len() == 0
     }
 
+    fn is_pessimized(&self, uri: &Uri) -> bool {
+        self.pessimized_nodes.contains(uri)
+    }
+
     // pessimize return true if state was changed
     pub(crate) fn pessimize(&mut self, uri: &Uri) -> bool {
-        if self.pessimized_nodes.contains(uri) {
+        if self.is_pessimized(uri) {
             return false;
         };
 
@@ -404,21 +408,20 @@ impl DiscoverySharedState {
 #[async_trait]
 impl Discovery for DiscoverySharedState {
     fn pessimization(&self, uri: &Uri) {
-        let Some(Ok(state)) = &*self.state_sender.borrow() else {
-            // Node pessimization is reset after discovery,
-            // so it makes no sense to add pessimize node before
-            // the first discovery.
-            return;
-        };
+        self.state_sender.send_if_modified(|current| {
+            let Some(Ok(state)) = current.as_mut() else {
+                // Node pessimization is reset after discovery,
+                // so it makes no sense to pessimize a node before
+                // the first discovery.
+                return false;
+            };
 
-        // TODO: suppress force copy every time
-        let mut state = state.as_ref().clone();
+            if state.is_pessimized(uri) {
+                return false;
+            }
 
-        if !state.pessimize(uri) {
-            return;
-        }
-
-        self.state_sender.send_replace(Some(Ok(Arc::new(state))));
+            Arc::make_mut(state).pessimize(uri)
+        });
     }
 
     fn subscribe(&self) -> BoxStream<'static, Arc<DiscoveryState>> {

--- a/ydb/src/discovery.rs
+++ b/ydb/src/discovery.rs
@@ -474,7 +474,7 @@ impl Waiter for DiscoverySharedState {
 #[cfg(test)]
 mod test {
     use crate::client_common::{DBCredentials, TokenCache};
-    use crate::discovery::DiscoverySharedState;
+    use crate::discovery::{Discovery, DiscoverySharedState, DiscoveryState, NodeInfo};
     use crate::errors::YdbResult;
     use crate::grpc_connection_manager::GrpcConnectionManager;
     use crate::grpc_wrapper::auth::AuthGrpcInterceptor;
@@ -484,7 +484,51 @@ mod test {
     use http::Uri;
     use std::str::FromStr;
     use std::sync::Arc;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
+
+    fn discovery_shared_state() -> YdbResult<DiscoverySharedState> {
+        const DATABASE: &str = "/local";
+        const ENDPOINT: &str = "grpc://localhost:2136";
+
+        let uri = Uri::from_str(ENDPOINT)?;
+        let load_balancer =
+            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(uri)));
+        let connection_manager = GrpcConnectionManager::new(
+            load_balancer,
+            DATABASE.to_string(),
+            MultiInterceptor::new(),
+            None,
+            crate::grpc_wrapper::grpc_limits::DEFAULT_GRPC_MESSAGE_SIZE_LIMIT_BYTES,
+        );
+
+        DiscoverySharedState::new(connection_manager, ENDPOINT)
+    }
+
+    #[test]
+    fn pessimization_completes_after_discovery() -> YdbResult<()> {
+        let state = Arc::new(discovery_shared_state()?);
+        let endpoint = Uri::from_static("http://localhost:2136");
+        state
+            .state_sender
+            .send_replace(Some(Ok(Arc::new(DiscoveryState::new(
+                Instant::now(),
+                vec![NodeInfo::new(endpoint.clone(), String::new())],
+            )))));
+
+        let state_for_thread = state.clone();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            state_for_thread.pessimization(&endpoint);
+            let _ = done_tx.send(());
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_secs(1)).is_ok(),
+            "endpoint pessimization deadlocked"
+        );
+
+        Ok(())
+    }
 
     #[tokio::test]
     #[ignore] // need YDB access


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Discovery pessimization function borrowed reader lock on tokio::watcher right before acquiring write lock to send new pessimized DiscoveryState, which caused dead locks and SLO metrics breakage.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Regression test added
- Pessimization implementation in SharedDiscovery avoids holding read locks


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
