### PR TITLE
feat: Rust SDK topic service benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,6 +3825,7 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 name = "ydb"
 version = "0.17.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "async_once",
  "bon",
@@ -3834,6 +3835,7 @@ dependencies = [
  "derive_builder",
  "flate2",
  "futures-util",
+ "hdrhistogram",
  "http 1.3.1",
  "itertools 0.10.5",
  "jsonwebtoken",

--- a/benchmarks/sdk-compare/README.md
+++ b/benchmarks/sdk-compare/README.md
@@ -1,0 +1,182 @@
+# YDB SDK comparison benchmark
+
+One scenario in. One result out. The same workload, on the same YDB, through
+different SDKs.
+
+This benchmark looks for large SDK differences and regressions. It is not a
+YDB server benchmark and it does not replace the correctness checks in the SLO
+workloads. Topic is implemented first; Query and Topic transactions should keep
+the same JSON-in/JSON-out shape.
+
+## Executable contract
+
+Each native benchmark executable:
+
+1. Accepts exactly one scenario JSON path.
+2. Reads credentials and the target from `YDB_CONNECTION_STRING`.
+3. Writes exactly one result JSON to standard output.
+4. Writes diagnostics to standard error.
+5. Returns non-zero without a result when setup, workload, drain, or shutdown
+   fails.
+
+JSON is the interchange format because Rust and C++ support it directly and a
+checked-in scenario records the complete experiment.
+
+## Run the Rust benchmark
+
+From the repository root:
+
+```bash
+docker compose up -d
+export YDB_CONNECTION_STRING='grpc://localhost:2136/local'
+
+cargo bench --quiet -p ydb --bench sdk_compare -- \
+  "$PWD/benchmarks/sdk-compare/scenarios/topic-smoke.json" \
+  > target/topic-smoke-rust.json
+```
+
+Use `topic-single-thread.json` or `topic-multi-thread.json` for measurements.
+The absolute path is intentional: Cargo starts the executable from the `ydb`
+package directory.
+
+## Scenario
+
+One file describes one run. Every field is required; missing, unknown, or
+invalid fields are rejected.
+
+```json
+{
+  "schema_version": 1,
+  "name": "topic-single-thread",
+  "execution": {
+    "worker_threads": 1,
+    "warmup_seconds": 15,
+    "measurement_seconds": 60,
+    "drain_timeout_seconds": 30
+  },
+  "workload": {
+    "kind": "topic",
+    "topic_name": "sdk-compare-topic-single-thread",
+    "consumer_name": "sdk-compare-consumer",
+    "partition_count": 4,
+    "writer_count": 4,
+    "reader_count": 4,
+    "message_size_bytes": 1024,
+    "max_in_flight_per_writer": 100,
+    "partition_write_speed_bytes_per_second": 52428800
+  }
+}
+```
+
+`schema_version` versions the complete scenario and result protocol.
+`worker_threads` controls benchmark-owned executor threads, not threads created
+inside an SDK. Single-thread therefore means one application executor thread,
+not one process-wide CPU.
+
+The Topic is created directly below the database from the connection string.
+It has `partition_count` fixed partitions, one important consumer, RAW payloads,
+and the configured per-partition write quota. Fixed partitions hold server
+topology constant while the clients are compared. Setup fails if the Topic
+already exists.
+
+Writer `i` uses producer ID `sdk-compare-writer-{i}` and normal SDK sequence
+numbering and producer-ID routing. `max_in_flight_per_writer` is enforced by the
+benchmark; SDK batching and transport defaults remain untouched. Readers use
+normal SDK/server partition assignment and commit every delivered SDK batch.
+
+## Timeline
+
+All SDK sessions open before the benchmark clock starts. One monotonic schedule
+then governs every worker:
+
+```text
+warm up continuously
+        │ warmup_seconds
+        ▼
+measure continuously
+        │ measurement_seconds
+        ▼
+stop new writes and drain work already started
+```
+
+Reader and writer tasks are created once and stay alive across the boundary.
+Task startup belongs to warm-up. The pipeline is not emptied or restarted
+before measurement.
+
+The payload timestamp determines whether a message began during warm-up or
+measurement. Warm-up work that finishes late is ignored. At the measurement
+boundary writers stop submitting and readers stop requesting batches. Drain
+waits only for write and commit acknowledgements already started; it does not
+try to consume every written message. `drain_timeout_seconds` bounds this work
+and shutdown. Topic-drop failure is only a warning because measurement has
+already completed.
+
+## Payload
+
+The payload has an eight-byte header followed by `0xA5` bytes. Integers are
+little-endian.
+
+| Bytes | Value |
+|---|---|
+| `0..8` | nanoseconds from the process monotonic clock (`u64`) |
+| `8..message_size_bytes` | `0xA5` |
+
+The buffer is allocated before the header is timestamped immediately before
+submission. Readers decode only the timestamp. This benchmark trusts the SLO
+workloads for deeper payload verification.
+
+## Measurements
+
+| Result key | Boundary |
+|---|---|
+| `topic.write_ack` | message submission to server write acknowledgement |
+| `topic.end_to_end` | message submission to reader application delivery |
+| `topic.commit_ack` | measured-batch commit submission to server acknowledgement |
+
+A write enters `topic.write_ack` when its submission starts during measurement,
+even if its acknowledgement arrives during drain. Reader delivery occurs when
+the SDK returns a batch to application code; `topic.commit_ack` includes a
+commit when that batch contains at least one measured message.
+
+Write throughput is `topic.write_ack.count / measurement_seconds`; read
+throughput is `topic.end_to_end.count / measurement_seconds`. Byte rates are
+message rates multiplied by `message_size_bytes`.
+
+Latency uses microseconds and an HDR Histogram covering 1 microsecond through
+300 seconds with three significant digits. Each latency metric exports `count`,
+then `min`, `max`, `mean`, `p50`, `p95`, `p99`, and `p99_9` under `latency_us`.
+`latency_us` is `null` when the count is zero.
+
+## Result
+
+The result has three top-level fields:
+
+| Field | Content |
+|---|---|
+| `scenario` | the complete input scenario object |
+| `implementation` | `language`, `sdk_version`, and descriptive `build_profile` |
+| `metrics` | the three latency metrics and four throughput rates |
+
+Every latency metric has the same shape:
+
+```json
+{
+  "count": 120000,
+  "latency_us": {
+    "min": 410,
+    "max": 18200,
+    "mean": 930.4,
+    "p50": 810,
+    "p95": 1410,
+    "p99": 2300,
+    "p99_9": 7900
+  }
+}
+```
+
+The throughput keys are `write_messages_per_second`,
+`write_bytes_per_second`, `read_messages_per_second`, and
+`read_bytes_per_second`.
+
+Compare only results with identical scenarios and equivalent test environments.
+Build profiles are descriptive metadata: Rust and C++ names need not be equal.

--- a/benchmarks/sdk-compare/README.md
+++ b/benchmarks/sdk-compare/README.md
@@ -46,7 +46,6 @@ invalid fields are rejected.
 
 ```json
 {
-  "schema_version": 1,
   "name": "topic-single-thread",
   "execution": {
     "worker_threads": 1,
@@ -63,12 +62,13 @@ invalid fields are rejected.
     "reader_count": 4,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 100,
+    "write_batch_max_messages": 1,
+    "write_batch_max_delay_ms": 1,
     "partition_write_speed_bytes_per_second": 52428800
   }
 }
 ```
 
-`schema_version` versions the complete scenario and result protocol.
 `worker_threads` controls benchmark-owned executor threads, not threads created
 inside an SDK. Single-thread therefore means one application executor thread,
 not one process-wide CPU.
@@ -82,9 +82,11 @@ already exists.
 Each partition has `writers_per_partition` writers pinned to it. Writer `i` for
 partition `p` uses producer ID `sdk-compare-writer-{p}-{i}` and normal SDK
 sequence numbering. `max_in_flight_per_writer` is enforced independently for
-every writer; SDK batching and transport defaults remain untouched. Readers
-subscribe to the entire topic, use normal SDK/server partition assignment, and
-commit every delivered SDK batch.
+every writer. `write_batch_max_messages` and `write_batch_max_delay_ms`
+configure SDK write-request batching. Other transport settings keep their SDK
+defaults. Readers subscribe to the entire topic, use normal SDK/server
+partition assignment, and commit every delivered SDK batch. Commit
+acknowledgements are recorded asynchronously and do not backpressure reading.
 
 ## Timeline
 

--- a/benchmarks/sdk-compare/README.md
+++ b/benchmarks/sdk-compare/README.md
@@ -59,7 +59,7 @@ invalid fields are rejected.
     "topic_name": "sdk-compare-topic-single-thread",
     "consumer_name": "sdk-compare-consumer",
     "partition_count": 4,
-    "writer_count": 4,
+    "writers_per_partition": 1,
     "reader_count": 4,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 100,
@@ -79,10 +79,12 @@ and the configured per-partition write quota. Fixed partitions hold server
 topology constant while the clients are compared. Setup fails if the Topic
 already exists.
 
-Writer `i` uses producer ID `sdk-compare-writer-{i}` and normal SDK sequence
-numbering and producer-ID routing. `max_in_flight_per_writer` is enforced by the
-benchmark; SDK batching and transport defaults remain untouched. Readers use
-normal SDK/server partition assignment and commit every delivered SDK batch.
+Each partition has `writers_per_partition` writers pinned to it. Writer `i` for
+partition `p` uses producer ID `sdk-compare-writer-{p}-{i}` and normal SDK
+sequence numbering. `max_in_flight_per_writer` is enforced independently for
+every writer; SDK batching and transport defaults remain untouched. Readers
+subscribe to the entire topic, use normal SDK/server partition assignment, and
+commit every delivered SDK batch.
 
 ## Timeline
 

--- a/benchmarks/sdk-compare/scenarios/topic-multi-thread.json
+++ b/benchmarks/sdk-compare/scenarios/topic-multi-thread.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "name": "topic-multi-thread",
+  "execution": {
+    "worker_threads": 4,
+    "warmup_seconds": 15,
+    "measurement_seconds": 60,
+    "drain_timeout_seconds": 30
+  },
+  "workload": {
+    "kind": "topic",
+    "topic_name": "sdk-compare-topic-multi-thread",
+    "consumer_name": "sdk-compare-consumer",
+    "partition_count": 4,
+    "writer_count": 4,
+    "reader_count": 4,
+    "message_size_bytes": 1024,
+    "max_in_flight_per_writer": 100,
+    "partition_write_speed_bytes_per_second": 52428800
+  }
+}

