### PR TITLE
Add nightly to CI for codecov

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -2,11 +2,11 @@ name: YDB tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '18 4 * * *'
+    - cron: "18 4 * * *"
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,26 +15,33 @@ env:
   RUST_VERSION_MSRV: "1.88"
   # Pinned modern Rust version used for forward compatibility coverage.
   RUST_VERSION_MODERN: "1.96"
-  # Stable Rust version used against dependencies test
-  RUST_VERSION_STABLE: stable
 
 jobs:
   tests:
-    name: ${{ matrix.name }}
+    name: tests (${{ matrix.rust_version }}${{ case(matrix.latest_deps, ', latest deps', '') }})
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: tests (RUST_VERSION_MSRV)
-            rust_version: "RUST_VERSION_MSRV"
+          - rust_version: ${{ env.RUST_VERSION_MSRV }}
+            codecov: false
             latest_deps: false
-          - name: tests (RUST_VERSION_MODERN)
-            rust_version: "RUST_VERSION_MODERN"
+          - rust_version: ${{ env.RUST_VERSION_MODERN }}
+            codecov: false
             latest_deps: false
-          # Advisory leg: failures do not block merges.
-          - name: tests (RUST_VERSION_STABLE, latest deps (advisory))
-            rust_version: "RUST_VERSION_STABLE"
+          - rust_version: stable
+            codecov: false
+            latest_deps: false
+          # Test with nightly compiler.
+          # Coverarage only tested with nightly compiler
+          # because it supports `--doctests` flag
+          - rust_version: nightly
+            codecov: true
+            latest_deps: false
+          # Test with the latest versions of deps
+          - rust_version: stable
+            codecov: false
             latest_deps: true
 
     services:
@@ -48,60 +55,67 @@ jobs:
           - /tmp/ydb_certs:/ydb_certs
         env:
           YDB_USE_IN_MEMORY_PDISKS: true
-        options: '-h localhost --name ydb'
+        options: "-h localhost --name ydb"
 
     runs-on: ubuntu-24.04
-    continue-on-error: ${{ matrix.latest_deps }}
 
     steps:
-    - name: Show YDB server version
-      run: docker ps; docker exec ydb /ydbd -V
+      - name: Show YDB server version
+        run: docker ps; docker exec ydb /ydbd -V
 
-    - name: Install rust
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        toolchain: ${{ env[matrix.rust_version] }}
-        components: llvm-tools-preview
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: llvm-tools-preview
 
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: true
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
 
-    - name: Update dependencies to latest compatible versions
-      if: ${{ matrix.latest_deps }}
-      run: |
-        cargo update --verbose
-        git diff -- Cargo.lock
+      - name: Update dependencies to latest compatible versions
+        if: ${{ matrix.latest_deps }}
+        run: |
+          cargo update --verbose
+          git diff -- Cargo.lock
 
-    - name: Rust version
-      id: rust_version_step
-      run: |
-        rustc --version
-        cargo --version
-        echo "CARGO_INCREMENTAL=$CARGO_INCREMENTAL"
-        echo "version=$(rustc --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
+      - name: Rust version
+        id: rust_version_step
+        run: |
+          rustc --version
+          cargo --version
+          echo "CARGO_INCREMENTAL=$CARGO_INCREMENTAL"
+          echo "version=$(rustc --version | cut -d ' ' -f 2)" >> "$GITHUB_OUTPUT"
 
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-    - name: Rustdoc examples check
-      run: cargo test --workspace --doc
+      - name: Rustdoc examples check
+        run: cargo test --workspace --doc
 
-    - name: Run tests with coverage
-      env:
-        YDB_CONNECTION_STRING: grpc://localhost:2136/local
-      run: cargo llvm-cov --workspace --exclude slo-framework --exclude slo-native-query --exclude slo-native-topic --lcov --output-path lcov.info -- --include-ignored
+      - name: Run tests with coverage
+        if: ${{ matrix.codecov }}
+        env:
+          YDB_CONNECTION_STRING: grpc://localhost:2136/local
+        run: >
+          cargo llvm-cov
+            --doctests
+            --workspace
+            --exclude slo-framework
+            --exclude slo-native-query
+            --exclude slo-native-topic
+            --lcov --output-path lcov.info -- --include-ignored
 
