### PR TITLE
Fix: SLO e2e metrics and reliability

### DIFF
--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -155,6 +155,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workload_name: ${{ matrix.sdk.name }}
           workload_duration: ${{ inputs.slo_workload_duration_seconds || '600' }}
+          fail_on_workload_error: "true"
           workload_current_ref: ${{ github.head_ref || github.ref_name }}
           workload_current_image: ydb-app-current
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -49,6 +49,7 @@ jobs:
             path: native/query
           - name: native-topic
             path: native/topic
+            metrics_yaml_path: current/tests/slo/metrics-topic.yaml
 
     concurrency:
       group: slo-${{ github.ref }}-${{ matrix.sdk.name }}
@@ -158,3 +159,4 @@ jobs:
           workload_current_image: ydb-app-current
           workload_baseline_ref: ${{ steps.baseline.outputs.ref }}
           workload_baseline_image: ydb-app-baseline
+          metrics_yaml_path: ${{ matrix.sdk.metrics_yaml_path }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,17 +321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
-name = "clocksource"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ca503ea4a169812981018ee2810f4e4157b0c9006f5dc4a582df637b415c2e"
-dependencies = [
- "libc",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,17 +2103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratelimit"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea961700fd7260e7fa3701c8287d901b2172c51f9c1421fa0f21d7f7e184b7"
-dependencies = [
- "clocksource",
- "parking_lot",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,7 +2585,6 @@ dependencies = [
  "opentelemetry_sdk 0.27.1",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "ratelimit",
  "tokio",
  "tokio-util",
  "ydb",
@@ -3470,22 +3447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,12 +3454,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/tests/slo/README.md
+++ b/tests/slo/README.md
@@ -43,8 +43,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:9090/api/v1/otlp
 
 # Topic workload (set WORKLOAD_NAME=native-topic):
 ./target/release/slo-native-topic \
-  --read-rps 100 \
-  --write-rps 10
+  --write-rps 1000
 ```
 
 Or via cargo:
@@ -61,7 +60,7 @@ YDB_CONNECTION_STRING=grpc://localhost:2136/local \
 WORKLOAD_REF=local \
 WORKLOAD_NAME=native-topic \
 WORKLOAD_DURATION=60 \
-cargo run --release -p slo-native-topic -- --read-rps 100 --write-rps 10
+cargo run --release -p slo-native-topic -- --write-rps 1000
 ```
 
 ### CLI flags
@@ -76,6 +75,25 @@ cargo run --release -p slo-native-topic -- --read-rps 100 --write-rps 10
 | `--partition-size` | 1 | Auto-partition size (MB) |
 | `--min-partition-count` | 6 | Minimum partitions |
 | `--max-partition-count` | 1000 | Maximum partitions |
+
+### Topic CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--write-rps` | 1000 | Total messages submitted per second |
+| `--write-timeout` | 5000 | Message submission and acknowledgement deadline (ms) |
+| `--delivery-timeout` | 5000 | Maximum wait for the next message batch (ms) |
+| `--commit-timeout` | 5000 | Commit acknowledgement deadline (ms) |
+| `--partition-count` | 10 | Topic partitions |
+| `--reader-count` | 5 | Topic readers |
+| `--writer-count` | 20 | Topic writers |
+
+For the topic workload, `write` is one message submission completed by a server
+acknowledgement. A successful `read` is one batch commit completed by a server
+acknowledgement; delivery timeouts, SDK read errors, and validation failures are
+also failed `read` operations. Successful read latency measures only commit
+acknowledgement time. Consequently, write throughput counts messages while read
+throughput counts committed batches.
 
 Table path: `{database}/{WORKLOAD_NAME}/{WORKLOAD_REF}` (e.g. `/local/native-query/local`).
 

--- a/tests/slo/metrics-topic.yaml
+++ b/tests/slo/metrics-topic.yaml
@@ -1,0 +1,22 @@
+# Topic metrics are merged with the ydb-slo-action defaults for topic runs.
+metrics:
+  - name: topic_e2e_latency_p50_ms
+    unit: ms
+    query: |
+      1000 * max by(ref) (
+        sdk_topic_e2e_latency_p50_seconds
+      )
+
+  - name: topic_e2e_latency_p95_ms
+    unit: ms
+    query: |
+      1000 * max by(ref) (
+        sdk_topic_e2e_latency_p95_seconds
+      )
+
+  - name: topic_e2e_latency_p99_ms
+    unit: ms
+    query: |
+      1000 * max by(ref) (
+        sdk_topic_e2e_latency_p99_seconds
+      )

--- a/tests/slo/native/query/src/main.rs
+++ b/tests/slo/native/query/src/main.rs
@@ -4,6 +4,6 @@ mod storage;
 use slo_framework::run;
 
 #[tokio::main]
-async fn main() {
-    run(|fw| Box::pin(storage::new_workload(fw.clone()))).await;
+async fn main() -> Result<(), String> {
+    run(|fw| Box::pin(storage::new_workload(fw.clone()))).await
 }

--- a/tests/slo/native/topic/src/main.rs
+++ b/tests/slo/native/topic/src/main.rs
@@ -4,6 +4,6 @@ mod storage;
 use slo_framework::run;
 
 #[tokio::main]
-async fn main() {
-    run(|fw| Box::pin(storage::new_workload(fw.clone()))).await;
+async fn main() -> Result<(), String> {
+    run(|fw| Box::pin(storage::new_workload(fw.clone()))).await
 }

--- a/tests/slo/slo-framework/Cargo.toml
+++ b/tests/slo/slo-framework/Cargo.toml
@@ -21,6 +21,9 @@ opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.27"
 rand = "0.8.5"
 rand_core = "0.6.4"
-tokio = { version = "=1.38.1", features = ["full", "signal", "test-util"] }
+tokio = { version = "=1.38.1", features = ["full", "signal"] }
 tokio-util = { version = "=0.7.11" }
 ydb = { path = "../../../ydb" }
+
+[dev-dependencies]
+tokio = { version = "=1.38.1", features = ["test-util"] }

--- a/tests/slo/slo-framework/Cargo.toml
+++ b/tests/slo/slo-framework/Cargo.toml
@@ -21,7 +21,6 @@ opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
 opentelemetry-semantic-conventions = "0.27"
 rand = "0.8.5"
 rand_core = "0.6.4"
-ratelimit = "0.10.0"
-tokio = { version = "=1.38.1", features = ["full", "signal"] }
+tokio = { version = "=1.38.1", features = ["full", "signal", "test-util"] }
 tokio-util = { version = "=0.7.11" }
 ydb = { path = "../../../ydb" }

--- a/tests/slo/slo-framework/src/framework.rs
+++ b/tests/slo/slo-framework/src/framework.rs
@@ -11,6 +11,7 @@ use crate::logger::{Logger, Phase};
 use crate::metrics::Metrics;
 
 const SHUTDOWN_DURATION: Duration = Duration::from_secs(30);
+const WORKLOAD_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(20);
 
 #[derive(Clone)]
 pub struct Framework {
@@ -26,7 +27,7 @@ pub trait Workload: Send {
     async fn teardown(&self, ctx: &CancellationToken) -> Result<(), String>;
 }
 
-pub async fn run<F, Fut>(factory: F)
+pub async fn run<F, Fut>(factory: F) -> Result<(), String>
 where
     F: for<'a> Fn(&'a Framework) -> Fut,
     Fut: Future<Output = Result<Box<dyn Workload>, String>> + Send,
@@ -47,13 +48,10 @@ where
         cancel_bg.cancel();
     });
 
-    let mut exit_code = 0;
-
     let config = match Config::from_env() {
         Ok(cfg) => cfg,
         Err(err) => {
-            eprintln!("create config failed: {err}");
-            std::process::exit(1);
+            return Err(format!("create config failed: {err}"));
         }
     };
 
@@ -61,8 +59,7 @@ where
     let metrics = match Metrics::new(&config) {
         Ok(m) => m,
         Err(err) => {
-            eprintln!("create metrics failed: {err}");
-            std::process::exit(1);
+            return Err(format!("create metrics failed: {err}"));
         }
     };
 
@@ -77,11 +74,8 @@ where
     let workload = match factory(&fw).await {
         Ok(w) => w,
         Err(err) => {
-            logger.errorf(format!("create workload failed: {err}"));
-            metrics.push().await;
-            metrics.close().await;
             logger.flush();
-            std::process::exit(1);
+            return Err(format!("create workload failed: {err}"));
         }
     };
 
@@ -106,11 +100,11 @@ where
             res = &mut run_fut => res?,
             _ = sleep(run_duration) => {
                 run_cancel.cancel();
-                run_fut.await?;
+                wait_for_workload_shutdown(&mut run_fut, WORKLOAD_SHUTDOWN_TIMEOUT).await?;
             }
             _ = cancel.cancelled() => {
                 run_cancel.cancel();
-                run_fut.await?;
+                wait_for_workload_shutdown(&mut run_fut, WORKLOAD_SHUTDOWN_TIMEOUT).await?;
             }
         }
 
@@ -119,20 +113,39 @@ where
     }
     .await;
 
-    if let Err(err) = run_result {
-        logger.errorf(format!("workload failed: {err}"));
-        exit_code = 1;
-    } else {
+    if run_result.is_ok() {
         logger.printf("workload completed successfully");
     }
 
-    if let Err(err) = teardown_result.await {
-        logger.errorf(format!("teardown failed: {err}"));
+    let teardown_result = teardown_result
+        .await
+        .map_err(|err| format!("teardown failed: {err}"));
+    let result = preserve_primary_error(run_result, teardown_result);
+
+    logger.flush();
+    if result.is_ok() {
+        logger.printf("program finished");
     }
 
-    metrics.push().await;
-    metrics.close().await;
-    logger.flush();
-    logger.printf("program finished");
-    std::process::exit(exit_code);
+    result
+}
+
+async fn wait_for_workload_shutdown<F>(run_fut: F, shutdown_timeout: Duration) -> Result<(), String>
+where
+    F: Future<Output = Result<(), String>>,
+{
+    timeout(shutdown_timeout, run_fut)
+        .await
+        .map_err(|_| "workload did not stop after cancellation".to_string())?
+}
+
+fn preserve_primary_error(
+    primary: Result<(), String>,
+    cleanup: Result<(), String>,
+) -> Result<(), String> {
+    match (primary, cleanup) {
+        (Ok(()), cleanup) => cleanup,
+        (Err(primary), Ok(())) => Err(primary),
+        (Err(primary), Err(cleanup)) => Err(format!("{primary}; additionally, {cleanup}")),
+    }
 }

--- a/tests/slo/slo-framework/src/framework.rs
+++ b/tests/slo/slo-framework/src/framework.rs
@@ -121,6 +121,7 @@ where
         .await
         .map_err(|err| format!("teardown failed: {err}"));
     let result = preserve_primary_error(run_result, teardown_result);
+    let result = preserve_primary_error(result, metrics.check());
 
     logger.flush();
     if result.is_ok() {

--- a/tests/slo/slo-framework/src/framework.rs
+++ b/tests/slo/slo-framework/src/framework.rs
@@ -106,11 +106,11 @@ where
             res = &mut run_fut => res?,
             _ = sleep(run_duration) => {
                 run_cancel.cancel();
-                let _ = run_fut.await;
+                run_fut.await?;
             }
             _ = cancel.cancelled() => {
                 run_cancel.cancel();
-                let _ = run_fut.await;
+                run_fut.await?;
             }
         }
 

--- a/tests/slo/slo-framework/src/helpers.rs
+++ b/tests/slo/slo-framework/src/helpers.rs
@@ -1,24 +1,40 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ratelimit::Ratelimiter;
-use tokio::time::sleep;
+use tokio::sync::Mutex;
+use tokio::time::{Instant, sleep_until};
 use tokio_util::sync::CancellationToken;
 
-pub fn new_rate_limiter(rps: u32) -> Ratelimiter {
+pub struct RateLimiter {
+    interval: Duration,
+    next: Mutex<Instant>,
+}
+
+impl RateLimiter {
+    pub async fn wait(&self) {
+        // Holding the FIFO mutex while sleeping queues every caller behind one
+        // timer instead of waking all workers to race for the same permit.
+        let mut next = self.next.lock().await;
+        let scheduled = (*next).max(Instant::now());
+        sleep_until(scheduled).await;
+        *next = scheduled + self.interval;
+    }
+}
+
+pub fn new_rate_limiter(rps: u32) -> RateLimiter {
     let rps = rps.max(1) as u64;
-    let interval = Duration::from_nanos(1_000_000_000 / rps);
-    Ratelimiter::builder(1, interval)
-        .max_tokens(1)
-        .initial_available(1)
-        .build()
-        .expect("valid ratelimiter")
+    let interval = Duration::from_nanos((1_000_000_000 / rps).max(1));
+
+    RateLimiter {
+        interval,
+        next: Mutex::new(Instant::now()),
+    }
 }
 
 pub async fn run_workers<F, Fut>(
     ctx: &CancellationToken,
     workers: usize,
-    limiter: Ratelimiter,
+    limiter: RateLimiter,
     f: F,
 ) where
     F: Fn() -> Fut + Clone + Send + 'static,
@@ -31,11 +47,15 @@ pub async fn run_workers<F, Fut>(
         let limiter = limiter.clone();
         let f = f.clone();
         handles.push(tokio::spawn(async move {
-            while !ctx.is_cancelled() {
-                if let Err(wait) = limiter.try_wait() {
-                    sleep(wait).await;
-                    continue;
+            loop {
+                tokio::select! {
+                    _ = ctx.cancelled() => break,
+                    _ = limiter.wait() => {}
                 }
+                if ctx.is_cancelled() {
+                    break;
+                }
+
                 f().await;
             }
         }));
@@ -49,12 +69,59 @@ pub async fn run_workers<F, Fut>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::mpsc;
+    use tokio::time::{advance, timeout};
 
-    #[test]
-    fn go_style_rate_limiter_supports_default_slo_rps() {
-        let rl = new_rate_limiter(1000);
-        assert!((rl.rate() - 1000.0).abs() < 1.0);
-        let rl = new_rate_limiter(100);
-        assert!((rl.rate() - 100.0).abs() < 1.0);
+    #[tokio::test(start_paused = true)]
+    async fn rate_limiter_does_not_catch_up_after_a_delay() {
+        let limiter = new_rate_limiter(1000);
+        let started = Instant::now();
+        limiter.wait().await;
+        assert_eq!(Instant::now(), started);
+
+        advance(Duration::from_millis(10)).await;
+        limiter.wait().await;
+
+        assert!(timeout(Duration::ZERO, limiter.wait()).await.is_err());
+        advance(Duration::from_millis(1)).await;
+        limiter.wait().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limiter_wakes_waiters_in_order() {
+        let limiter = Arc::new(new_rate_limiter(1000));
+        limiter.wait().await;
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        for worker in 0..3 {
+            let limiter = limiter.clone();
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                limiter.wait().await;
+                tx.send(worker).expect("result receiver remains open");
+            });
+            tokio::task::yield_now().await;
+        }
+        drop(tx);
+
+        for worker in 0..3 {
+            advance(Duration::from_millis(1)).await;
+            assert_eq!(rx.recv().await, Some(worker));
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn workers_stop_while_waiting_for_a_permit() {
+        let ctx = CancellationToken::new();
+        let workers = tokio::spawn({
+            let ctx = ctx.clone();
+            async move {
+                run_workers(&ctx, 2, new_rate_limiter(1), || async {}).await;
+            }
+        });
+
+        tokio::task::yield_now().await;
+        ctx.cancel();
+        workers.await.expect("worker supervisor completes");
     }
 }

--- a/tests/slo/slo-framework/src/helpers.rs
+++ b/tests/slo/slo-framework/src/helpers.rs
@@ -1,4 +1,3 @@
-use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,43 +44,6 @@ pub async fn run_workers<F, Fut>(
     for handle in handles {
         let _ = handle.await;
     }
-}
-
-/// Outcome of awaiting a future bounded by a deadline and a cancellation token.
-pub enum TimeoutOutcome<T> {
-    Completed(T),
-    TimedOut,
-    Cancelled,
-}
-
-/// Awaits `fut` until it completes, the `timeout` elapses, or `ctx` is cancelled —
-/// whichever happens first. Cancellation is checked first on each poll.
-pub async fn timeout_or_cancel<F: Future>(
-    ctx: &CancellationToken,
-    timeout: Duration,
-    fut: F,
-) -> TimeoutOutcome<F::Output> {
-    tokio::select! {
-        biased;
-        _ = ctx.cancelled() => TimeoutOutcome::Cancelled,
-        res = tokio::time::timeout(timeout, fut) => match res {
-            Ok(v) => TimeoutOutcome::Completed(v),
-            Err(_) => TimeoutOutcome::TimedOut,
-        }
-    }
-}
-
-pub async fn run_workers_for<I, F, Fut>(tasks: I)
-where
-    I: IntoIterator<Item = F>,
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = ()> + Send + 'static,
-{
-    let mut set = tokio::task::JoinSet::new();
-    for task in tasks {
-        set.spawn(task());
-    }
-    while set.join_next().await.is_some() {}
 }
 
 #[cfg(test)]

--- a/tests/slo/slo-framework/src/metrics.rs
+++ b/tests/slo/slo-framework/src/metrics.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use hdrhistogram::Histogram;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Gauge, MeterProvider as _, UpDownCounter};
 use opentelemetry_otlp::WithExportConfig;
@@ -12,14 +10,13 @@ use opentelemetry_sdk::runtime;
 
 use crate::config::Config;
 
-const HDR_MIN_MICROSECONDS: u64 = 1;
-const HDR_MAX_MICROSECONDS: u64 = 60_000_000;
-const HDR_SIGNIFICANT_DIGITS: u8 = 5;
+use self::latency::LatencySeries;
+
+mod latency;
 
 pub type OperationType = &'static str;
 pub const OPERATION_READ: OperationType = "read";
 pub const OPERATION_WRITE: OperationType = "write";
-pub const OPERATION_MESSAGE_RTT: OperationType = "message_rtt";
 
 const STATUS_SUCCESS: &str = "success";
 const STATUS_FAILURE: &str = "failure";
@@ -32,51 +29,14 @@ pub struct Metrics {
 struct MetricsInner {
     ref_name: String,
     provider: Option<SdkMeterProvider>,
-    latency: Arc<Mutex<LatencyHistogram>>,
+    operation_latency: Arc<Mutex<LatencySeries>>,
+    topic_e2e_latency: Arc<Mutex<LatencySeries>>,
     operations_total: Option<Counter<u64>>,
     retry_attempts_total: Option<Counter<u64>>,
     retry_attempts: Option<Gauge<u64>>,
     pending_operations: Option<UpDownCounter<i64>>,
     errors_total: Option<Counter<u64>>,
     timeouts_total: Option<Counter<u64>>,
-}
-
-struct LatencyHistogram {
-    by_attrs: HashMap<String, Histogram<u64>>,
-    cached_percentiles: HashMap<String, [f64; 3]>,
-}
-
-impl LatencyHistogram {
-    fn new() -> Self {
-        Self {
-            by_attrs: HashMap::new(),
-            cached_percentiles: HashMap::new(),
-        }
-    }
-
-    fn record(&mut self, latency_micros: u64, attrs_key: String) {
-        let hist = self.by_attrs.entry(attrs_key.clone()).or_insert_with(|| {
-            Histogram::new_with_bounds(
-                HDR_MIN_MICROSECONDS,
-                HDR_MAX_MICROSECONDS,
-                HDR_SIGNIFICANT_DIGITS,
-            )
-            .expect("valid hdr bounds")
-        });
-        hist.record(latency_micros).ok();
-        self.cached_percentiles.insert(
-            attrs_key,
-            [
-                hist.value_at_quantile(0.5) as f64 / 1_000_000.0,
-                hist.value_at_quantile(0.95) as f64 / 1_000_000.0,
-                hist.value_at_quantile(0.99) as f64 / 1_000_000.0,
-            ],
-        );
-    }
-
-    fn percentiles(&self) -> &HashMap<String, [f64; 3]> {
-        &self.cached_percentiles
-    }
 }
 
 pub struct Span {
@@ -87,7 +47,8 @@ pub struct Span {
 
 impl Metrics {
     pub fn new(cfg: &Config) -> Result<Self, String> {
-        let latency = Arc::new(Mutex::new(LatencyHistogram::new()));
+        let operation_latency = Arc::new(Mutex::new(LatencySeries::new()));
+        let topic_e2e_latency = Arc::new(Mutex::new(LatencySeries::new()));
         let ref_name = cfg.ref_name.clone();
         let label = cfg.label.clone();
 
@@ -96,7 +57,8 @@ impl Metrics {
                 inner: Arc::new(MetricsInner {
                     ref_name,
                     provider: None,
-                    latency,
+                    operation_latency,
+                    topic_e2e_latency,
                     operations_total: None,
                     retry_attempts_total: None,
                     retry_attempts: None,
@@ -132,47 +94,25 @@ impl Metrics {
 
         let meter = provider.meter("slo-workload");
 
-        let latency_p50 = latency.clone();
-        let _latency_p50 = meter
-            .f64_observable_gauge("sdk.operation.latency.p50.seconds")
-            .with_description("50th percentile latency of operations in seconds")
-            .with_unit("s")
-            .with_callback(move |observer| {
-                for (attrs_key, vals) in latency_p50.lock().unwrap().percentiles() {
-                    observer.observe(vals[0], &attrs_from_key(attrs_key));
-                }
-            })
-            .build();
-
-        let latency_p95 = latency.clone();
-        let _latency_p95 = meter
-            .f64_observable_gauge("sdk.operation.latency.p95.seconds")
-            .with_description("95th percentile latency of operations in seconds")
-            .with_unit("s")
-            .with_callback(move |observer| {
-                for (attrs_key, vals) in latency_p95.lock().unwrap().percentiles() {
-                    observer.observe(vals[1], &attrs_from_key(attrs_key));
-                }
-            })
-            .build();
-
-        let latency_p99 = latency.clone();
-        let _latency_p99 = meter
-            .f64_observable_gauge("sdk.operation.latency.p99.seconds")
-            .with_description("99th percentile latency of operations in seconds")
-            .with_unit("s")
-            .with_callback(move |observer| {
-                for (attrs_key, vals) in latency_p99.lock().unwrap().percentiles() {
-                    observer.observe(vals[2], &attrs_from_key(attrs_key));
-                }
-            })
-            .build();
+        latency::register_gauges(
+            &meter,
+            operation_latency.clone(),
+            "sdk.operation.latency",
+            "operation latency",
+        );
+        latency::register_gauges(
+            &meter,
+            topic_e2e_latency.clone(),
+            "sdk.topic.e2e.latency",
+            "topic end-to-end latency",
+        );
 
         Ok(Self {
             inner: Arc::new(MetricsInner {
                 ref_name,
                 provider: Some(provider),
-                latency,
+                operation_latency,
+                topic_e2e_latency,
                 operations_total: Some(
                     meter
                         .u64_counter("sdk.operations.total")
@@ -219,19 +159,19 @@ impl Metrics {
 
     pub fn record_latency_with_attrs_key(&self, attrs_key: String, latency: Duration) {
         self.inner
-            .latency
+            .operation_latency
             .lock()
             .unwrap()
             .record(latency.as_micros() as u64, attrs_key);
     }
 
-    pub fn record_latency_with_operation(&self, operation_type: OperationType, latency: Duration) {
-        let attrs_key = format!(
-            "ref={};operation_type={};operation_status={}",
-            self.inner.ref_name, operation_type, STATUS_SUCCESS
-        );
-
-        self.record_latency_with_attrs_key(attrs_key, latency);
+    pub fn record_topic_e2e_latency(&self, latency: Duration) {
+        let attrs_key = format!("ref={}", self.inner.ref_name);
+        self.inner
+            .topic_e2e_latency
+            .lock()
+            .unwrap()
+            .record(latency.as_micros() as u64, attrs_key);
     }
 
     pub fn start(&self, operation_type: OperationType) -> Span {

--- a/tests/slo/slo-framework/src/metrics.rs
+++ b/tests/slo/slo-framework/src/metrics.rs
@@ -43,6 +43,7 @@ pub struct Span {
     metrics: Metrics,
     operation_type: OperationType,
     started: Instant,
+    pending: bool,
 }
 
 impl Metrics {
@@ -189,6 +190,7 @@ impl Metrics {
             metrics: self.clone(),
             operation_type,
             started: Instant::now(),
+            pending: true,
         }
     }
 
@@ -206,7 +208,7 @@ impl Metrics {
 }
 
 impl Span {
-    pub fn finish(self, err: Option<&str>, attempts: u64) {
+    pub fn finish(mut self, err: Option<&str>, attempts: u64) {
         let status = if err.is_some() {
             STATUS_FAILURE
         } else {
@@ -231,15 +233,7 @@ impl Span {
         if let Some(gauge) = &self.metrics.inner.retry_attempts {
             gauge.record(attempts, &attrs);
         }
-        if let Some(counter) = &self.metrics.inner.pending_operations {
-            counter.add(
-                -1,
-                &[
-                    KeyValue::new("ref", self.metrics.inner.ref_name.clone()),
-                    KeyValue::new("operation_type", self.operation_type),
-                ],
-            );
-        }
+        self.finish_pending();
 
         if let Some(err_msg) = err {
             if (err_msg.contains("timeout") || err_msg.contains("deadline"))
@@ -256,7 +250,16 @@ impl Span {
         }
     }
 
-    pub fn cancel(self) {
+    pub fn cancel(mut self) {
+        self.finish_pending();
+    }
+
+    fn finish_pending(&mut self) {
+        if !self.pending {
+            return;
+        }
+        self.pending = false;
+
         if let Some(counter) = &self.metrics.inner.pending_operations {
             counter.add(
                 -1,
@@ -266,6 +269,12 @@ impl Span {
                 ],
             );
         }
+    }
+}
+
+impl Drop for Span {
+    fn drop(&mut self) {
+        self.finish_pending();
     }
 }
 

--- a/tests/slo/slo-framework/src/metrics.rs
+++ b/tests/slo/slo-framework/src/metrics.rs
@@ -28,15 +28,16 @@ pub struct Metrics {
 
 struct MetricsInner {
     ref_name: String,
-    provider: Option<SdkMeterProvider>,
     operation_latency: Arc<Mutex<LatencySeries>>,
     topic_e2e_latency: Arc<Mutex<LatencySeries>>,
-    operations_total: Option<Counter<u64>>,
-    retry_attempts_total: Option<Counter<u64>>,
-    retry_attempts: Option<Gauge<u64>>,
-    pending_operations: Option<UpDownCounter<i64>>,
-    errors_total: Option<Counter<u64>>,
-    timeouts_total: Option<Counter<u64>>,
+    operations_total: Counter<u64>,
+    retry_attempts_total: Counter<u64>,
+    retry_attempts: Gauge<u64>,
+    pending_operations: UpDownCounter<i64>,
+    errors_total: Counter<u64>,
+    timeouts_total: Counter<u64>,
+    // Keeps the provider alive until all metric instruments are dropped.
+    _provider: SdkMeterProvider,
 }
 
 pub struct Span {
@@ -51,109 +52,83 @@ impl Metrics {
         let operation_latency = Arc::new(Mutex::new(LatencySeries::new()));
         let topic_e2e_latency = Arc::new(Mutex::new(LatencySeries::new()));
         let ref_name = cfg.ref_name.clone();
-        let label = cfg.label.clone();
-
-        let Some(endpoint) = cfg.otlp_endpoint.as_ref() else {
-            return Ok(Self {
-                inner: Arc::new(MetricsInner {
-                    ref_name,
-                    provider: None,
-                    operation_latency,
-                    topic_e2e_latency,
-                    operations_total: None,
-                    retry_attempts_total: None,
-                    retry_attempts: None,
-                    pending_operations: None,
-                    errors_total: None,
-                    timeouts_total: None,
-                }),
-            });
-        };
-
-        let exporter = opentelemetry_otlp::MetricExporter::builder()
-            .with_http()
-            .with_endpoint(endpoint.clone())
-            .with_temporality(Temporality::Cumulative)
-            .build()
-            .map_err(|err| format!("failed to create OTLP exporter: {err}"))?;
-
-        let reader = PeriodicReader::builder(exporter, runtime::Tokio)
-            .with_interval(Duration::from_secs(1))
-            .build();
 
         let resource = Resource::new(vec![
-            KeyValue::new("service.name", label.clone()),
+            KeyValue::new("service.name", cfg.label.clone()),
             KeyValue::new("ref", ref_name.clone()),
             KeyValue::new("sdk", "rust"),
             KeyValue::new("sdk_version", env!("CARGO_PKG_VERSION")),
         ]);
 
-        let provider = SdkMeterProvider::builder()
-            .with_resource(resource)
-            .with_reader(reader)
-            .build();
+        let provider_builder = SdkMeterProvider::builder().with_resource(resource);
+        let provider = if let Some(endpoint) = &cfg.otlp_endpoint {
+            let exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
+                .with_endpoint(endpoint.clone())
+                .with_temporality(Temporality::Cumulative)
+                .build()
+                .map_err(|err| format!("failed to create OTLP exporter: {err}"))?;
+
+            let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+                .with_interval(Duration::from_secs(1))
+                .build();
+
+            provider_builder.with_reader(reader).build()
+        } else {
+            provider_builder.build()
+        };
 
         let meter = provider.meter("slo-workload");
 
-        latency::register_gauges(
-            &meter,
-            operation_latency.clone(),
-            "sdk.operation.latency",
-            "operation latency",
-        );
-        latency::register_gauges(
-            &meter,
-            topic_e2e_latency.clone(),
-            "sdk.topic.e2e.latency",
-            "topic end-to-end latency",
-        );
+        if cfg.otlp_endpoint.is_some() {
+            latency::register_gauges(
+                &meter,
+                operation_latency.clone(),
+                "sdk.operation.latency",
+                "operation latency",
+            );
+            latency::register_gauges(
+                &meter,
+                topic_e2e_latency.clone(),
+                "sdk.topic.e2e.latency",
+                "topic end-to-end latency",
+            );
+        }
 
         Ok(Self {
             inner: Arc::new(MetricsInner {
                 ref_name,
-                provider: Some(provider),
                 operation_latency,
                 topic_e2e_latency,
-                operations_total: Some(
-                    meter
-                        .u64_counter("sdk.operations.total")
-                        .with_description("Total number of operations, categorized by type")
-                        .with_unit("{operation}")
-                        .build(),
-                ),
-                retry_attempts_total: Some(
-                    meter
-                        .u64_counter("sdk.retry.attempts.total")
-                        .with_description("Total number of retry attempts")
-                        .with_unit("{attempt}")
-                        .build(),
-                ),
-                retry_attempts: Some(
-                    meter
-                        .u64_gauge("sdk.retry.attempts")
-                        .with_description("Current retry attempts")
-                        .build(),
-                ),
-                pending_operations: Some(
-                    meter
-                        .i64_up_down_counter("sdk.pending.operations")
-                        .with_description("Current number of pending operations")
-                        .build(),
-                ),
-                errors_total: Some(
-                    meter
-                        .u64_counter("sdk.errors.total")
-                        .with_description("Total number of errors encountered")
-                        .with_unit("{error}")
-                        .build(),
-                ),
-                timeouts_total: Some(
-                    meter
-                        .u64_counter("sdk.timeouts.total")
-                        .with_description("Total number of timeout errors")
-                        .with_unit("{timeout}")
-                        .build(),
-                ),
+                operations_total: meter
+                    .u64_counter("sdk.operations.total")
+                    .with_description("Total number of operations, categorized by type")
+                    .with_unit("{operation}")
+                    .build(),
+                retry_attempts_total: meter
+                    .u64_counter("sdk.retry.attempts.total")
+                    .with_description("Total number of retry attempts")
+                    .with_unit("{attempt}")
+                    .build(),
+                retry_attempts: meter
+                    .u64_gauge("sdk.retry.attempts")
+                    .with_description("Current retry attempts")
+                    .build(),
+                pending_operations: meter
+                    .i64_up_down_counter("sdk.pending.operations")
+                    .with_description("Current number of pending operations")
+                    .build(),
+                errors_total: meter
+                    .u64_counter("sdk.errors.total")
+                    .with_description("Total number of errors encountered")
+                    .with_unit("{error}")
+                    .build(),
+                timeouts_total: meter
+                    .u64_counter("sdk.timeouts.total")
+                    .with_description("Total number of timeout errors")
+                    .with_unit("{timeout}")
+                    .build(),
+                _provider: provider,
             }),
         })
     }
@@ -176,33 +151,19 @@ impl Metrics {
     }
 
     pub fn start(&self, operation_type: OperationType) -> Span {
-        if let Some(counter) = &self.inner.pending_operations {
-            counter.add(
-                1,
-                &[
-                    KeyValue::new("ref", self.inner.ref_name.clone()),
-                    KeyValue::new("operation_type", operation_type),
-                ],
-            );
-        }
+        self.inner.pending_operations.add(
+            1,
+            &[
+                KeyValue::new("ref", self.inner.ref_name.clone()),
+                KeyValue::new("operation_type", operation_type),
+            ],
+        );
 
         Span {
             metrics: self.clone(),
             operation_type,
             started: Instant::now(),
             pending: true,
-        }
-    }
-
-    pub async fn push(&self) {
-        if let Some(provider) = &self.inner.provider {
-            let _ = provider.force_flush();
-        }
-    }
-
-    pub async fn close(&self) {
-        if let Some(provider) = &self.inner.provider {
-            let _ = provider.shutdown();
         }
     }
 }
@@ -224,29 +185,22 @@ impl Span {
         self.metrics
             .record_latency_with_attrs_key(attrs_key, self.started.elapsed());
 
-        if let Some(counter) = &self.metrics.inner.operations_total {
-            counter.add(1, &attrs);
-        }
-        if let Some(counter) = &self.metrics.inner.retry_attempts_total {
-            counter.add(attempts, &attrs);
-        }
-        if let Some(gauge) = &self.metrics.inner.retry_attempts {
-            gauge.record(attempts, &attrs);
-        }
+        self.metrics.inner.operations_total.add(1, &attrs);
+        self.metrics
+            .inner
+            .retry_attempts_total
+            .add(attempts, &attrs);
+        self.metrics.inner.retry_attempts.record(attempts, &attrs);
         self.finish_pending();
 
         if let Some(err_msg) = err {
-            if (err_msg.contains("timeout") || err_msg.contains("deadline"))
-                && let Some(counter) = &self.metrics.inner.timeouts_total
-            {
-                counter.add(1, &attrs);
+            if err_msg.contains("timeout") || err_msg.contains("deadline") {
+                self.metrics.inner.timeouts_total.add(1, &attrs);
             }
-            if let Some(counter) = &self.metrics.inner.errors_total {
-                let mut error_attrs = attrs;
-                error_attrs.push(KeyValue::new("error_category", "ydb"));
-                error_attrs.push(KeyValue::new("error_name", err_msg.to_string()));
-                counter.add(1, &error_attrs);
-            }
+            let mut error_attrs = attrs;
+            error_attrs.push(KeyValue::new("error_category", "ydb"));
+            error_attrs.push(KeyValue::new("error_name", err_msg.to_string()));
+            self.metrics.inner.errors_total.add(1, &error_attrs);
         }
     }
 
@@ -260,15 +214,13 @@ impl Span {
         }
         self.pending = false;
 
-        if let Some(counter) = &self.metrics.inner.pending_operations {
-            counter.add(
-                -1,
-                &[
-                    KeyValue::new("ref", self.metrics.inner.ref_name.clone()),
-                    KeyValue::new("operation_type", self.operation_type),
-                ],
-            );
-        }
+        self.metrics.inner.pending_operations.add(
+            -1,
+            &[
+                KeyValue::new("ref", self.metrics.inner.ref_name.clone()),
+                KeyValue::new("operation_type", self.operation_type),
+            ],
+        );
     }
 }
 

--- a/tests/slo/slo-framework/src/metrics.rs
+++ b/tests/slo/slo-framework/src/metrics.rs
@@ -134,20 +134,17 @@ impl Metrics {
     }
 
     pub fn record_latency_with_attrs_key(&self, attrs_key: String, latency: Duration) {
-        self.inner
-            .operation_latency
-            .lock()
-            .unwrap()
-            .record(latency.as_micros() as u64, attrs_key);
+        record_latency_series(&self.inner.operation_latency, latency, attrs_key);
     }
 
     pub fn record_topic_e2e_latency(&self, latency: Duration) {
         let attrs_key = format!("ref={}", self.inner.ref_name);
-        self.inner
-            .topic_e2e_latency
-            .lock()
-            .unwrap()
-            .record(latency.as_micros() as u64, attrs_key);
+        record_latency_series(&self.inner.topic_e2e_latency, latency, attrs_key);
+    }
+
+    pub(crate) fn check(&self) -> Result<(), String> {
+        check_latency_series(&self.inner.operation_latency, "operation latency")?;
+        check_latency_series(&self.inner.topic_e2e_latency, "topic end-to-end latency")
     }
 
     pub fn start(&self, operation_type: OperationType) -> Span {
@@ -165,6 +162,26 @@ impl Metrics {
             started: Instant::now(),
             pending: true,
         }
+    }
+}
+
+fn record_latency_series(series: &Mutex<LatencySeries>, latency: Duration, attrs_key: String) {
+    match series.lock() {
+        Ok(mut series) => series.record(latency, attrs_key),
+        Err(poisoned) => poisoned
+            .into_inner()
+            .fail("latency histogram lock is poisoned"),
+    }
+}
+
+fn check_latency_series(series: &Mutex<LatencySeries>, name: &str) -> Result<(), String> {
+    let series = series
+        .lock()
+        .map_err(|_| format!("{name} histogram lock is poisoned"))?;
+
+    match series.recording_error() {
+        Some(error) => Err(format!("{name} metrics failed: {error}")),
+        None => Ok(()),
     }
 }
 

--- a/tests/slo/slo-framework/src/metrics/latency.rs
+++ b/tests/slo/slo-framework/src/metrics/latency.rs
@@ -1,0 +1,134 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use hdrhistogram::Histogram;
+use opentelemetry::metrics::Meter;
+
+const HDR_MIN_MICROSECONDS: u64 = 1;
+const HDR_MAX_MICROSECONDS: u64 = 60_000_000;
+const HDR_SIGNIFICANT_DIGITS: u8 = 5;
+
+const LATENCY_PERCENTILES: [LatencyPercentile; 3] = [
+    LatencyPercentile {
+        metric_suffix: "p50",
+        quantile: 0.50,
+    },
+    LatencyPercentile {
+        metric_suffix: "p95",
+        quantile: 0.95,
+    },
+    LatencyPercentile {
+        metric_suffix: "p99",
+        quantile: 0.99,
+    },
+];
+
+struct LatencyPercentile {
+    metric_suffix: &'static str,
+    quantile: f64,
+}
+
+pub(super) struct LatencySeries {
+    histograms: HashMap<String, Histogram<u64>>,
+    // The first percentile callback snapshots and resets the histograms. The
+    // remaining callbacks read that snapshot in any order while new samples
+    // accumulate for the next collection.
+    pending_snapshot: Option<LatencySnapshot>,
+}
+
+struct LatencySnapshot {
+    percentiles: HashMap<String, [f64; LATENCY_PERCENTILES.len()]>,
+    callbacks_remaining: usize,
+}
+
+impl LatencySeries {
+    pub(super) fn new() -> Self {
+        Self {
+            histograms: HashMap::new(),
+            pending_snapshot: None,
+        }
+    }
+
+    pub(super) fn record(&mut self, latency_micros: u64, attrs_key: String) {
+        let histogram = self.histograms.entry(attrs_key).or_insert_with(|| {
+            Histogram::new_with_bounds(
+                HDR_MIN_MICROSECONDS,
+                HDR_MAX_MICROSECONDS,
+                HDR_SIGNIFICANT_DIGITS,
+            )
+            .expect("valid hdr bounds")
+        });
+        histogram.record(latency_micros).ok();
+    }
+
+    fn observations_for(&mut self, percentile_index: usize) -> Vec<(String, f64)> {
+        let mut snapshot = match self.pending_snapshot.take() {
+            Some(snapshot) => snapshot,
+            None => self.snapshot_and_reset(),
+        };
+        let observations = snapshot
+            .percentiles
+            .iter()
+            .map(|(attrs, values)| (attrs.clone(), values[percentile_index]))
+            .collect();
+
+        if snapshot.callbacks_remaining > 1 {
+            snapshot.callbacks_remaining -= 1;
+            self.pending_snapshot = Some(snapshot);
+        }
+
+        observations
+    }
+
+    fn snapshot_and_reset(&mut self) -> LatencySnapshot {
+        let percentiles = self
+            .histograms
+            .iter_mut()
+            .filter_map(|(attrs, histogram)| {
+                if histogram.is_empty() {
+                    return None;
+                }
+
+                let values = LATENCY_PERCENTILES.map(|percentile| {
+                    histogram.value_at_quantile(percentile.quantile) as f64 / 1_000_000.0
+                });
+                histogram.reset();
+
+                Some((attrs.clone(), values))
+            })
+            .collect();
+
+        LatencySnapshot {
+            percentiles,
+            callbacks_remaining: LATENCY_PERCENTILES.len(),
+        }
+    }
+}
+
+pub(super) fn register_gauges(
+    meter: &Meter,
+    series: Arc<Mutex<LatencySeries>>,
+    metric_prefix: &'static str,
+    description: &'static str,
+) {
+    for (index, percentile) in LATENCY_PERCENTILES.into_iter().enumerate() {
+        let series = series.clone();
+        meter
+            .f64_observable_gauge(format!(
+                "{metric_prefix}.{}.seconds",
+                percentile.metric_suffix
+            ))
+            .with_description(format!(
+                "{} {description} in seconds",
+                percentile.metric_suffix.to_uppercase()
+            ))
+            .with_unit("s")
+            .with_callback(move |observer| {
+                let observations = series.lock().unwrap().observations_for(index);
+                for (attrs_key, value) in observations {
+                    observer.observe(value, &super::attrs_from_key(&attrs_key));
+                }
+            })
+            .build();
+    }
+}

--- a/tests/slo/slo-framework/src/metrics/latency.rs
+++ b/tests/slo/slo-framework/src/metrics/latency.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use hdrhistogram::Histogram;
 use opentelemetry::metrics::Meter;
 
-const HDR_MIN_MICROSECONDS: u64 = 1;
-const HDR_MAX_MICROSECONDS: u64 = 60_000_000;
-const HDR_SIGNIFICANT_DIGITS: u8 = 5;
+const HDR_SIGNIFICANT_DIGITS: u8 = 3;
 
 const LATENCY_PERCENTILES: [LatencyPercentile; 3] = [
     LatencyPercentile {
@@ -30,10 +29,12 @@ struct LatencyPercentile {
 
 pub(super) struct LatencySeries {
     histograms: HashMap<String, Histogram<u64>>,
-    // The first percentile callback snapshots and resets the histograms. The
-    // remaining callbacks read that snapshot in any order while new samples
-    // accumulate for the next collection.
+    // OpenTelemetry 0.27 invokes all registered callbacks sequentially during
+    // one collection. The first callback snapshots and resets the histograms;
+    // the remaining callbacks read that snapshot while new samples accumulate
+    // for the next collection.
     pending_snapshot: Option<LatencySnapshot>,
+    recording_error: Option<String>,
 }
 
 struct LatencySnapshot {
@@ -46,19 +47,45 @@ impl LatencySeries {
         Self {
             histograms: HashMap::new(),
             pending_snapshot: None,
+            recording_error: None,
         }
     }
 
-    pub(super) fn record(&mut self, latency_micros: u64, attrs_key: String) {
-        let histogram = self.histograms.entry(attrs_key).or_insert_with(|| {
-            Histogram::new_with_bounds(
-                HDR_MIN_MICROSECONDS,
-                HDR_MAX_MICROSECONDS,
-                HDR_SIGNIFICANT_DIGITS,
-            )
-            .expect("valid hdr bounds")
-        });
-        histogram.record(latency_micros).ok();
+    pub(super) fn record(&mut self, latency: Duration, attrs_key: String) {
+        if self.recording_error.is_some() {
+            return;
+        }
+
+        if let Err(error) = self.try_record(latency, attrs_key) {
+            self.fail(error);
+        }
+    }
+
+    pub(super) fn recording_error(&self) -> Option<&str> {
+        self.recording_error.as_deref()
+    }
+
+    pub(super) fn fail(&mut self, error: impl Into<String>) {
+        if self.recording_error.is_none() {
+            self.recording_error = Some(error.into());
+        }
+    }
+
+    fn try_record(&mut self, latency: Duration, attrs_key: String) -> Result<(), String> {
+        let latency_micros = u64::try_from(latency.as_micros())
+            .map_err(|_| "latency does not fit into u64 microseconds".to_string())?;
+        let histogram = match self.histograms.entry(attrs_key) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let histogram = Histogram::new(HDR_SIGNIFICANT_DIGITS)
+                    .map_err(|error| format!("create latency histogram: {error}"))?;
+                entry.insert(histogram)
+            }
+        };
+
+        histogram
+            .record(latency_micros)
+            .map_err(|error| format!("record latency: {error}"))
     }
 
     fn observations_for(&mut self, percentile_index: usize) -> Vec<(String, f64)> {
@@ -124,11 +151,68 @@ pub(super) fn register_gauges(
             ))
             .with_unit("s")
             .with_callback(move |observer| {
-                let observations = series.lock().unwrap().observations_for(index);
+                let observations = match series.lock() {
+                    Ok(mut series) => series.observations_for(index),
+                    Err(poisoned) => {
+                        poisoned
+                            .into_inner()
+                            .fail("latency histogram lock is poisoned");
+                        Vec::new()
+                    }
+                };
                 for (attrs_key, value) in observations {
                     observer.observe(value, &super::attrs_from_key(&attrs_key));
                 }
             })
             .build();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ATTRS: &str = "ref=current;operation_type=read;operation_status=success";
+
+    #[test]
+    fn percentile_callbacks_share_one_snapshot() {
+        let mut series = LatencySeries::new();
+        series.record(Duration::from_micros(100), ATTRS.to_string());
+
+        assert_eq!(observation(&mut series, 0), 0.000_1);
+        series.record(Duration::from_micros(200), ATTRS.to_string());
+        assert_eq!(observation(&mut series, 1), 0.000_1);
+        assert_eq!(observation(&mut series, 2), 0.000_1);
+
+        assert_eq!(observation(&mut series, 0), 0.000_2);
+    }
+
+    #[test]
+    fn latency_above_previous_limit_is_recorded() {
+        let mut series = LatencySeries::new();
+        series.record(Duration::from_secs(120), ATTRS.to_string());
+
+        let latency = observation(&mut series, 2);
+        assert!((latency - 120.0).abs() < 0.1, "recorded {latency}");
+        assert_eq!(series.recording_error(), None);
+    }
+
+    #[test]
+    fn unrepresentable_latency_is_reported() {
+        let mut series = LatencySeries::new();
+        series.record(Duration::MAX, ATTRS.to_string());
+
+        assert_eq!(
+            series.recording_error(),
+            Some("latency does not fit into u64 microseconds")
+        );
+    }
+
+    fn observation(series: &mut LatencySeries, percentile_index: usize) -> f64 {
+        series
+            .observations_for(percentile_index)
+            .into_iter()
+            .find_map(|(attrs, value)| (attrs == ATTRS).then_some(value))
+            .expect("latency observation must exist")
     }
 }

--- a/tests/slo/slo-framework/src/topic/params.rs
+++ b/tests/slo/slo-framework/src/topic/params.rs
@@ -9,15 +9,13 @@ use crate::Framework;
 #[command(disable_help_flag = true, disable_version_flag = true)]
 pub struct QueueFlags {
     #[arg(long, default_value_t = 1_000)]
-    pub read_rps: u32,
-    #[arg(long, default_value_t = 100)]
     pub write_rps: u32,
-    #[arg(long, default_value_t = 120_000 /* two minutes */)]
-    pub read_timeout: u64,
-    #[arg(long, default_value_t = 120_000 /* two minutes */)]
+    #[arg(long, default_value_t = 5_000)]
+    pub delivery_timeout: u64,
+    #[arg(long, default_value_t = 5_000)]
+    pub commit_timeout: u64,
+    #[arg(long, default_value_t = 5_000)]
     pub write_timeout: u64,
-    #[arg(long, default_value_t = 100)]
-    pub commit_delay: u64,
     #[arg(long, default_value_t = 10)]
     pub partition_count: u32,
     #[arg(long, default_value = "slo-consumer")]
@@ -32,11 +30,10 @@ pub struct QueueFlags {
 
 #[derive(Debug, Clone)]
 pub struct Params {
-    pub read_rps: u32,
     pub write_rps: u32,
-    pub read_timeout: Duration,
+    pub delivery_timeout: Duration,
+    pub commit_timeout: Duration,
     pub write_timeout: Duration,
-    pub commit_delay: Duration,
     pub partition_count: u32,
     pub consumer_name: String,
     pub reader_count: u32,
@@ -55,12 +52,11 @@ pub fn parse_params(fw: &Framework) -> Params {
         .into_owned();
 
     Params {
-        read_rps: flags.read_rps,
         write_rps: flags.write_rps,
 
-        read_timeout: Duration::from_millis(flags.read_timeout),
+        delivery_timeout: Duration::from_millis(flags.delivery_timeout),
+        commit_timeout: Duration::from_millis(flags.commit_timeout),
         write_timeout: Duration::from_millis(flags.write_timeout),
-        commit_delay: Duration::from_millis(flags.commit_delay),
 
         partition_count: flags.partition_count,
         consumer_name: flags.consumer_name,

--- a/tests/slo/slo-framework/src/topic/workload.rs
+++ b/tests/slo/slo-framework/src/topic/workload.rs
@@ -170,6 +170,7 @@ async fn writer_worker(
                 let msg = err.to_string();
                 span.finish(Some(&msg), 1);
                 fw.logger.errorf(format!("write failed: {msg}"));
+                return Err(format!("writer failed: {msg}"));
             }
             Err(_) => {
                 span.finish(Some("write timeout"), 1);

--- a/tests/slo/slo-framework/src/topic/workload.rs
+++ b/tests/slo/slo-framework/src/topic/workload.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::Framework;
 use crate::framework::Workload;
-use crate::helpers::new_rate_limiter;
+use crate::helpers::{RateLimiter, new_rate_limiter};
 use crate::metrics::{OPERATION_READ, OPERATION_WRITE};
 
 use super::{Params, TopicService, verification};
@@ -150,16 +150,13 @@ fn unexpected_worker_exit(joined: Option<Result<WorkerResult, JoinError>>) -> Re
 async fn writer_worker(
     fw: Arc<Framework>,
     writer: ydb::TopicWriter,
-    limiter: Arc<ratelimit::Ratelimiter>,
+    limiter: Arc<RateLimiter>,
     operation_timeout: Duration,
 ) -> WorkerResult {
     let mut seq_no: i64 = 1;
 
     loop {
-        if let Err(wait) = limiter.try_wait() {
-            tokio::time::sleep(wait).await;
-            continue;
-        }
+        limiter.wait().await;
 
         let payload = format!("{seq_no}").into_bytes();
         seq_no = seq_no.wrapping_add(1);

--- a/tests/slo/slo-framework/src/topic/workload.rs
+++ b/tests/slo/slo-framework/src/topic/workload.rs
@@ -58,9 +58,8 @@ impl<T: TopicService + 'static> Workload for TopicWorkload<T> {
             ctx.clone(),
             self.fw.clone(),
             readers,
-            self.params.read_rps,
-            self.params.read_timeout,
-            self.params.commit_delay,
+            self.params.delivery_timeout,
+            self.params.commit_timeout,
         );
 
         let _ = tokio::join!(write_handle, read_handle);
@@ -108,8 +107,8 @@ fn spawn_writer_workers(
                 let message = ydb::TopicWriterMessage::builder().data(payload).build();
 
                 let span = fw.metrics.start(OPERATION_WRITE);
-                match timeout_or_cancel(&ctx, timeout, writer.write(message)).await {
-                    TimeoutOutcome::Completed(Ok(())) => span.finish(None, 1),
+                match timeout_or_cancel(&ctx, timeout, writer.write_with_ack(message)).await {
+                    TimeoutOutcome::Completed(Ok(_)) => span.finish(None, 1),
                     TimeoutOutcome::Completed(Err(err)) => {
                         let msg = err.to_string();
                         span.finish(Some(&msg), 1);
@@ -133,71 +132,96 @@ fn spawn_reader_workers(
     ctx: CancellationToken,
     fw: Arc<Framework>,
     readers: Vec<ydb::TopicReader>,
-    rps: u32,
-    timeout: Duration,
-    commit_delay: Duration,
+    delivery_timeout: Duration,
+    commit_timeout: Duration,
 ) -> tokio::task::JoinHandle<()> {
-    let limiter = Arc::new(new_rate_limiter(rps));
     let messages_order = Arc::new(verification::MessagesOrder::default());
     let offsets_order = Arc::new(verification::OffsetOrder::default());
 
-    tokio::spawn(run_workers_for(readers.into_iter().map(move |reader| {
-        let ctx = ctx.clone();
-        let fw = fw.clone();
-        let limiter = limiter.clone();
+    tokio::spawn(run_workers_for(readers.into_iter().map(
+        move |mut reader| {
+            let ctx = ctx.clone();
+            let fw = fw.clone();
 
-        let reader = Arc::new(tokio::sync::Mutex::new(reader));
-        let messages_order = messages_order.clone();
-        let offset_order = offsets_order.clone();
+            let messages_order = messages_order.clone();
+            let offset_order = offsets_order.clone();
 
-        move || async move {
-            while !ctx.is_cancelled() {
-                if let Err(wait) = limiter.try_wait() {
-                    tokio::time::sleep(wait).await;
-                    continue;
-                }
-
-                let span = fw.metrics.start(OPERATION_READ);
-
-                match timeout_or_cancel(&ctx, timeout, reader.lock().await.read_batch()).await {
-                    TimeoutOutcome::Completed(Ok(mut batch)) => {
-                        if let Err(err) =
-                            process_batch(&fw, &messages_order, &offset_order, &mut batch).await
-                        {
-                            fw.logger.errorf(format!("invariant violated: {err}"));
-                            span.finish(Some(&err), 1);
+            move || async move {
+                while !ctx.is_cancelled() {
+                    let delivery_span = fw.metrics.start(OPERATION_READ);
+                    let mut batch = match timeout_or_cancel(
+                        &ctx,
+                        delivery_timeout,
+                        reader.read_batch(),
+                    )
+                    .await
+                    {
+                        TimeoutOutcome::Completed(Ok(batch)) => batch,
+                        TimeoutOutcome::Completed(Err(err)) => {
+                            let msg = err.to_string();
+                            delivery_span.finish(Some(&msg), 1);
+                            fw.logger.errorf(format!("read failed: {msg}"));
                             continue;
                         }
+                        TimeoutOutcome::TimedOut => {
+                            delivery_span.finish(Some("message delivery timeout"), 1);
+                            fw.logger.errorf("read failed: message delivery timeout");
+                            continue;
+                        }
+                        TimeoutOutcome::Cancelled => {
+                            delivery_span.cancel();
+                            break;
+                        }
+                    };
 
-                        spawn_commit(
-                            fw.clone(),
-                            reader.clone(),
-                            offset_order.clone(),
-                            batch.partition_id(),
-                            batch.offset(),
-                            batch.get_commit_marker(),
-                            commit_delay,
-                        );
+                    if let Err(err) =
+                        process_batch(&fw, &messages_order, &offset_order, &mut batch).await
+                    {
+                        delivery_span.finish(Some(&err), 1);
+                        fw.logger.errorf(format!("invariant violated: {err}"));
+                        continue;
+                    }
 
-                        span.finish(None, 1)
-                    }
-                    TimeoutOutcome::Completed(Err(err)) => {
-                        let msg = err.to_string();
-                        span.finish(Some(&msg), 1);
-                        fw.logger.errorf(format!("read failed: {msg}"));
-                    }
-                    TimeoutOutcome::TimedOut => {
-                        span.finish(Some("read timeout"), 1);
-                        fw.logger.errorf("read failed: timeout");
-                    }
-                    TimeoutOutcome::Cancelled => {
-                        span.cancel();
-                        break;
+                    // A delivered batch is not a completed read operation until
+                    // its offset commit is acknowledged. The commit span below
+                    // records that single successful operation.
+                    delivery_span.cancel();
+
+                    let partition_id = batch.partition_id();
+                    let end_offset = batch.offset();
+                    let commit_marker = batch.get_commit_marker();
+                    let span = fw.metrics.start(OPERATION_READ);
+
+                    match timeout_or_cancel(
+                        &ctx,
+                        commit_timeout,
+                        reader.commit_with_ack(commit_marker),
+                    )
+                    .await
+                    {
+                        TimeoutOutcome::Completed(Ok(())) => {
+                            offset_order.insert(partition_id, end_offset);
+                            span.finish(None, 1);
+                        }
+                        TimeoutOutcome::Completed(Err(err)) => {
+                            let msg = err.to_string();
+                            span.finish(Some(&msg), 1);
+                            fw.logger
+                                .errorf(format!("commit acknowledgement failed: {msg}"));
+                        }
+                        TimeoutOutcome::TimedOut => {
+                            span.finish(Some("commit acknowledgement timeout"), 1);
+                            fw.logger.errorf("commit acknowledgement failed: timeout");
+                        }
+                        TimeoutOutcome::Cancelled => {
+                            span.cancel();
+                            break;
+                        }
                     }
                 }
             }
-        }
-    })))
+        },
+    )))
 }
 
 async fn process_batch(
@@ -244,26 +268,4 @@ fn record_topic_e2e_latency(
     fw.metrics.record_topic_e2e_latency(latency);
 
     Ok(())
-}
-
-fn spawn_commit(
-    fw: Arc<Framework>,
-    reader: Arc<tokio::sync::Mutex<ydb::TopicReader>>,
-    offset_order: Arc<verification::OffsetOrder>,
-
-    partition_id: i64,
-    offset: i64,
-
-    commit_marker: ydb::TopicReaderCommitMarker,
-    commit_delay: Duration,
-) {
-    tokio::spawn(async move {
-        tokio::time::sleep(commit_delay).await;
-        let handle = reader.lock().await.commit_with_ack(commit_marker);
-
-        match handle.await {
-            Ok(()) => offset_order.insert(partition_id, offset),
-            Err(err) => fw.logger.printf(format!("commit not acked: {err}")),
-        }
-    });
 }

--- a/tests/slo/slo-framework/src/topic/workload.rs
+++ b/tests/slo/slo-framework/src/topic/workload.rs
@@ -196,7 +196,7 @@ async fn reader_worker(
                 let msg = err.to_string();
                 delivery_span.finish(Some(&msg), 1);
                 fw.logger.errorf(format!("read failed: {msg}"));
-                continue;
+                return Err(format!("reader {worker_id} failed: {msg}"));
             }
             Err(_) => {
                 delivery_span.finish(Some("message delivery timeout"), 1);

--- a/tests/slo/slo-framework/src/topic/workload.rs
+++ b/tests/slo/slo-framework/src/topic/workload.rs
@@ -6,7 +6,7 @@ use tokio_util::sync::CancellationToken;
 use crate::Framework;
 use crate::framework::Workload;
 use crate::helpers::{TimeoutOutcome, new_rate_limiter, run_workers_for, timeout_or_cancel};
-use crate::metrics::{OPERATION_MESSAGE_RTT, OPERATION_READ, OPERATION_WRITE};
+use crate::metrics::{OPERATION_READ, OPERATION_WRITE};
 
 use super::{Params, TopicService, verification};
 
@@ -206,8 +206,6 @@ async fn process_batch(
     offset_order: &verification::OffsetOrder,
     batch: &mut ydb::TopicReaderBatch,
 ) -> Result<(), String> {
-    let now = std::time::SystemTime::now();
-
     for message in batch.messages.iter_mut() {
         let payload = message
             .read_and_take()
@@ -225,27 +223,25 @@ async fn process_batch(
 
         messages_order.insert(message)?;
         offset_order.ack_message(message)?;
-        log_message_rtt_latency(fw, message, now)?;
+        record_topic_e2e_latency(fw, message)?;
     }
 
     Ok(())
 }
 
-fn log_message_rtt_latency(
+fn record_topic_e2e_latency(
     fw: &Framework,
     message: &ydb::TopicReaderMessage,
-    now: std::time::SystemTime,
 ) -> Result<(), String> {
     let created_at = message
         .created_at
         .ok_or_else(|| "message has no timestamp".to_string())?;
 
-    let latency = now
+    let latency = std::time::SystemTime::now()
         .duration_since(created_at)
         .map_err(|e| format!("message timestamp in the future: {e}"))?;
 
-    fw.metrics
-        .record_latency_with_operation(OPERATION_MESSAGE_RTT, latency);
+    fw.metrics.record_topic_e2e_latency(latency);
 
     Ok(())
 }

--- a/tests/slo/slo-framework/src/topic/workload.rs
+++ b/tests/slo/slo-framework/src/topic/workload.rs
@@ -1,14 +1,21 @@
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 
+use tokio::task::{JoinError, JoinSet};
+use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 use crate::Framework;
 use crate::framework::Workload;
-use crate::helpers::{TimeoutOutcome, new_rate_limiter, run_workers_for, timeout_or_cancel};
+use crate::helpers::new_rate_limiter;
 use crate::metrics::{OPERATION_READ, OPERATION_WRITE};
 
 use super::{Params, TopicService, verification};
+
+const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+type WorkerResult = Result<Infallible, String>;
 
 pub struct TopicWorkload<T: TopicService> {
     fw: Arc<Framework>,
@@ -46,25 +53,25 @@ impl<T: TopicService + 'static> Workload for TopicWorkload<T> {
             readers.len(),
         ));
 
-        let write_handle = spawn_writer_workers(
-            ctx.clone(),
+        let mut workers = JoinSet::new();
+
+        spawn_writer_workers(
+            &mut workers,
             self.fw.clone(),
             writers,
             self.params.write_rps,
             self.params.write_timeout,
         );
 
-        let read_handle = spawn_reader_workers(
-            ctx.clone(),
+        spawn_reader_workers(
+            &mut workers,
             self.fw.clone(),
             readers,
             self.params.delivery_timeout,
             self.params.commit_timeout,
         );
 
-        let _ = tokio::join!(write_handle, read_handle);
-
-        Ok(())
+        supervise_workers(ctx, workers).await
     }
 
     async fn teardown(&self, _ctx: &CancellationToken) -> Result<(), String> {
@@ -79,149 +86,160 @@ impl<T: TopicService + 'static> Workload for TopicWorkload<T> {
 }
 
 fn spawn_writer_workers(
-    ctx: CancellationToken,
+    workers: &mut JoinSet<WorkerResult>,
     fw: Arc<Framework>,
     writers: Vec<ydb::TopicWriter>,
     rps: u32,
     timeout: Duration,
-) -> tokio::task::JoinHandle<()> {
+) {
     let limiter = Arc::new(new_rate_limiter(rps));
 
-    tokio::spawn(run_workers_for(writers.into_iter().map(move |writer| {
-        let ctx = ctx.clone();
-        let fw = fw.clone();
-        let limiter = limiter.clone();
-
-        move || async move {
-            let mut seq_no: i64 = 1;
-
-            while !ctx.is_cancelled() {
-                if let Err(wait) = limiter.try_wait() {
-                    tokio::time::sleep(wait).await;
-                    continue;
-                }
-
-                let payload = format!("{seq_no}").into_bytes();
-                seq_no = seq_no.wrapping_add(1);
-
-                let message = ydb::TopicWriterMessage::builder().data(payload).build();
-
-                let span = fw.metrics.start(OPERATION_WRITE);
-                match timeout_or_cancel(&ctx, timeout, writer.write_with_ack(message)).await {
-                    TimeoutOutcome::Completed(Ok(_)) => span.finish(None, 1),
-                    TimeoutOutcome::Completed(Err(err)) => {
-                        let msg = err.to_string();
-                        span.finish(Some(&msg), 1);
-                        fw.logger.errorf(format!("write failed: {msg}"));
-                    }
-                    TimeoutOutcome::TimedOut => {
-                        span.finish(Some("write timeout"), 1);
-                        fw.logger.errorf("write failed: timeout");
-                    }
-                    TimeoutOutcome::Cancelled => {
-                        span.cancel();
-                        break;
-                    }
-                }
-            }
-        }
-    })))
+    for writer in writers {
+        workers.spawn(writer_worker(fw.clone(), writer, limiter.clone(), timeout));
+    }
 }
 
 fn spawn_reader_workers(
-    ctx: CancellationToken,
+    workers: &mut JoinSet<WorkerResult>,
     fw: Arc<Framework>,
     readers: Vec<ydb::TopicReader>,
     delivery_timeout: Duration,
     commit_timeout: Duration,
-) -> tokio::task::JoinHandle<()> {
+) {
     let messages_order = Arc::new(verification::MessagesOrder::default());
     let offsets_order = Arc::new(verification::OffsetOrder::default());
 
-    tokio::spawn(run_workers_for(readers.into_iter().map(
-        move |mut reader| {
-            let ctx = ctx.clone();
-            let fw = fw.clone();
+    for (worker_id, reader) in readers.into_iter().enumerate() {
+        workers.spawn(reader_worker(
+            worker_id,
+            fw.clone(),
+            reader,
+            messages_order.clone(),
+            offsets_order.clone(),
+            delivery_timeout,
+            commit_timeout,
+        ));
+    }
+}
 
-            let messages_order = messages_order.clone();
-            let offset_order = offsets_order.clone();
+async fn supervise_workers(
+    ctx: &CancellationToken,
+    mut workers: JoinSet<WorkerResult>,
+) -> Result<(), String> {
+    tokio::select! {
+        _ = ctx.cancelled() => {
+            workers.abort_all();
+            timeout(WORKER_SHUTDOWN_TIMEOUT, workers.shutdown())
+                .await
+                .map_err(|_| "topic workers did not stop after cancellation".to_string())?;
+            Ok(())
+        }
+        joined = workers.join_next() => unexpected_worker_exit(joined),
+    }
+}
 
-            move || async move {
-                while !ctx.is_cancelled() {
-                    let delivery_span = fw.metrics.start(OPERATION_READ);
-                    let mut batch = match timeout_or_cancel(
-                        &ctx,
-                        delivery_timeout,
-                        reader.read_batch(),
-                    )
-                    .await
-                    {
-                        TimeoutOutcome::Completed(Ok(batch)) => batch,
-                        TimeoutOutcome::Completed(Err(err)) => {
-                            let msg = err.to_string();
-                            delivery_span.finish(Some(&msg), 1);
-                            fw.logger.errorf(format!("read failed: {msg}"));
-                            continue;
-                        }
-                        TimeoutOutcome::TimedOut => {
-                            delivery_span.finish(Some("message delivery timeout"), 1);
-                            fw.logger.errorf("read failed: message delivery timeout");
-                            continue;
-                        }
-                        TimeoutOutcome::Cancelled => {
-                            delivery_span.cancel();
-                            break;
-                        }
-                    };
+fn unexpected_worker_exit(joined: Option<Result<WorkerResult, JoinError>>) -> Result<(), String> {
+    match joined {
+        Some(Ok(Err(err))) => Err(err),
+        Some(Ok(Ok(never))) => match never {},
+        Some(Err(err)) => Err(format!("topic worker task failed: {err}")),
+        None => Err("topic worker set is empty".to_string()),
+    }
+}
 
-                    if let Err(err) =
-                        process_batch(&fw, &messages_order, &offset_order, &mut batch).await
-                    {
-                        delivery_span.finish(Some(&err), 1);
-                        fw.logger.errorf(format!("invariant violated: {err}"));
-                        continue;
-                    }
+async fn writer_worker(
+    fw: Arc<Framework>,
+    writer: ydb::TopicWriter,
+    limiter: Arc<ratelimit::Ratelimiter>,
+    operation_timeout: Duration,
+) -> WorkerResult {
+    let mut seq_no: i64 = 1;
 
-                    // A delivered batch is not a completed read operation until
-                    // its offset commit is acknowledged. The commit span below
-                    // records that single successful operation.
-                    delivery_span.cancel();
+    loop {
+        if let Err(wait) = limiter.try_wait() {
+            tokio::time::sleep(wait).await;
+            continue;
+        }
 
-                    let partition_id = batch.partition_id();
-                    let end_offset = batch.offset();
-                    let commit_marker = batch.get_commit_marker();
-                    let span = fw.metrics.start(OPERATION_READ);
+        let payload = format!("{seq_no}").into_bytes();
+        seq_no = seq_no.wrapping_add(1);
 
-                    match timeout_or_cancel(
-                        &ctx,
-                        commit_timeout,
-                        reader.commit_with_ack(commit_marker),
-                    )
-                    .await
-                    {
-                        TimeoutOutcome::Completed(Ok(())) => {
-                            offset_order.insert(partition_id, end_offset);
-                            span.finish(None, 1);
-                        }
-                        TimeoutOutcome::Completed(Err(err)) => {
-                            let msg = err.to_string();
-                            span.finish(Some(&msg), 1);
-                            fw.logger
-                                .errorf(format!("commit acknowledgement failed: {msg}"));
-                        }
-                        TimeoutOutcome::TimedOut => {
-                            span.finish(Some("commit acknowledgement timeout"), 1);
-                            fw.logger.errorf("commit acknowledgement failed: timeout");
-                        }
-                        TimeoutOutcome::Cancelled => {
-                            span.cancel();
-                            break;
-                        }
-                    }
-                }
+        let message = ydb::TopicWriterMessage::builder().data(payload).build();
+        let span = fw.metrics.start(OPERATION_WRITE);
+
+        match timeout(operation_timeout, writer.write_with_ack(message)).await {
+            Ok(Ok(_)) => span.finish(None, 1),
+            Ok(Err(err)) => {
+                let msg = err.to_string();
+                span.finish(Some(&msg), 1);
+                fw.logger.errorf(format!("write failed: {msg}"));
             }
-        },
-    )))
+            Err(_) => {
+                span.finish(Some("write timeout"), 1);
+                fw.logger.errorf("write failed: timeout");
+            }
+        }
+    }
+}
+
+async fn reader_worker(
+    worker_id: usize,
+    fw: Arc<Framework>,
+    mut reader: ydb::TopicReader,
+    messages_order: Arc<verification::MessagesOrder>,
+    offset_order: Arc<verification::OffsetOrder>,
+    delivery_timeout: Duration,
+    commit_timeout: Duration,
+) -> WorkerResult {
+    loop {
+        let delivery_span = fw.metrics.start(OPERATION_READ);
+        let mut batch = match timeout(delivery_timeout, reader.read_batch()).await {
+            Ok(Ok(batch)) => batch,
+            Ok(Err(err)) => {
+                let msg = err.to_string();
+                delivery_span.finish(Some(&msg), 1);
+                fw.logger.errorf(format!("read failed: {msg}"));
+                continue;
+            }
+            Err(_) => {
+                delivery_span.finish(Some("message delivery timeout"), 1);
+                fw.logger.errorf("read failed: message delivery timeout");
+                continue;
+            }
+        };
+
+        if let Err(err) = process_batch(&fw, &messages_order, &offset_order, &mut batch).await {
+            delivery_span.finish(Some(&err), 1);
+            return Err(format!("reader {worker_id} invariant violated: {err}"));
+        }
+
+        // A delivered batch is not a completed read operation until
+        // its offset commit is acknowledged. The commit span below
+        // records that single successful operation.
+        delivery_span.cancel();
+
+        let partition_id = batch.partition_id();
+        let end_offset = batch.offset();
+        let commit_marker = batch.get_commit_marker();
+        let span = fw.metrics.start(OPERATION_READ);
+
+        match timeout(commit_timeout, reader.commit_with_ack(commit_marker)).await {
+            Ok(Ok(())) => {
+                offset_order.insert(partition_id, end_offset);
+                span.finish(None, 1);
+            }
+            Ok(Err(err)) => {
+                let msg = err.to_string();
+                span.finish(Some(&msg), 1);
+                fw.logger
+                    .errorf(format!("commit acknowledgement failed: {msg}"));
+            }
+            Err(_) => {
+                span.finish(Some("commit acknowledgement timeout"), 1);
+                fw.logger.errorf("commit acknowledgement failed: timeout");
+            }
+        }
+    }
 }
 
 async fn process_batch(

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -359,6 +359,7 @@ impl YdbError {
                     | StatusCode::Unavailable
                     | StatusCode::Overloaded
                     | StatusCode::BadSession
+                    | StatusCode::SessionExpired
                     | StatusCode::SessionBusy => NeedRetry::True,
                     StatusCode::Undetermined => NeedRetry::IdempotentOnly,
                     _ => NeedRetry::False,


### PR DESCRIPTION
  ## Pull request type

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting, renaming)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] Documentation content changes
  - [ ] Other (please describe):

  ## What is the current behavior?

  Topic SLO records message RTT as a generic operation latency, so it is not included
  in the resulting statistics.

  Some operation metrics are also reported too early: writes are counted before
  write acknowledgement, and reads before commit acknowledgement. Worker failures
  and invariant violations may be lost during shutdown.

  Issue Number: N/A

  ## What is the new behavior?

  - Added `topic_e2e` p50/p95/p99 metrics to the SLO report
  - Topic e2e latency is measured from message creation to processing by the reader
  - Write success is recorded after write acknowledgement
  - Read success is recorded after commit acknowledgement
  - Topic workers are supervised; worker and invariant errors fail the workload
  - Removed `process::exit`, so metrics and other resources are shut down normally
  - Replaced the bursty rate limiter with a fair async limiter
  - All percentiles use the same OTLP export snapshot and are reset after export
  - Long latency outliers are no longer silently dropped
  - Wired topic e2e metrics into CI

  ## Other information

  For a successful topic SLO run this PR also needs:

  - #539 — fixes the discovery deadlock which can hang the workload
  - #535 — fixes topic reader batching and SLO invariant breakage
