### PR TITLE
ci: SLO db-paths collision fix

### DIFF
--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -97,6 +97,8 @@ jobs:
           cd current
           if [[ -n "${{ inputs.baseline_ref }}" ]]; then
             BASELINE="${{ inputs.baseline_ref }}"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            BASELINE="${{ github.event.before }}"
           else
             BASELINE=$(git merge-base HEAD origin/master)
           fi


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

https://github.com/ydb-platform/ydb-rs-sdk/actions/runs/30547378515
As seen in that run, ci runner produced BASELINE=master and CURRENT=master runs for SLO. Those two runs had access to the same YDB resources. This produces errors of deletion/creation. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

On push BASELINE is explicitly set to the commit master branch pointed before.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