-    - name: Upload coverage report to Codecov
-      if: ${{ !matrix.latest_deps }}
-      uses: codecov/codecov-action@v4
-      with:
-        file: ./lcov.info
-        flags: tests,ubuntu,rust-${{ steps.rust_version_step.outputs.version }}
-        name: tests
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage report to Codecov
+        if: ${{ matrix.codecov }}
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./lcov.info
+          flags: tests,ubuntu,rust-${{ steps.rust_version_step.outputs.version }}
+          name: tests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   tests:
-    name: tests (${{ matrix.label }})
+    name: tests (${{ case(matrix.label != '', matrix.label, format('{0} rustc', matrix.rust_version)) }})
 
     strategy:
       fail-fast: false
@@ -30,19 +30,18 @@ jobs:
             rust_version: "1.96"
             codecov: false
             latest_deps: false
-          - label: stable rustc
-            rust_version: stable
+          - rust_version: stable
             codecov: false
             latest_deps: false
           # Test with nightly compiler.
           # Coverage only tested with nightly compiler
           # because it supports `--doctests` flag
-          - label: nightly rustc
-            rust_version: nightly
+          - rust_version: nightly
             codecov: true
             latest_deps: false
           # Test with the latest versions of deps
           - label: stable rustc, latest deps
+            rust_version: stable
             codecov: false
             latest_deps: true
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   tests:
-    name: tests (${{ matrix.rust_version }}${{ case(matrix.latest_deps, ', latest deps', '') }})
+    name: ${{ format('tests ({0}{1})', matrix.rust_version, case(matrix.latest_deps, ', latest deps', '')) }}
 
     strategy:
       fail-fast: false
@@ -101,14 +101,7 @@ jobs:
         if: ${{ matrix.codecov }}
         env:
           YDB_CONNECTION_STRING: grpc://localhost:2136/local