--- a/benchmarks/sdk-compare/scenarios/topic-multi-thread.json
+++ b/benchmarks/sdk-compare/scenarios/topic-multi-thread.json
@@ -1,5 +1,4 @@
 {
-  "schema_version": 1,
   "name": "topic-multi-thread",
   "execution": {
     "worker_threads": 4,
@@ -16,6 +15,8 @@
     "reader_count": 4,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 100,
+    "write_batch_max_messages": 1,
+    "write_batch_max_delay_ms": 1,
     "partition_write_speed_bytes_per_second": 52428800
   }
 }

--- a/benchmarks/sdk-compare/scenarios/topic-multi-thread.json
+++ b/benchmarks/sdk-compare/scenarios/topic-multi-thread.json
@@ -12,7 +12,7 @@
     "topic_name": "sdk-compare-topic-multi-thread",
     "consumer_name": "sdk-compare-consumer",
     "partition_count": 4,
-    "writer_count": 4,
+    "writers_per_partition": 1,
     "reader_count": 4,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 100,

--- a/benchmarks/sdk-compare/scenarios/topic-single-thread.json
+++ b/benchmarks/sdk-compare/scenarios/topic-single-thread.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "name": "topic-single-thread",
+  "execution": {
+    "worker_threads": 1,
+    "warmup_seconds": 15,
+    "measurement_seconds": 60,
+    "drain_timeout_seconds": 30
+  },
+  "workload": {
+    "kind": "topic",
+    "topic_name": "sdk-compare-topic-single-thread",
+    "consumer_name": "sdk-compare-consumer",
+    "partition_count": 4,
+    "writer_count": 4,
+    "reader_count": 4,
+    "message_size_bytes": 1024,
+    "max_in_flight_per_writer": 100,
+    "partition_write_speed_bytes_per_second": 52428800
+  }
+}

--- a/benchmarks/sdk-compare/scenarios/topic-single-thread.json
+++ b/benchmarks/sdk-compare/scenarios/topic-single-thread.json
@@ -1,5 +1,4 @@
 {
-  "schema_version": 1,
   "name": "topic-single-thread",
   "execution": {
     "worker_threads": 1,
@@ -16,6 +15,8 @@
     "reader_count": 4,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 100,
+    "write_batch_max_messages": 1,
+    "write_batch_max_delay_ms": 1,
     "partition_write_speed_bytes_per_second": 52428800
   }
 }

--- a/benchmarks/sdk-compare/scenarios/topic-single-thread.json
+++ b/benchmarks/sdk-compare/scenarios/topic-single-thread.json
@@ -12,7 +12,7 @@
     "topic_name": "sdk-compare-topic-single-thread",
     "consumer_name": "sdk-compare-consumer",
     "partition_count": 4,
-    "writer_count": 4,
+    "writers_per_partition": 1,
     "reader_count": 4,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 100,

--- a/benchmarks/sdk-compare/scenarios/topic-smoke.json
+++ b/benchmarks/sdk-compare/scenarios/topic-smoke.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "name": "topic-smoke",
+  "execution": {
+    "worker_threads": 1,
+    "warmup_seconds": 1,
+    "measurement_seconds": 2,
+    "drain_timeout_seconds": 10
+  },
+  "workload": {
+    "kind": "topic",
+    "topic_name": "sdk-compare-topic-smoke",
+    "consumer_name": "sdk-compare-consumer",
+    "partition_count": 1,
+    "writer_count": 1,
+    "reader_count": 1,
+    "message_size_bytes": 1024,
+    "max_in_flight_per_writer": 10,
+    "partition_write_speed_bytes_per_second": 52428800
+  }
+}

--- a/benchmarks/sdk-compare/scenarios/topic-smoke.json
+++ b/benchmarks/sdk-compare/scenarios/topic-smoke.json
@@ -12,7 +12,7 @@
     "topic_name": "sdk-compare-topic-smoke",
     "consumer_name": "sdk-compare-consumer",
     "partition_count": 1,
-    "writer_count": 1,
+    "writers_per_partition": 1,
     "reader_count": 1,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 10,

--- a/benchmarks/sdk-compare/scenarios/topic-smoke.json
+++ b/benchmarks/sdk-compare/scenarios/topic-smoke.json
@@ -1,5 +1,4 @@
 {
-  "schema_version": 1,
   "name": "topic-smoke",
   "execution": {
     "worker_threads": 1,
@@ -16,6 +15,8 @@
     "reader_count": 1,
     "message_size_bytes": 1024,
     "max_in_flight_per_writer": 10,
+    "write_batch_max_messages": 1,
+    "write_batch_max_delay_ms": 1,
     "partition_write_speed_bytes_per_second": 52428800
   }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ coverage:
 
 ignore:
   - ydb-grpc/src/generated
+  - ydb/benches
   - ydb/examples
   - tests/slo
 

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -63,12 +63,14 @@ flate2 = "1.1.9"
 rayon = "1.10"
 
 [dev-dependencies]
+anyhow = "1"
 async_once = "0.2"
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "std",
 ] }
 lazy_static = "1.4"
+hdrhistogram = "7.5.4"
 ntest = "0.7"
 opentelemetry = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic"] }

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -78,3 +78,9 @@ opentelemetry_sdk = "0.32.1"
 tokio = { version = "1.22", features = ["test-util"] }
 tracing-opentelemetry = "0.33.0"
 uuid = { version = "1.17.0", features = ["v4"] }
+
+[[bench]]
+name = "sdk_compare"
+path = "benches/sdk_compare/main.rs"
+harness = false
+test = false

--- a/ydb/benches/sdk_compare/config.rs
+++ b/ydb/benches/sdk_compare/config.rs
@@ -1,0 +1,142 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+
+use crate::payload::HEADER_SIZE_BYTES;
+
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Scenario {
+    pub(crate) schema_version: u32,
+    pub(crate) name: String,
+    pub(crate) execution: Execution,
+    pub(crate) workload: Workload,
+}
+
+impl Scenario {
+    pub(crate) fn load(path: &Path) -> Result<Self> {
+        let json = fs::read_to_string(path)
+            .with_context(|| format!("failed to read scenario file {}", path.display()))?;
+
+        Self::from_json(&json)
+            .with_context(|| format!("failed to load scenario file {}", path.display()))
+    }
+
+    pub(crate) fn from_json(json: &str) -> Result<Self> {
+        let scenario: Self = serde_json::from_str(json).context("failed to parse scenario JSON")?;
+        scenario.validate()?;
+        Ok(scenario)
+    }
+
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.schema_version == SCHEMA_VERSION,
+            "unsupported schema_version {}; expected {}",
+            self.schema_version,
+            SCHEMA_VERSION
+        );
+        ensure!(
+            !self.name.trim().is_empty(),
+            "scenario name must not be empty"
+        );
+        self.execution.validate()?;
+        self.workload.validate()?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Execution {
+    pub(crate) worker_threads: usize,
+    pub(crate) warmup_seconds: u64,
+    pub(crate) measurement_seconds: u64,
+    pub(crate) drain_timeout_seconds: u64,
+}
+
+impl Execution {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.worker_threads > 0,
+            "worker_threads must be greater than zero"
+        );
+        ensure!(
+            self.measurement_seconds > 0,
+            "measurement_seconds must be greater than zero"
+        );
+        ensure!(
+            self.drain_timeout_seconds > 0,
+            "drain_timeout_seconds must be greater than zero"
+        );
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum Workload {
+    Topic(TopicWorkload),
+}
+
+impl Workload {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Self::Topic(topic) => topic.validate(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TopicWorkload {
+    pub(crate) topic_name: String,
+    pub(crate) consumer_name: String,
+    pub(crate) partition_count: u32,
+    pub(crate) writer_count: usize,
+    pub(crate) reader_count: usize,
+    pub(crate) message_size_bytes: usize,
+    pub(crate) max_in_flight_per_writer: usize,
+    pub(crate) partition_write_speed_bytes_per_second: i64,
+}
+
+impl TopicWorkload {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            !self.topic_name.trim().is_empty(),
+            "topic_name must not be empty"
+        );
+        ensure!(
+            !self.consumer_name.trim().is_empty(),
+            "consumer_name must not be empty"
+        );
+        ensure!(
+            self.partition_count > 0,
+            "partition_count must be greater than zero"
+        );
+        ensure!(
+            self.writer_count > 0,
+            "writer_count must be greater than zero"
+        );
+        ensure!(
+            self.reader_count > 0,
+            "reader_count must be greater than zero"
+        );
+        ensure!(
+            self.message_size_bytes >= HEADER_SIZE_BYTES,
+            "message_size_bytes must be at least {HEADER_SIZE_BYTES}"
+        );
+        ensure!(
+            self.max_in_flight_per_writer > 0,
+            "max_in_flight_per_writer must be greater than zero"
+        );
+        ensure!(
+            self.partition_write_speed_bytes_per_second > 0,
+            "partition_write_speed_bytes_per_second must be greater than zero"
+        );
+        Ok(())
+    }
+}