-        run: >
-          cargo llvm-cov
-            --doctests
-            --workspace
-            --exclude slo-framework
-            --exclude slo-native-query
-            --exclude slo-native-topic
-            --lcov --output-path lcov.info -- --include-ignored
+        run: cargo llvm-cov --doctests --workspace --exclude slo-framework --exclude slo-native-query --exclude slo-native-topic --lcov --output-path lcov.info -- --include-ignored
 
       - name: Upload coverage report to Codecov
         if: ${{ matrix.codecov }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -36,7 +36,8 @@ jobs:
           # Test with nightly compiler.
           # Coverage only tested with nightly compiler
           # because it supports `--doctests` flag
-          - rust_version: nightly
+          - label: nightly rustc, codecov
+            rust_version: nightly
             codecov: true
             latest_deps: false
           # Test with the latest versions of deps

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -14,35 +14,35 @@ env:
 
 jobs:
   tests:
-    name: ${{ format('tests ({0}{1})', matrix.rust_version_name, case(matrix.latest_deps, ', latest deps', '')) }}
+    name: tests (${{ matrix.label }})
 
     strategy:
       fail-fast: false
       matrix:
         include:
           # MSRV. Keep in sync with [workspace.package].rust-version in Cargo.toml.
-          - rust_version_name: MSRV
+          - label: MSRV
             rust_version: "1.88"
             codecov: false
             latest_deps: false
           # Pinned modern Rust version used for forward compatibility coverage.
-          - rust_version_name: modern
+          - label: modern
             rust_version: "1.96"
             codecov: false
             latest_deps: false
-          - rust_version_name: stable
+          - label: stable
             rust_version: stable
             codecov: false
             latest_deps: false
           # Test with nightly compiler.
           # Coverage only tested with nightly compiler
           # because it supports `--doctests` flag
-          - rust_version_name: nightly
+          - label: nightly
             rust_version: nightly
             codecov: true
             latest_deps: false
           # Test with the latest versions of deps
-          - rust_version: stable
+          - label: stable, with latest deps
             codecov: false
             latest_deps: true
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -97,7 +97,14 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Rustdoc examples check
+        if: ${{ !matrix.codecov }}
         run: cargo test --workspace --doc
+
+      - name: Run tests
+        if: ${{ !matrix.codecov }}
+        env:
+          YDB_CONNECTION_STRING: grpc://localhost:2136/local
+        run: cargo test --workspace -- --include-ignored
 
       - name: Run tests with coverage
         if: ${{ matrix.codecov }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -11,32 +11,34 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
-  # MSRV. Keep in sync with [workspace.package].rust-version in Cargo.toml.
-  RUST_VERSION_MSRV: "1.88"
-  # Pinned modern Rust version used for forward compatibility coverage.
-  RUST_VERSION_MODERN: "1.96"
 
 jobs:
   tests:
-    name: ${{ format('tests ({0}{1})', matrix.rust_version, case(matrix.latest_deps, ', latest deps', '')) }}
+    name: ${{ format('tests ({0}{1})', matrix.rust_version_name, case(matrix.latest_deps, ', latest deps', '')) }}
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - rust_version: ${{ env.RUST_VERSION_MSRV }}
+          # MSRV. Keep in sync with [workspace.package].rust-version in Cargo.toml.
+          - rust_version_name: MSRV
+            rust_version: "1.88"
             codecov: false
             latest_deps: false
-          - rust_version: ${{ env.RUST_VERSION_MODERN }}
+          # Pinned modern Rust version used for forward compatibility coverage.
+          - rust_version_name: modern
+            rust_version: "1.96"
             codecov: false
             latest_deps: false
-          - rust_version: stable
+          - rust_version_name: stable
+            rust_version: stable
             codecov: false
             latest_deps: false
           # Test with nightly compiler.
-          # Coverarage only tested with nightly compiler
+          # Coverage only tested with nightly compiler
           # because it supports `--doctests` flag
-          - rust_version: nightly
+          - rust_version_name: nightly
+            rust_version: nightly
             codecov: true
             latest_deps: false
           # Test with the latest versions of deps

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -21,28 +21,28 @@ jobs:
       matrix:
         include:
           # MSRV. Keep in sync with [workspace.package].rust-version in Cargo.toml.
-          - label: MSRV
+          - label: MSRV rustc
             rust_version: "1.88"
             codecov: false
             latest_deps: false
           # Pinned modern Rust version used for forward compatibility coverage.
-          - label: modern
+          - label: modern rustc
             rust_version: "1.96"
             codecov: false
             latest_deps: false
-          - label: stable
+          - label: stable rustc
             rust_version: stable
             codecov: false
             latest_deps: false
           # Test with nightly compiler.
           # Coverage only tested with nightly compiler
           # because it supports `--doctests` flag
-          - label: nightly
+          - label: nightly rustc
             rust_version: nightly
             codecov: true
             latest_deps: false
           # Test with the latest versions of deps
-          - label: stable, with latest deps
+          - label: stable rustc, latest deps
             codecov: false
             latest_deps: true
 

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -176,6 +176,8 @@ impl QueryClient {
     /// Run a callback inside a retried interactive transaction.
     ///
     /// ```no_run
+    /// # #![recursion_limit = "256"]
+    /// #
     /// # use std::time::Duration;
     /// # use ydb::{AccessTokenCredentials, ClientBuilder, TxMode, YdbResultWithCustomerErr};
     /// #

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -3,6 +3,8 @@
 //! # Example
 //!
 //! ```no_run
+//! # #![recursion_limit = "256"]
+//! #
 //! # use ydb::{AccessTokenCredentials, ClientBuilder, YdbResult};
 //! #
 //! # #[tokio::main]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The crate is not tested on nightly compiler, also doctests are not included in coverage reports. Also being broken with the latest
versions of deps don't block merging.

Issue Number: N/A

## What is the new behavior?

The crate is tested on nightly compiler too, covecoverage tests are run only against nightly compiler because it support
including doctests in coverage tests, also being broken with the latest versions of deps now block merging as it should.
<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