--- a/ydb/benches/sdk_compare/config.rs
+++ b/ydb/benches/sdk_compare/config.rs
@@ -6,12 +6,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::payload::HEADER_SIZE_BYTES;
 
-pub(crate) const SCHEMA_VERSION: u32 = 1;
-
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Scenario {
-    pub(crate) schema_version: u32,
     pub(crate) name: String,
     pub(crate) execution: Execution,
     pub(crate) workload: Workload,
@@ -33,12 +30,6 @@ impl Scenario {
     }
 
     fn validate(&self) -> Result<()> {
-        ensure!(
-            self.schema_version == SCHEMA_VERSION,
-            "unsupported schema_version {}; expected {}",
-            self.schema_version,
-            SCHEMA_VERSION
-        );
         ensure!(
             !self.name.trim().is_empty(),
             "scenario name must not be empty"
@@ -100,6 +91,8 @@ pub(crate) struct TopicWorkload {
     pub(crate) reader_count: usize,
     pub(crate) message_size_bytes: usize,
     pub(crate) max_in_flight_per_writer: usize,
+    pub(crate) write_batch_max_messages: usize,
+    pub(crate) write_batch_max_delay_ms: u64,
     pub(crate) partition_write_speed_bytes_per_second: i64,
 }
 
@@ -132,6 +125,14 @@ impl TopicWorkload {
         ensure!(
             self.max_in_flight_per_writer > 0,
             "max_in_flight_per_writer must be greater than zero"
+        );
+        ensure!(
+            self.write_batch_max_messages == 1,
+            "write_batch_max_messages must be 1 for comparable SDK writes"
+        );
+        ensure!(
+            self.write_batch_max_delay_ms > 0,
+            "write_batch_max_delay_ms must be greater than zero"
         );
         ensure!(
             self.partition_write_speed_bytes_per_second > 0,

--- a/ydb/benches/sdk_compare/config.rs
+++ b/ydb/benches/sdk_compare/config.rs
@@ -96,7 +96,7 @@ pub(crate) struct TopicWorkload {
     pub(crate) topic_name: String,
     pub(crate) consumer_name: String,
     pub(crate) partition_count: u32,
-    pub(crate) writer_count: usize,
+    pub(crate) writers_per_partition: usize,
     pub(crate) reader_count: usize,
     pub(crate) message_size_bytes: usize,
     pub(crate) max_in_flight_per_writer: usize,
@@ -118,8 +118,8 @@ impl TopicWorkload {
             "partition_count must be greater than zero"
         );
         ensure!(
-            self.writer_count > 0,
-            "writer_count must be greater than zero"
+            self.writers_per_partition > 0,
+            "writers_per_partition must be greater than zero"
         );
         ensure!(
             self.reader_count > 0,

--- a/ydb/benches/sdk_compare/config.rs
+++ b/ydb/benches/sdk_compare/config.rs
@@ -127,8 +127,8 @@ impl TopicWorkload {
             "max_in_flight_per_writer must be greater than zero"
         );
         ensure!(
-            self.write_batch_max_messages == 1,
-            "write_batch_max_messages must be 1 for comparable SDK writes"
+            self.write_batch_max_messages > 0,
+            "write_batch_max_messages must be greater than zero"
         );
         ensure!(
             self.write_batch_max_delay_ms > 0,

--- a/ydb/benches/sdk_compare/main.rs
+++ b/ydb/benches/sdk_compare/main.rs
@@ -1,0 +1,50 @@
+mod config;
+mod metrics;
+mod payload;
+mod result;
+mod topic;
+
+use std::env;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use config::{Scenario, Workload};
+use tokio::runtime::Builder;
+
+fn main() -> Result<()> {
+    let scenario_path = scenario_path()?;
+    let scenario = Scenario::load(&scenario_path)?;
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(scenario.execution.worker_threads)
+        .enable_all()
+        .build()
+        .context("failed to build Tokio runtime")?;
+
+    let result = match &scenario.workload {
+        Workload::Topic(workload) => runtime.block_on(topic::run(&scenario, workload))?,
+    };
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+    serde_json::to_writer_pretty(&mut output, &result)
+        .context("failed to serialize result JSON")?;
+    writeln!(output).context("failed to finish result JSON")
+}
+
+fn scenario_path() -> Result<PathBuf> {
+    let mut arguments = env::args_os();
+    let executable = arguments.next().unwrap_or_else(|| "sdk_compare".into());
+    let Some(path) = arguments.next() else {
+        bail!(
+            "usage: {} <scenario.json>",
+            PathBuf::from(executable).display()
+        );
+    };
+    // Cargo appends `--bench` when it runs a harness-free benchmark target.
+    match arguments.next() {
+        None => {}
+        Some(argument) if argument == "--bench" && arguments.next().is_none() => {}
+        Some(_) => bail!("expected exactly one scenario file argument"),
+    }
+    Ok(path.into())
+}

--- a/ydb/benches/sdk_compare/metrics.rs
+++ b/ydb/benches/sdk_compare/metrics.rs
@@ -1,0 +1,72 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use hdrhistogram::Histogram;
+use serde::Serialize;
+
+const LOWEST_LATENCY_US: u64 = 1;
+const HIGHEST_LATENCY_US: u64 = 300_000_000;
+const SIGNIFICANT_DIGITS: u8 = 3;
+
+pub(crate) struct LatencyRecorder {
+    histogram: Histogram<u64>,
+}
+
+impl LatencyRecorder {
+    pub(crate) fn new() -> Result<Self> {
+        let histogram =
+            Histogram::new_with_bounds(LOWEST_LATENCY_US, HIGHEST_LATENCY_US, SIGNIFICANT_DIGITS)
+                .context("failed to create latency histogram")?;
+        Ok(Self { histogram })
+    }
+
+    pub(crate) fn record(&mut self, latency: Duration) -> Result<()> {
+        let latency_us = latency.as_micros().max(1);
+        let latency_us = u64::try_from(latency_us).context("latency does not fit into u64")?;
+        self.histogram
+            .record(latency_us)
+            .with_context(|| format!("latency {latency_us} us is outside histogram bounds"))
+    }
+
+    pub(crate) fn merge(&mut self, other: &Self) -> Result<()> {
+        self.histogram
+            .add(&other.histogram)
+            .context("failed to merge latency histograms")
+    }
+
+    pub(crate) fn count(&self) -> u64 {
+        self.histogram.len()
+    }
+
+    pub(crate) fn summary(&self) -> LatencyMetric {
+        let count = self.count();
+        let latency_us = (count > 0).then(|| LatencySummary {
+            min: self.histogram.min(),
+            max: self.histogram.max(),
+            mean: self.histogram.mean(),
+            p50: self.histogram.value_at_quantile(0.5),
+            p95: self.histogram.value_at_quantile(0.95),
+            p99: self.histogram.value_at_quantile(0.99),
+            p99_9: self.histogram.value_at_quantile(0.999),
+        });
+
+        LatencyMetric { count, latency_us }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LatencyMetric {
+    pub(crate) count: u64,
+    pub(crate) latency_us: Option<LatencySummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct LatencySummary {
+    pub(crate) min: u64,
+    pub(crate) max: u64,
+    pub(crate) mean: f64,
+    pub(crate) p50: u64,
+    pub(crate) p95: u64,
+    pub(crate) p99: u64,
+    pub(crate) p99_9: u64,
+}

--- a/ydb/benches/sdk_compare/payload.rs
+++ b/ydb/benches/sdk_compare/payload.rs
@@ -1,0 +1,36 @@
+use anyhow::{Result, ensure};
+
+pub(crate) const HEADER_SIZE_BYTES: usize = 8;
+
+const FILL_BYTE: u8 = 0xA5;
+
+pub(crate) fn allocate(message_size_bytes: usize) -> Result<Vec<u8>> {
+    ensure!(
+        message_size_bytes >= HEADER_SIZE_BYTES,
+        "message size must be at least {HEADER_SIZE_BYTES} bytes"
+    );
+
+    let mut payload = vec![FILL_BYTE; message_size_bytes];
+    payload[..HEADER_SIZE_BYTES].fill(0);
+    Ok(payload)
+}
+
+pub(crate) fn write_timestamp(payload: &mut [u8], sent_at_ns: u64) -> Result<()> {
+    ensure!(
+        payload.len() >= HEADER_SIZE_BYTES,
+        "payload is shorter than the {HEADER_SIZE_BYTES}-byte header"
+    );
+    payload[..HEADER_SIZE_BYTES].copy_from_slice(&sent_at_ns.to_le_bytes());
+    Ok(())
+}
+
+pub(crate) fn read_timestamp(payload: &[u8]) -> Result<u64> {
+    ensure!(
+        payload.len() >= HEADER_SIZE_BYTES,
+        "payload is shorter than the {HEADER_SIZE_BYTES}-byte header"
+    );
+
+    let mut sent_at_ns = [0_u8; 8];
+    sent_at_ns.copy_from_slice(&payload[..HEADER_SIZE_BYTES]);
+    Ok(u64::from_le_bytes(sent_at_ns))
+}

--- a/ydb/benches/sdk_compare/result.rs
+++ b/ydb/benches/sdk_compare/result.rs
@@ -1,0 +1,56 @@
+use serde::Serialize;
+
+use crate::config::Scenario;
+use crate::metrics::LatencyMetric;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct BenchmarkResult {
+    scenario: Scenario,
+    implementation: Implementation,
+    metrics: TopicMetrics,
+}
+
+impl BenchmarkResult {
+    pub(crate) fn new(scenario: Scenario, metrics: TopicMetrics) -> Self {
+        Self {
+            scenario,
+            implementation: Implementation::rust(),
+            metrics,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Implementation {
+    language: &'static str,
+    sdk_version: &'static str,
+    build_profile: &'static str,
+}
+
+impl Implementation {
+    fn rust() -> Self {
+        Self {
+            language: "rust",
+            sdk_version: env!("CARGO_PKG_VERSION"),
+            build_profile: if cfg!(debug_assertions) {
+                "debug"
+            } else {
+                "release"
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TopicMetrics {
+    #[serde(rename = "topic.write_ack")]
+    pub(crate) write_ack: LatencyMetric,
+    #[serde(rename = "topic.end_to_end")]
+    pub(crate) end_to_end: LatencyMetric,
+    #[serde(rename = "topic.commit_ack")]
+    pub(crate) commit_ack: LatencyMetric,
+    pub(crate) write_messages_per_second: f64,
+    pub(crate) write_bytes_per_second: f64,
+    pub(crate) read_messages_per_second: f64,
+    pub(crate) read_bytes_per_second: f64,
+}

--- a/ydb/benches/sdk_compare/topic.rs
+++ b/ydb/benches/sdk_compare/topic.rs
@@ -1,0 +1,174 @@
+mod reader;
+mod writer;
+
+use std::env;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use tokio::time::timeout_at;
+use ydb::{Client, ClientBuilder, Codec, ConsumerBuilder, CreateTopicOptionsBuilder, TopicClient};
+
+use crate::config::{Scenario, TopicWorkload};
+use crate::result::{BenchmarkResult, TopicMetrics};
+
+const CONNECTION_STRING_ENV: &str = "YDB_CONNECTION_STRING";
+
+pub(crate) async fn run(scenario: &Scenario, workload: &TopicWorkload) -> Result<BenchmarkResult> {
+    let client = connect().await?;
+    let topic_path = format!(
+        "{}/{}",
+        client.database().trim_end_matches('/'),
+        workload.topic_name
+    );
+    let mut topic_client = client.topic_client();
+    create_topic(&mut topic_client, &topic_path, workload).await?;
+
+    let result = run_workload(&mut topic_client, &topic_path, scenario, workload).await;
+    if let Err(error) = topic_client.drop_topic(topic_path.clone()).await {
+        eprintln!("warning: failed to drop benchmark topic {topic_path}: {error}");
+    }
+    result
+}
+
+async fn connect() -> Result<Client> {
+    let connection_string = env::var(CONNECTION_STRING_ENV)
+        .with_context(|| format!("{CONNECTION_STRING_ENV} is not set"))?;
+
+    let client = ClientBuilder::new_from_connection_string(&connection_string)
+        .context("failed to parse YDB connection string")?
+        .client()
+        .context("failed to create YDB client")?;
+
+    client
+        .wait()
+        .await
+        .context("failed to initialize YDB client")?;
+
+    Ok(client)
+}
+
+async fn create_topic(
+    topic_client: &mut TopicClient,
+    topic_path: &str,
+    workload: &TopicWorkload,
+) -> Result<()> {
+    let partition_count = i64::from(workload.partition_count);
+    let consumer = ConsumerBuilder::default()
+        .name(workload.consumer_name.clone())
+        .important(true)
+        .build()
+        .context("failed to build benchmark consumer")?;
+
+    let options = CreateTopicOptionsBuilder::default()
+        .min_active_partitions(partition_count)
+        .partition_count_limit(partition_count)
+        .supported_codecs(vec![Codec::RAW])
+        .partition_write_speed_bytes_per_second(workload.partition_write_speed_bytes_per_second)
+        .consumers(vec![consumer])
+        .build()
+        .context("failed to build topic options")?;
+
+    topic_client
+        .create_topic(topic_path.to_owned(), options)
+        .await
+        .with_context(|| format!("failed to create topic {topic_path}"))
+}
+
+async fn run_workload(
+    topic_client: &mut TopicClient,
+    topic_path: &str,
+    scenario: &Scenario,
+    workload: &TopicWorkload,
+) -> Result<BenchmarkResult> {
+    let drain_timeout = Duration::from_secs(scenario.execution.drain_timeout_seconds);
+    let measurement_duration = Duration::from_secs(scenario.execution.measurement_seconds);
+
+    // Open every SDK session before the benchmark clock starts.
+    let writers = writer::open(topic_client, topic_path, workload).await?;
+    let readers = reader::open(topic_client, topic_path, workload).await?;
+    let schedule = BenchmarkSchedule::new(
+        Duration::from_secs(scenario.execution.warmup_seconds),
+        measurement_duration,
+        drain_timeout,
+    )?;
+
+    // Run readers and writers continuously across the warm-up/measurement boundary.
+    let worker_run = async {
+        tokio::try_join!(
+            writer::run(writers, schedule, workload),
+            reader::run(readers, schedule),
+        )
+    };
+    let (writer_metrics, reader_metrics) =
+        timeout_at(schedule.completion_deadline.into(), worker_run)
+            .await
+            .context("benchmark drain timed out")??;
+
+    let seconds = measurement_duration.as_secs_f64();
+    let message_size = workload.message_size_bytes as f64;
+    let write_messages_per_second = writer_metrics.write_ack.count() as f64 / seconds;
+    let read_messages_per_second = reader_metrics.end_to_end.count() as f64 / seconds;
+
+    Ok(BenchmarkResult::new(
+        scenario.clone(),
+        TopicMetrics {
+            write_ack: writer_metrics.write_ack.summary(),
+            end_to_end: reader_metrics.end_to_end.summary(),
+            commit_ack: reader_metrics.commit_ack.summary(),
+            write_messages_per_second,
+            write_bytes_per_second: write_messages_per_second * message_size,
+            read_messages_per_second,
+            read_bytes_per_second: read_messages_per_second * message_size,
+        },
+    ))
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct BenchmarkSchedule {
+    origin: Instant,
+    pub(super) measurement_start: Instant,
+    pub(super) measurement_end: Instant,
+    pub(super) completion_deadline: Instant,
+}
+
+impl BenchmarkSchedule {
+    fn new(
+        warmup_duration: Duration,
+        measurement_duration: Duration,
+        drain_timeout: Duration,
+    ) -> Result<Self> {
+        let origin = Instant::now();
+        let measurement_start = origin
+            .checked_add(warmup_duration)
+            .context("warm-up deadline overflowed")?;
+        let measurement_end = measurement_start
+            .checked_add(measurement_duration)
+            .context("measurement deadline overflowed")?;
+        let completion_deadline = measurement_end
+            .checked_add(drain_timeout)
+            .context("measurement drain deadline overflowed")?;
+
+        Ok(Self {
+            origin,
+            measurement_start,
+            measurement_end,
+            completion_deadline,
+        })
+    }
+
+    pub(super) fn is_measurement_instant(&self, instant: Instant) -> bool {
+        instant >= self.measurement_start && instant < self.measurement_end
+    }
+
+    pub(super) fn ns_at(&self, instant: Instant) -> Result<u64> {
+        let elapsed = instant
+            .checked_duration_since(self.origin)
+            .context("benchmark instant is before schedule origin")?;
+        u64::try_from(elapsed.as_nanos())
+            .context("benchmark schedule does not fit into u64 nanoseconds")
+    }
+
+    pub(super) fn now_ns(&self) -> Result<u64> {
+        self.ns_at(Instant::now())
+    }
+}

--- a/ydb/benches/sdk_compare/topic.rs
+++ b/ydb/benches/sdk_compare/topic.rs
@@ -131,6 +131,12 @@ pub(super) struct BenchmarkSchedule {
     pub(super) completion_deadline: Instant,
 }
 
+#[derive(Clone, Copy)]
+pub(super) enum AckLatencyStart {
+    Warmup,
+    Measured(Instant),
+}
+
 impl BenchmarkSchedule {
     fn new(
         warmup_duration: Duration,

--- a/ydb/benches/sdk_compare/topic/reader.rs
+++ b/ydb/benches/sdk_compare/topic/reader.rs
@@ -1,0 +1,149 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use tokio::task::JoinSet;
+use tokio::time::sleep_until;
+use ydb::{TopicClient, TopicReader, TopicReaderMessage, TopicReaderOptions, TopicSelector};
+
+use super::BenchmarkSchedule;
+use crate::config::TopicWorkload;
+use crate::metrics::LatencyRecorder;
+use crate::payload;
+
+pub(super) struct ReaderMetrics {
+    pub(super) end_to_end: LatencyRecorder,
+    pub(super) commit_ack: LatencyRecorder,
+}
+
+impl ReaderMetrics {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            end_to_end: LatencyRecorder::new()?,
+            commit_ack: LatencyRecorder::new()?,
+        })
+    }
+
+    fn merge(&mut self, other: &Self) -> Result<()> {
+        self.end_to_end.merge(&other.end_to_end)?;
+        self.commit_ack.merge(&other.commit_ack)?;
+        Ok(())
+    }
+
+    fn record_commit(&mut self, latency: Option<Duration>) -> Result<()> {
+        if let Some(latency) = latency {
+            self.commit_ack.record(latency)?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) async fn open(
+    topic_client: &mut TopicClient,
+    topic_path: &str,
+    workload: &TopicWorkload,
+) -> Result<Vec<TopicReader>> {
+    let mut readers = Vec::with_capacity(workload.reader_count);
+    for reader_id in 0..workload.reader_count {
+        let options = TopicReaderOptions::builder()
+            .consumer(workload.consumer_name.clone())
+            .topic(TopicSelector::new(topic_path))
+            .build();
+        let reader = topic_client
+            .create_reader_with_params(options)
+            .await
+            .with_context(|| format!("failed to create reader {reader_id}"))?;
+        readers.push(reader);
+    }
+    Ok(readers)
+}
+
+pub(super) async fn run(
+    readers: Vec<TopicReader>,
+    schedule: BenchmarkSchedule,
+) -> Result<ReaderMetrics> {
+    let mut tasks = JoinSet::new();
+    for reader in readers {
+        tasks.spawn(run_reader(reader, schedule));
+    }
+
+    let mut combined_metrics = ReaderMetrics::new()?;
+    while let Some(joined) = tasks.join_next().await {
+        let worker_metrics = joined.context("reader task panicked or was cancelled")??;
+        combined_metrics.merge(&worker_metrics)?;
+    }
+
+    Ok(combined_metrics)
+}
+
+async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Result<ReaderMetrics> {
+    let mut metrics = ReaderMetrics::new()?;
+    let mut commits = FuturesUnordered::new();
+    let measurement_start_ns = schedule.ns_at(schedule.measurement_start)?;
+    let measurement_end = schedule.measurement_end;
+
+    loop {
+        // Keep reading while completed commit acknowledgements are recorded in parallel.
+        let batch = tokio::select! {
+            () = sleep_until(measurement_end.into()) => break,
+            Some(completion) = commits.next(), if !commits.is_empty() => {
+                metrics.record_commit(completion?)?;
+                continue;
+            }
+            batch = reader.read_batch() => batch.context("reader failed")?,
+        };
+
+        let delivered_at_ns = schedule.now_ns()?;
+        let marker = batch.get_commit_marker();
+        let measured_batch = process_batch(
+            batch.messages,
+            delivered_at_ns,
+            measurement_start_ns,
+            &mut metrics,
+        )
+        .await?;
+
+        let started = Instant::now();
+        let ack = reader.commit_with_ack(marker);
+
+        commits.push(async move {
+            ack.await.context("commit acknowledgement failed")?;
+            anyhow::Ok(measured_batch.then(|| started.elapsed()))
+        });
+    }
+
+    // Stop reading at the measurement boundary, then finish commits already started.
+    while let Some(completion) = commits.next().await {
+        metrics.record_commit(completion?)?;
+    }
+    Ok(metrics)
+}
+
+async fn process_batch(
+    messages: Vec<TopicReaderMessage>,
+    delivered_at_ns: u64,
+    measurement_start_ns: u64,
+    metrics: &mut ReaderMetrics,
+) -> Result<bool> {
+    let mut measured_batch = false;
+    for mut message in messages {
+        let data = message
+            .read_and_take()
+            .await?
+            .context("reader message has no payload")?;
+        let sent_at_ns =
+            payload::read_timestamp(&data).context("failed to decode benchmark payload")?;
+        if sent_at_ns < measurement_start_ns {
+            continue;
+        }
+
+        measured_batch = true;
+        let latency_ns = delivered_at_ns
+            .checked_sub(sent_at_ns)
+            .context("payload timestamp is ahead of the benchmark clock")?;
+        metrics
+            .end_to_end
+            .record(Duration::from_nanos(latency_ns))?;
+    }
+    Ok(measured_batch)
+}

--- a/ydb/benches/sdk_compare/topic/reader.rs
+++ b/ydb/benches/sdk_compare/topic/reader.rs
@@ -1,7 +1,6 @@
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio::task::JoinSet;
 use tokio::time::sleep_until;
 use ydb::{TopicClient, TopicReader, TopicReaderMessage, TopicReaderOptions, TopicSelector};
@@ -27,13 +26,6 @@ impl ReaderMetrics {
     fn merge(&mut self, other: &Self) -> Result<()> {
         self.end_to_end.merge(&other.end_to_end)?;
         self.commit_ack.merge(&other.commit_ack)?;
-        Ok(())
-    }
-
-    fn record_commit(&mut self, latency: Option<Duration>) -> Result<()> {
-        if let Some(latency) = latency {
-            self.commit_ack.record(latency)?;
-        }
         Ok(())
     }
 }
@@ -77,19 +69,29 @@ pub(super) async fn run(
 }
 
 async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Result<ReaderMetrics> {
-    let mut metrics = ReaderMetrics::new()?;
-    let mut commits = FuturesUnordered::new();
     let measurement_start_ns = schedule.ns_at(schedule.measurement_start)?;
     let measurement_end = schedule.measurement_end;
+
+    let (pending_acks_tx, mut pending_acks_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let ack_recorder_task = tokio::spawn(async move {
+        let mut ack_latency = LatencyRecorder::new()?;
+
+        while let Some(pending_ack) = pending_acks_rx.recv().await {
+            if let Some(elapsed) = pending_ack.await? {
+                ack_latency.record(elapsed)?;
+            }
+        }
+
+        anyhow::Ok(ack_latency)
+    });
+
+    let mut end_to_end = LatencyRecorder::new()?;
 
     loop {
         // Keep reading while completed commit acknowledgements are recorded in parallel.
         let batch = tokio::select! {
             () = sleep_until(measurement_end.into()) => break,
-            Some(completion) = commits.next(), if !commits.is_empty() => {
-                metrics.record_commit(completion?)?;
-                continue;
-            }
             batch = reader.read_batch() => batch.context("reader failed")?,
         };
 
@@ -99,31 +101,37 @@ async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Res
             batch.messages,
             delivered_at_ns,
             measurement_start_ns,
-            &mut metrics,
+            &mut end_to_end,
         )
         .await?;
 
         let started = Instant::now();
         let ack = reader.commit_with_ack(marker);
 
-        commits.push(async move {
-            ack.await.context("commit acknowledgement failed")?;
-            anyhow::Ok(measured_batch.then(|| started.elapsed()))
-        });
+        pending_acks_tx.send(async move {
+            ack.await?;
+            anyhow::Ok(measured_batch.then_some(started.elapsed()))
+        })?;
     }
 
-    // Stop reading at the measurement boundary, then finish commits already started.
-    while let Some(completion) = commits.next().await {
-        metrics.record_commit(completion?)?;
-    }
-    Ok(metrics)
+    // Close the channel so the acknowledgement recorder can finish.
+    drop(pending_acks_tx);
+
+    let commit_ack = ack_recorder_task
+        .await
+        .context("commit acknowledgement recorder panicked or was cancelled")??;
+
+    Ok(ReaderMetrics {
+        end_to_end,
+        commit_ack,
+    })
 }
 
 async fn process_batch(
     messages: Vec<TopicReaderMessage>,
     delivered_at_ns: u64,
     measurement_start_ns: u64,
-    metrics: &mut ReaderMetrics,
+    end_to_end: &mut LatencyRecorder,
 ) -> Result<bool> {
     let mut measured_batch = false;
     for mut message in messages {
@@ -141,9 +149,7 @@ async fn process_batch(
         let latency_ns = delivered_at_ns
             .checked_sub(sent_at_ns)
             .context("payload timestamp is ahead of the benchmark clock")?;
-        metrics
-            .end_to_end
-            .record(Duration::from_nanos(latency_ns))?;
+        end_to_end.record(Duration::from_nanos(latency_ns))?;
     }
     Ok(measured_batch)
 }

--- a/ydb/benches/sdk_compare/topic/reader.rs
+++ b/ydb/benches/sdk_compare/topic/reader.rs
@@ -3,9 +3,12 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use tokio::task::JoinSet;
 use tokio::time::sleep_until;
-use ydb::{TopicClient, TopicReader, TopicReaderMessage, TopicReaderOptions, TopicSelector};
+use ydb::{
+    TopicClient, TopicReader, TopicReaderCommitAckFuture, TopicReaderMessage, TopicReaderOptions,
+    TopicSelector,
+};
 
-use super::BenchmarkSchedule;
+use super::{AckLatencyStart, BenchmarkSchedule};
 use crate::config::TopicWorkload;
 use crate::metrics::LatencyRecorder;
 use crate::payload;
@@ -13,6 +16,11 @@ use crate::payload;
 pub(super) struct ReaderMetrics {
     pub(super) end_to_end: LatencyRecorder,
     pub(super) commit_ack: LatencyRecorder,
+}
+
+struct PendingCommit {
+    acknowledgement: TopicReaderCommitAckFuture,
+    latency_start: AckLatencyStart,
 }
 
 impl ReaderMetrics {
@@ -72,14 +80,21 @@ async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Res
     let measurement_start_ns = schedule.ns_at(schedule.measurement_start)?;
     let measurement_end = schedule.measurement_end;
 
-    let (pending_acks_tx, mut pending_acks_rx) = tokio::sync::mpsc::unbounded_channel();
+    // Ordered commit acknowledgements must not backpressure message delivery.
+    let (pending_commits_tx, mut pending_commits_rx) =
+        tokio::sync::mpsc::unbounded_channel::<PendingCommit>();
 
     let ack_recorder_task = tokio::spawn(async move {
         let mut ack_latency = LatencyRecorder::new()?;
 
-        while let Some(pending_ack) = pending_acks_rx.recv().await {
-            if let Some(elapsed) = pending_ack.await? {
-                ack_latency.record(elapsed)?;
+        while let Some(pending_commit) = pending_commits_rx.recv().await {
+            pending_commit
+                .acknowledgement
+                .await
+                .context("commit acknowledgement failed")?;
+
+            if let AckLatencyStart::Measured(started_at) = pending_commit.latency_start {
+                ack_latency.record(started_at.elapsed())?;
             }
         }
 
@@ -97,7 +112,7 @@ async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Res
 
         let delivered_at_ns = schedule.now_ns()?;
         let marker = batch.get_commit_marker();
-        let measured_batch = process_batch(
+        let contains_measured_messages = record_end_to_end_latencies(
             batch.messages,
             delivered_at_ns,
             measurement_start_ns,
@@ -105,17 +120,24 @@ async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Res
         )
         .await?;
 
-        let started = Instant::now();
-        let ack = reader.commit_with_ack(marker);
+        let commit_started_at = Instant::now();
+        let acknowledgement = reader.commit_with_ack(marker);
+        let latency_start = if contains_measured_messages {
+            AckLatencyStart::Measured(commit_started_at)
+        } else {
+            AckLatencyStart::Warmup
+        };
 
-        pending_acks_tx.send(async move {
-            ack.await?;
-            anyhow::Ok(measured_batch.then_some(started.elapsed()))
-        })?;
+        pending_commits_tx
+            .send(PendingCommit {
+                acknowledgement,
+                latency_start,
+            })
+            .context("commit acknowledgement recorder stopped")?;
     }
 
     // Close the channel so the acknowledgement recorder can finish.
-    drop(pending_acks_tx);
+    drop(pending_commits_tx);
 
     let commit_ack = ack_recorder_task
         .await
@@ -127,13 +149,13 @@ async fn run_reader(mut reader: TopicReader, schedule: BenchmarkSchedule) -> Res
     })
 }
 
-async fn process_batch(
+async fn record_end_to_end_latencies(
     messages: Vec<TopicReaderMessage>,
     delivered_at_ns: u64,
     measurement_start_ns: u64,
     end_to_end: &mut LatencyRecorder,
 ) -> Result<bool> {
-    let mut measured_batch = false;
+    let mut contains_measured_messages = false;
     for mut message in messages {
         let data = message
             .read_and_take()
@@ -145,11 +167,11 @@ async fn process_batch(
             continue;
         }
 
-        measured_batch = true;
+        contains_measured_messages = true;
         let latency_ns = delivered_at_ns
             .checked_sub(sent_at_ns)
             .context("payload timestamp is ahead of the benchmark clock")?;
         end_to_end.record(Duration::from_nanos(latency_ns))?;
     }
-    Ok(measured_batch)
+    Ok(contains_measured_messages)
 }

--- a/ydb/benches/sdk_compare/topic/writer.rs
+++ b/ydb/benches/sdk_compare/topic/writer.rs
@@ -1,0 +1,160 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use tokio::task::JoinSet;
+use ydb::{PartitioningStrategy, TopicClient, TopicWriter, TopicWriterMessage, TopicWriterOptions};
+
+use super::BenchmarkSchedule;
+use crate::config::TopicWorkload;
+use crate::metrics::LatencyRecorder;
+use crate::payload;
+
+#[derive(Clone, Copy)]
+struct WriterSettings {
+    message_size_bytes: usize,
+    max_in_flight: usize,
+}
+
+impl WriterSettings {
+    fn new(workload: &TopicWorkload) -> Self {
+        Self {
+            message_size_bytes: workload.message_size_bytes,
+            max_in_flight: workload.max_in_flight_per_writer,
+        }
+    }
+}
+
+pub(super) struct WriterMetrics {
+    pub(super) write_ack: LatencyRecorder,
+}
+
+impl WriterMetrics {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            write_ack: LatencyRecorder::new()?,
+        })
+    }
+
+    fn merge(&mut self, other: &Self) -> Result<()> {
+        self.write_ack.merge(&other.write_ack)?;
+        Ok(())
+    }
+
+    fn record_acknowledgement(&mut self, latency: Option<Duration>) -> Result<()> {
+        if let Some(latency) = latency {
+            self.write_ack.record(latency)?;
+        }
+        Ok(())
+    }
+}
+
+pub(super) async fn open(
+    topic_client: &mut TopicClient,
+    topic_path: &str,
+    workload: &TopicWorkload,
+) -> Result<Vec<TopicWriter>> {
+    let mut writers = Vec::with_capacity(workload.writer_count);
+
+    for writer_id in 0..workload.writer_count {
+        let options = TopicWriterOptions::builder()
+            .topic_path(topic_path)
+            .producer_id(format!("sdk-compare-writer-{writer_id}"))
+            .partitioning(PartitioningStrategy::ByProducerId)
+            .build();
+
+        let writer = topic_client
+            .create_writer_with_params(options)
+            .await
+            .with_context(|| format!("failed to create writer {writer_id}"))?;
+
+        writers.push(writer);
+    }
+
+    Ok(writers)
+}
+
+pub(super) async fn run(
+    writers: Vec<TopicWriter>,
+    schedule: BenchmarkSchedule,
+    workload: &TopicWorkload,
+) -> Result<WriterMetrics> {
+    let settings = WriterSettings::new(workload);
+    let mut tasks = JoinSet::new();
+    for writer in writers {
+        tasks.spawn(run_writer(writer, schedule, settings));
+    }
+
+    let mut combined_metrics = WriterMetrics::new()?;
+    while let Some(joined) = tasks.join_next().await {
+        let worker_metrics = joined.context("writer task panicked or was cancelled")??;
+        combined_metrics.merge(&worker_metrics)?;
+    }
+
+    Ok(combined_metrics)
+}
+
+async fn run_writer(
+    writer: TopicWriter,
+    schedule: BenchmarkSchedule,
+    settings: WriterSettings,
+) -> Result<WriterMetrics> {
+    let mut in_flight = FuturesUnordered::new();
+    let mut metrics = WriterMetrics::new()?;
+
+    // Keep one continuous pipeline across warm-up and measurement.
+    loop {
+        if in_flight.len() < settings.max_in_flight {
+            let Some(message) = prepare_next_message(&schedule, settings.message_size_bytes)?
+            else {
+                break;
+            };
+            let ack = writer
+                .write_with_ack_future(message.message)
+                .await
+                .context("writer submission failed")?;
+            let measured = schedule.is_measurement_instant(message.started);
+            in_flight.push(async move {
+                ack.await.context("writer acknowledgement failed")?;
+                anyhow::Ok(measured.then(|| message.started.elapsed()))
+            });
+        } else {
+            let completion = in_flight
+                .next()
+                .await
+                .context("writer acknowledgement stream ended")?;
+            metrics.record_acknowledgement(completion?)?;
+        }
+    }
+
+    // Stop submitting at the measurement boundary, then finish acknowledgements already started.
+    while let Some(completion) = in_flight.next().await {
+        metrics.record_acknowledgement(completion?)?;
+    }
+
+    writer.stop().await.context("failed to stop writer")?;
+    Ok(metrics)
+}
+
+fn prepare_next_message(
+    schedule: &BenchmarkSchedule,
+    message_size_bytes: usize,
+) -> Result<Option<PreparedMessage>> {
+    // Allocate before starting the latency timer, then check that submissions remain open.
+    let mut data = payload::allocate(message_size_bytes)?;
+    let started = Instant::now();
+    if started >= schedule.measurement_end {
+        return Ok(None);
+    }
+    payload::write_timestamp(&mut data, schedule.ns_at(started)?)?;
+
+    Ok(Some(PreparedMessage {
+        message: TopicWriterMessage::builder().data(data).build(),
+        started,
+    }))
+}
+
+struct PreparedMessage {
+    message: TopicWriterMessage,
+    started: Instant,
+}

--- a/ydb/benches/sdk_compare/topic/writer.rs
+++ b/ydb/benches/sdk_compare/topic/writer.rs
@@ -1,7 +1,6 @@
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
-use futures_util::stream::{FuturesUnordered, StreamExt};
 use tokio::task::JoinSet;
 use ydb::{PartitioningStrategy, TopicClient, TopicWriter, TopicWriterMessage, TopicWriterOptions};
 
@@ -38,13 +37,6 @@ impl WriterMetrics {
 
     fn merge(&mut self, other: &Self) -> Result<()> {
         self.write_ack.merge(&other.write_ack)?;
-        Ok(())
-    }
-
-    fn record_acknowledgement(&mut self, latency: Option<Duration>) -> Result<()> {
-        if let Some(latency) = latency {
-            self.write_ack.record(latency)?;
-        }
         Ok(())
     }
 }
@@ -99,62 +91,52 @@ async fn run_writer(
     schedule: BenchmarkSchedule,
     settings: WriterSettings,
 ) -> Result<WriterMetrics> {
-    let mut in_flight = FuturesUnordered::new();
-    let mut metrics = WriterMetrics::new()?;
+    let (pending_acks_tx, mut pending_acks_rx) = tokio::sync::mpsc::channel(settings.max_in_flight);
+
+    let ack_recorder_task = tokio::spawn(async move {
+        let mut ack_latency = LatencyRecorder::new()?;
+
+        while let Some(pending_ack) = pending_acks_rx.recv().await {
+            if let Some(elapsed) = pending_ack.await? {
+                ack_latency.record(elapsed)?;
+            }
+        }
+
+        anyhow::Ok(ack_latency)
+    });
 
     // Keep one continuous pipeline across warm-up and measurement.
     loop {
-        if in_flight.len() < settings.max_in_flight {
-            let Some(message) = prepare_next_message(&schedule, settings.message_size_bytes)?
-            else {
-                break;
-            };
-            let ack = writer
-                .write_with_ack_future(message.message)
-                .await
-                .context("writer submission failed")?;
-            let measured = schedule.is_measurement_instant(message.started);
-            in_flight.push(async move {
-                ack.await.context("writer acknowledgement failed")?;
-                anyhow::Ok(measured.then(|| message.started.elapsed()))
-            });
-        } else {
-            let completion = in_flight
-                .next()
-                .await
-                .context("writer acknowledgement stream ended")?;
-            metrics.record_acknowledgement(completion?)?;
+        // Allocate before starting the latency timer.
+        let mut data = payload::allocate(settings.message_size_bytes)?;
+        let started = Instant::now();
+        if started >= schedule.measurement_end {
+            break;
         }
+        payload::write_timestamp(&mut data, schedule.ns_at(started)?)?;
+
+        let message = TopicWriterMessage::builder().data(data).build();
+        let ack = writer
+            .write_with_ack_future(message)
+            .await
+            .context("writer submission failed")?;
+        let measured = schedule.is_measurement_instant(started);
+
+        pending_acks_tx
+            .send(async move {
+                ack.await.context("writer ack failed")?;
+                anyhow::Ok(measured.then_some(started.elapsed()))
+            })
+            .await?;
     }
 
-    // Stop submitting at the measurement boundary, then finish acknowledgements already started.
-    while let Some(completion) = in_flight.next().await {
-        metrics.record_acknowledgement(completion?)?;
-    }
+    // Close the channel so the acknowledgement recorder can finish.
+    drop(pending_acks_tx);
+
+    let metrics = WriterMetrics {
+        write_ack: ack_recorder_task.await??,
+    };
 
     writer.stop().await.context("failed to stop writer")?;
     Ok(metrics)
-}
-
-fn prepare_next_message(
-    schedule: &BenchmarkSchedule,
-    message_size_bytes: usize,
-) -> Result<Option<PreparedMessage>> {
-    // Allocate before starting the latency timer, then check that submissions remain open.
-    let mut data = payload::allocate(message_size_bytes)?;
-    let started = Instant::now();
-    if started >= schedule.measurement_end {
-        return Ok(None);
-    }
-    payload::write_timestamp(&mut data, schedule.ns_at(started)?)?;
-
-    Ok(Some(PreparedMessage {
-        message: TopicWriterMessage::builder().data(data).build(),
-        started,
-    }))
-}
-
-struct PreparedMessage {
-    message: TopicWriterMessage,
-    started: Instant,
 }

--- a/ydb/benches/sdk_compare/topic/writer.rs
+++ b/ydb/benches/sdk_compare/topic/writer.rs
@@ -1,27 +1,39 @@
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinSet;
-use ydb::{PartitioningStrategy, TopicClient, TopicWriter, TopicWriterMessage, TopicWriterOptions};
+use tokio::time::sleep_until;
+use ydb::{
+    MessageSkipReason, MessageWriteStatus, PartitioningStrategy, TopicClient, TopicWriter,
+    TopicWriterAckFuture, TopicWriterMessage, TopicWriterOptions,
+};
 
-use super::BenchmarkSchedule;
+use super::{AckLatencyStart, BenchmarkSchedule};
 use crate::config::TopicWorkload;
 use crate::metrics::LatencyRecorder;
 use crate::payload;
 
 #[derive(Clone, Copy)]
-struct WriterSettings {
+struct WriterTaskSettings {
     message_size_bytes: usize,
     max_in_flight: usize,
 }
 
-impl WriterSettings {
+impl WriterTaskSettings {
     fn new(workload: &TopicWorkload) -> Self {
         Self {
             message_size_bytes: workload.message_size_bytes,
             max_in_flight: workload.max_in_flight_per_writer,
         }
     }
+}
+
+struct PendingWrite {
+    acknowledgement: TopicWriterAckFuture,
+    latency_start: AckLatencyStart,
+    _concurrency_permit: OwnedSemaphorePermit,
 }
 
 pub(super) struct WriterMetrics {
@@ -84,7 +96,7 @@ pub(super) async fn run(
     schedule: BenchmarkSchedule,
     workload: &TopicWorkload,
 ) -> Result<WriterMetrics> {
-    let settings = WriterSettings::new(workload);
+    let settings = WriterTaskSettings::new(workload);
     let mut tasks = JoinSet::new();
     for writer in writers {
         tasks.spawn(run_writer(writer, schedule, settings));
@@ -102,16 +114,25 @@ pub(super) async fn run(
 async fn run_writer(
     writer: TopicWriter,
     schedule: BenchmarkSchedule,
-    settings: WriterSettings,
+    settings: WriterTaskSettings,
 ) -> Result<WriterMetrics> {
-    let (pending_acks_tx, mut pending_acks_rx) = tokio::sync::mpsc::channel(settings.max_in_flight);
+    let write_slots = Arc::new(Semaphore::new(settings.max_in_flight));
+    // The semaphore limits submitted writes; the channel only transfers ownership.
+    let (pending_writes_tx, mut pending_writes_rx) =
+        tokio::sync::mpsc::channel::<PendingWrite>(settings.max_in_flight);
 
     let ack_recorder_task = tokio::spawn(async move {
         let mut ack_latency = LatencyRecorder::new()?;
 
-        while let Some(pending_ack) = pending_acks_rx.recv().await {
-            if let Some(elapsed) = pending_ack.await? {
-                ack_latency.record(elapsed)?;
+        while let Some(pending_write) = pending_writes_rx.recv().await {
+            let status = pending_write
+                .acknowledgement
+                .await
+                .context("writer ack failed")?;
+            ensure_message_persisted(status)?;
+
+            if let AckLatencyStart::Measured(started_at) = pending_write.latency_start {
+                ack_latency.record(started_at.elapsed())?;
             }
         }
 
@@ -120,36 +141,57 @@ async fn run_writer(
 
     // Keep one continuous pipeline across warm-up and measurement.
     loop {
+        let concurrency_permit = tokio::select! {
+            permit = Arc::clone(&write_slots).acquire_owned() => {
+                permit.context("write concurrency limiter was closed")?
+            }
+            () = sleep_until(schedule.measurement_end.into()) => break,
+        };
+
         // Allocate before starting the latency timer.
         let mut data = payload::allocate(settings.message_size_bytes)?;
-        let started = Instant::now();
-        if started >= schedule.measurement_end {
+        let write_started_at = Instant::now();
+        if write_started_at >= schedule.measurement_end {
             break;
         }
-        payload::write_timestamp(&mut data, schedule.ns_at(started)?)?;
+        payload::write_timestamp(&mut data, schedule.ns_at(write_started_at)?)?;
 
         let message = TopicWriterMessage::builder().data(data).build();
-        let ack = writer
+        let acknowledgement = writer
             .write_with_ack_future(message)
             .await
             .context("writer submission failed")?;
-        let measured = schedule.is_measurement_instant(started);
+        let latency_start = if schedule.is_measurement_instant(write_started_at) {
+            AckLatencyStart::Measured(write_started_at)
+        } else {
+            AckLatencyStart::Warmup
+        };
 
-        pending_acks_tx
-            .send(async move {
-                ack.await.context("writer ack failed")?;
-                anyhow::Ok(measured.then_some(started.elapsed()))
+        pending_writes_tx
+            .try_send(PendingWrite {
+                acknowledgement,
+                latency_start,
+                _concurrency_permit: concurrency_permit,
             })
-            .await?;
+            .context("failed to hand write to acknowledgement recorder")?;
     }
 
     // Close the channel so the acknowledgement recorder can finish.
-    drop(pending_acks_tx);
+    drop(pending_writes_tx);
 
-    let metrics = WriterMetrics {
-        write_ack: ack_recorder_task.await??,
-    };
+    let write_ack = ack_recorder_task
+        .await
+        .context("write acknowledgement recorder panicked or was cancelled")??;
+    let metrics = WriterMetrics { write_ack };
 
     writer.stop().await.context("failed to stop writer")?;
     Ok(metrics)
+}
+
+fn ensure_message_persisted(status: MessageWriteStatus) -> Result<()> {
+    match status {
+        MessageWriteStatus::Written(_)
+        | MessageWriteStatus::Skipped(MessageSkipReason::AlreadyWritten) => Ok(()),
+        other => bail!("message was not persisted: server returned {other:?}"),
+    }
 }

--- a/ydb/benches/sdk_compare/topic/writer.rs
+++ b/ydb/benches/sdk_compare/topic/writer.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use tokio::task::JoinSet;
@@ -59,6 +59,10 @@ pub(super) async fn open(
                 .topic_path(topic_path)
                 .producer_id(format!("sdk-compare-writer-{partition_id}-{writer_index}"))
                 .partitioning(PartitioningStrategy::PartitionId(i64::from(partition_id)))
+                .write_request_messages_chunk_size(workload.write_batch_max_messages)
+                .write_request_send_messages_period(Duration::from_millis(
+                    workload.write_batch_max_delay_ms,
+                ))
                 .build();
 
             let writer = topic_client

--- a/ydb/benches/sdk_compare/topic/writer.rs
+++ b/ydb/benches/sdk_compare/topic/writer.rs
@@ -46,21 +46,30 @@ pub(super) async fn open(
     topic_path: &str,
     workload: &TopicWorkload,
 ) -> Result<Vec<TopicWriter>> {
-    let mut writers = Vec::with_capacity(workload.writer_count);
+    let partition_count = usize::try_from(workload.partition_count)
+        .context("partition count does not fit into usize")?;
+    let writer_count = partition_count
+        .checked_mul(workload.writers_per_partition)
+        .context("total writer count overflowed")?;
+    let mut writers = Vec::with_capacity(writer_count);
 
-    for writer_id in 0..workload.writer_count {
-        let options = TopicWriterOptions::builder()
-            .topic_path(topic_path)
-            .producer_id(format!("sdk-compare-writer-{writer_id}"))
-            .partitioning(PartitioningStrategy::ByProducerId)
-            .build();
+    for partition_id in 0..workload.partition_count {
+        for writer_index in 0..workload.writers_per_partition {
+            let options = TopicWriterOptions::builder()
+                .topic_path(topic_path)
+                .producer_id(format!("sdk-compare-writer-{partition_id}-{writer_index}"))
+                .partitioning(PartitioningStrategy::PartitionId(i64::from(partition_id)))
+                .build();
 
-        let writer = topic_client
-            .create_writer_with_params(options)
-            .await
-            .with_context(|| format!("failed to create writer {writer_id}"))?;
+            let writer = topic_client
+                .create_writer_with_params(options)
+                .await
+                .with_context(|| {
+                    format!("failed to create writer {writer_index} for partition {partition_id}")
+                })?;
 
-        writers.push(writer);
+            writers.push(writer);
+        }
     }
 
     Ok(writers)

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -297,3 +297,49 @@ pub struct TopicReaderCommitMarker {
     pub(crate) topic: String,
     pub(crate) epoch: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn commit_ack_future_reports_closed_channel() {
+        let (sender, receiver) = oneshot::channel();
+        drop(sender);
+
+        let future = TopicReaderCommitAckFuture {
+            state: TopicReaderCommitAckState::Waiting(receiver),
+        };
+
+        assert!(future.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn commit_ack_future_returns_initial_failure() {
+        let future = TopicReaderCommitAckFuture {
+            state: TopicReaderCommitAckState::Failed(YdbError::Transport(String::new())),
+        };
+
+        assert!(future.await.is_err());
+    }
+
+    #[test]
+    fn commit_ack_future_rejects_poll_after_completion() {
+        let (sender, receiver) = oneshot::channel();
+        sender.send(Ok(())).expect("receiver must remain open");
+
+        let mut future = std::pin::pin!(TopicReaderCommitAckFuture {
+            state: TopicReaderCommitAckState::Waiting(receiver),
+        });
+        let mut context = Context::from_waker(std::task::Waker::noop());
+
+        assert!(matches!(
+            future.as_mut().poll(&mut context),
+            Poll::Ready(Ok(()))
+        ));
+        assert!(matches!(
+            future.as_mut().poll(&mut context),
+            Poll::Ready(Err(_))
+        ));
+    }
+}

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -1,8 +1,11 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use futures_util::Future;
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -28,6 +31,42 @@ use crate::{YdbError, YdbResult};
 use super::reader_tx::TopicReaderTx;
 use super::reconnector::{Reconnector, ReconnectorTask};
 use super::runtime::RuntimeHandle;
+
+/// A pending acknowledgement for a submitted Topic reader commit.
+pub struct TopicReaderCommitAckFuture {
+    state: TopicReaderCommitAckState,
+}
+
+enum TopicReaderCommitAckState {
+    Waiting(oneshot::Receiver<YdbResult<()>>),
+    Failed(YdbError),
+    Completed,
+}
+
+impl Future for TopicReaderCommitAckFuture {
+    type Output = YdbResult<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let result = match &mut self.state {
+            TopicReaderCommitAckState::Waiting(receiver) => match Pin::new(receiver).poll(cx) {
+                Poll::Ready(Ok(result)) => result,
+                Poll::Ready(Err(_)) => Err(YdbError::custom(
+                    "commit channel was closed without error message",
+                )),
+                Poll::Pending => return Poll::Pending,
+            },
+            TopicReaderCommitAckState::Failed(error) => Err(error.clone()),
+            TopicReaderCommitAckState::Completed => {
+                return Poll::Ready(Err(YdbError::custom(
+                    "commit acknowledgement future was polled after completion",
+                )));
+            }
+        };
+
+        self.state = TopicReaderCommitAckState::Completed;
+        Poll::Ready(result)
+    }
+}
 
 pub struct TopicReader {
     pub(super) manager: GrpcConnectionManager,
@@ -128,19 +167,13 @@ impl TopicReader {
     pub fn commit_with_ack(
         &mut self,
         commit_marker: TopicReaderCommitMarker,
-    ) -> impl Future<Output = YdbResult<()>> + use<> {
-        let ack = self.runtime.commit(commit_marker);
+    ) -> TopicReaderCommitAckFuture {
+        let state = match self.runtime.commit(commit_marker) {
+            Ok(receiver) => TopicReaderCommitAckState::Waiting(receiver),
+            Err(error) => TopicReaderCommitAckState::Failed(error),
+        };
 
-        async {
-            let ack = ack?;
-
-            match ack.await {
-                Ok(res) => res,
-                Err(_) => Err(YdbError::custom(
-                    "commit channel was closed without error message",
-                )),
-            }
-        }
+        TopicReaderCommitAckFuture { state }
     }
 
     pub(super) fn runtime_handle(&self) -> RuntimeHandle {

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -28,11 +28,12 @@ pub struct TopicWriter {
     _cancel_on_drop: DropGuard,
 }
 
-pub struct AckFuture {
+/// A pending acknowledgement for a submitted Topic write.
+pub struct TopicWriterAckFuture {
     receiver: oneshot::Receiver<YdbResult<MessageWriteStatus>>,
 }
 
-impl Future for AckFuture {
+impl Future for TopicWriterAckFuture {
     type Output = YdbResult<MessageWriteStatus>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -151,12 +152,15 @@ impl TopicWriter {
     }
 
     #[instrument(name = "ydb.TopicWriter.WriteWithAckFuture", skip_all, fields(db.system.name = "ydb"), err)]
-    pub async fn write_with_ack_future(&self, message: TopicWriterMessage) -> YdbResult<AckFuture> {
+    pub async fn write_with_ack_future(
+        &self,
+        message: TopicWriterMessage,
+    ) -> YdbResult<TopicWriterAckFuture> {
         let (tx, rx) = oneshot::channel();
 
         self.write_message(message, Some(tx)).await?;
 
-        Ok(AckFuture { receiver: rx })
+        Ok(TopicWriterAckFuture { receiver: rx })
     }
 
     async fn write_message(

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -145,7 +145,8 @@ pub use client_topic::topicreader::messages::{
 };
 // full enum pub types
 pub use client_topic::topicreader::reader::{
-    TopicReader, TopicReaderCommitMarker, TopicSelector, TopicSelectorBuilder, TopicSelectors,
+    TopicReader, TopicReaderCommitAckFuture, TopicReaderCommitMarker, TopicSelector,
+    TopicSelectorBuilder, TopicSelectors,
 };
 pub use client_topic::topicreader::reader_options::{
     TopicReaderOptions, TopicReaderOptionsBuilder,
@@ -153,11 +154,14 @@ pub use client_topic::topicreader::reader_options::{
 pub use client_topic::topicreader::reader_tx::TopicReaderTx;
 // full enum pub types
 pub use client_topic::topicwriter::message::{TopicWriterMessage, TopicWriterMessageBuilder};
+pub use client_topic::topicwriter::message_write_status::{
+    MessageSkipReason, MessageWriteInTxInfo, MessageWriteInfo, MessageWriteStatus,
+};
 // full enum pub types
 pub use client_topic::topicwriter::partitioning::PartitioningStrategy;
 // full enum pub types
 pub use client_topic::compression::{CompressionDecoder, CompressionEncoder, Executor};
-pub use client_topic::topicwriter::writer::TopicWriter;
+pub use client_topic::topicwriter::writer::{TopicWriter, TopicWriterAckFuture};
 pub use client_topic::topicwriter::writer_options::{
     TopicWriterOptions, TopicWriterOptionsBuilder,
 };


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is no Rust SDK services benchmarks, therefore it is not possible to compare this SDK with C++ SDK.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This PR adds Rust implementation of topic service benchmark. 
<!-- Please describe the behavior or changes that are being added by this PR. -->
Accepts config via JSON, returns result of benchmark as JSON. 
Both Rust and C++ have convenient mapping JSON <-> structs. 

Benchmark collects:
- Write acknowledgement latency
- End-to-end delivery latency
- Reader commit acknowledgement latency
- Read/write throughput 

Benchmark does:
- Runs concurrently configured readers/writers
- During warmup they just send/accept messages
- During measurement they send/accept messages and record latency/throughput statistics
- Then measuring ends, all tasks end, their statistics are merged and returned as result of benchmark

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
