### PR TITLE
feat(topic writer): add max in flight message limits 

### DIFF
--- a/ydb/src/byte_units.rs
+++ b/ydb/src/byte_units.rs
@@ -1,0 +1,5 @@
+#[allow(non_upper_case_globals)]
+pub(crate) const KiB: usize = 1 << 10;
+
+#[allow(non_upper_case_globals)]
+pub(crate) const MiB: usize = 1 << 20;

--- a/ydb/src/client_topic/compression/compression_worker.rs
+++ b/ydb/src/client_topic/compression/compression_worker.rs
@@ -7,18 +7,23 @@ use crate::{YdbError, YdbResult};
 use std::{num::NonZeroUsize, sync::Arc};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
-use ydb_grpc::ydb_proto::topic::stream_write_message::WriteRequest;
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
-type ChunkResult = YdbResult<WriteRequest>;
+type ChunkResult = YdbResult<CompressedChunk>;
 type InputRx = mpsc::UnboundedReceiver<Vec<MessageData>>;
 type OutputTx = mpsc::UnboundedSender<ChunkResult>;
+
+pub(crate) struct CompressedChunk {
+    pub(crate) messages: Vec<MessageData>,
+    pub(crate) codec: Codec,
+    pub(crate) ends_batch: bool,
+}
 
 pub(crate) struct CompressionWorker {
     codec_selector: CodecSelector,
     codec_registry: Arc<CodecRegistry>,
-    queue: OrderedTaskQueue<WriteRequest>,
-    results_rx: ordered_task_queue::TaskResultRx<WriteRequest>,
+    queue: OrderedTaskQueue<CompressedChunk>,
+    results_rx: ordered_task_queue::TaskResultRx<CompressedChunk>,
     parallelism: NonZeroUsize,
 }
 
@@ -67,11 +72,14 @@ impl CompressionWorker {
                 while !batch.is_empty() {
                     let chunk: Vec<MessageData> =
                         batch.drain(..chunk_size.min(batch.len())).collect();
+                    let ends_batch = batch.is_empty();
 
                     let registry = codec_registry.clone();
 
                     queue
-                        .submit(Box::new(move || compress_batch(chunk, codec, registry)))
+                        .submit(Box::new(move || {
+                            compress_chunk(chunk, codec, ends_batch, registry)
+                        }))
                         .await;
                 }
             }
@@ -91,9 +99,10 @@ impl CompressionWorker {
     }
 }
 
-fn compress_batch(
-    mut batch: Vec<MessageData>,
+fn compress_chunk(
+    mut messages: Vec<MessageData>,
     codec: Codec,
+    ends_batch: bool,
     registry: Arc<CodecRegistry>,
 ) -> ChunkResult {
     if codec != Codec::RAW {
@@ -104,7 +113,7 @@ fn compress_batch(
             )));
         };
 
-        for message in batch.iter_mut() {
+        for message in messages.iter_mut() {
             message.data = encoder.encode(message.data.as_slice()).map_err(|err| {
                 YdbError::custom(format!(
                     "{encoder:?} failed to encode: {err}, message seq_no: {}",
@@ -114,9 +123,9 @@ fn compress_batch(
         }
     }
 
-    Ok(WriteRequest {
-        messages: batch,
-        codec: codec.code,
-        tx: None,
+    Ok(CompressedChunk {
+        messages,
+        codec,
+        ends_batch,
     })
 }

--- a/ydb/src/client_topic/compression/mod.rs
+++ b/ydb/src/client_topic/compression/mod.rs
@@ -12,7 +12,7 @@ pub(crate) const OUTPUT_BACKLOG_PER_TASK: std::num::NonZeroUsize =
 pub(crate) use codec_registry::CodecRegistry;
 pub use codec_registry::{CompressionDecoder, CompressionEncoder};
 pub use codec_selector::CodecSelection;
-pub(crate) use compression_worker::CompressionWorker;
+pub(crate) use compression_worker::{CompressedChunk, CompressionWorker};
 pub use executor::Executor;
 pub(crate) use executor::default_executor;
 pub(crate) use ordered_task_queue::{OrderedTaskQueue, TaskResultRx};

--- a/ydb/src/client_topic/topicwriter/capacity_limiter.rs
+++ b/ydb/src/client_topic/topicwriter/capacity_limiter.rs
@@ -5,7 +5,16 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::{YdbError, YdbResult};
 
-const MAX_MESSAGE_SIZE_BYTES: usize = u32::MAX as usize;
+/// Maximum message payload size supported by byte-capacity accounting.
+///
+/// A Tokio semaphore can hold at most [`Semaphore::MAX_PERMITS`] permits, while
+/// [`Semaphore::acquire_many_owned`] accepts a `u32` permit count. Use the smaller bound so the
+/// hard message limit is valid on every pointer width.
+const MAX_MESSAGE_SIZE_BYTES: usize = if Semaphore::MAX_PERMITS < u32::MAX as usize {
+    Semaphore::MAX_PERMITS
+} else {
+    u32::MAX as usize
+};
 
 #[derive(Clone)]
 pub(crate) struct CapacityLimiter {
@@ -123,8 +132,7 @@ impl CapacityLimiter {
             )));
         }
 
-        u32::try_from(message_size.min(self.max_inflight_bytes.get()))
-            .map_err(|err| YdbError::custom(format!("message size conversion failed: {err}")))
+        Ok(message_size.min(self.max_inflight_bytes.get()) as u32)
     }
 
     pub(crate) fn close(&self) {
@@ -160,13 +168,7 @@ mod tests {
         let capacity = MAX_MESSAGE_SIZE_BYTES + 1;
         let limiter = CapacityLimiter::new(nonzero(1), nonzero(capacity)).unwrap();
 
-        let err = limiter
-            .try_acquire(capacity)
-            .err()
-            .expect("oversized message is rejected");
-        let message = err.to_string();
-        assert!(message.contains(&format!("size={capacity}")));
-        assert!(message.contains(&format!("limit={MAX_MESSAGE_SIZE_BYTES}")));
+        assert!(limiter.try_acquire(capacity).is_err());
     }
 
     #[tokio::test]
@@ -226,7 +228,6 @@ mod tests {
 
         limiter.close();
 
-        let err = waiting.await.err().expect("closed limiter rejects waiter");
-        assert!(err.to_string().contains("closed for new messages"));
+        assert!(waiting.await.is_err());
     }
 }

--- a/ydb/src/client_topic/topicwriter/capacity_limiter.rs
+++ b/ydb/src/client_topic/topicwriter/capacity_limiter.rs
@@ -1,0 +1,232 @@
+use std::{num::NonZeroUsize, sync::Arc};
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use crate::client_topic::topicwriter::message::TopicWriterMessage;
+use crate::{YdbError, YdbResult};
+
+const MAX_MESSAGE_SIZE_BYTES: usize = u32::MAX as usize;
+
+#[derive(Clone)]
+pub(crate) struct CapacityLimiter {
+    message_slots: Arc<Semaphore>,
+    byte_slots: Arc<Semaphore>,
+    max_inflight_bytes: NonZeroUsize,
+}
+
+pub(crate) struct CapacityPermit {
+    _message: OwnedSemaphorePermit,
+    _bytes: OwnedSemaphorePermit,
+}
+
+pub(crate) struct AdmittedMessage {
+    message: TopicWriterMessage,
+    capacity: CapacityPermit,
+}
+
+impl AdmittedMessage {
+    pub(crate) fn message_mut(&mut self) -> &mut TopicWriterMessage {
+        &mut self.message
+    }
+
+    pub(crate) fn into_parts(self) -> (TopicWriterMessage, CapacityPermit) {
+        (self.message, self.capacity)
+    }
+}
+
+impl CapacityLimiter {
+    pub(crate) fn new(
+        max_inflight_messages: NonZeroUsize,
+        max_inflight_bytes: NonZeroUsize,
+    ) -> YdbResult<Self> {
+        if max_inflight_messages.get() > Semaphore::MAX_PERMITS {
+            return Err(YdbError::custom(format!(
+                "max_inflight_messages exceeds the supported limit: value={max_inflight_messages}, limit={}",
+                Semaphore::MAX_PERMITS,
+            )));
+        }
+        if max_inflight_bytes.get() > Semaphore::MAX_PERMITS {
+            return Err(YdbError::custom(format!(
+                "max_inflight_bytes exceeds the supported limit: value={max_inflight_bytes}, limit={}",
+                Semaphore::MAX_PERMITS,
+            )));
+        }
+
+        Ok(Self {
+            message_slots: Arc::new(Semaphore::new(max_inflight_messages.get())),
+            byte_slots: Arc::new(Semaphore::new(max_inflight_bytes.get())),
+            max_inflight_bytes,
+        })
+    }
+
+    pub(crate) async fn admit(&self, message: TopicWriterMessage) -> YdbResult<AdmittedMessage> {
+        let charged_bytes = self.charged_bytes(message.data.len())?;
+        let capacity = self.acquire(charged_bytes).await?;
+        Ok(AdmittedMessage { message, capacity })
+    }
+
+    async fn acquire(&self, charged_bytes: u32) -> YdbResult<CapacityPermit> {
+        let message = self
+            .message_slots
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| YdbError::custom("message queue is closed for new messages"))?;
+
+        // A message larger than the entire buffer occupies all byte slots. This lets one
+        // oversized message make progress while still applying backpressure to later writes.
+        let bytes = self
+            .byte_slots
+            .clone()
+            .acquire_many_owned(charged_bytes)
+            .await
+            .map_err(|_| YdbError::custom("message queue is closed for new messages"))?;
+
+        Ok(CapacityPermit {
+            _message: message,
+            _bytes: bytes,
+        })
+    }
+
+    #[cfg(test)]
+    fn try_admit(&self, message: TopicWriterMessage) -> YdbResult<AdmittedMessage> {
+        let capacity = self.try_acquire(message.data.len())?;
+        Ok(AdmittedMessage { message, capacity })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_acquire(&self, message_size: usize) -> YdbResult<CapacityPermit> {
+        let charged_bytes = self.charged_bytes(message_size)?;
+        let message = self
+            .message_slots
+            .clone()
+            .try_acquire_owned()
+            .map_err(|err| {
+                YdbError::custom(format!("failed to acquire message capacity: {err}"))
+            })?;
+        let bytes = self
+            .byte_slots
+            .clone()
+            .try_acquire_many_owned(charged_bytes)
+            .map_err(|err| YdbError::custom(format!("failed to acquire byte capacity: {err}")))?;
+
+        Ok(CapacityPermit {
+            _message: message,
+            _bytes: bytes,
+        })
+    }
+
+    fn charged_bytes(&self, message_size: usize) -> YdbResult<u32> {
+        if message_size > MAX_MESSAGE_SIZE_BYTES {
+            return Err(YdbError::custom(format!(
+                "message payload exceeds the supported size: size={message_size}, limit={MAX_MESSAGE_SIZE_BYTES}",
+            )));
+        }
+
+        u32::try_from(message_size.min(self.max_inflight_bytes.get()))
+            .map_err(|err| YdbError::custom(format!("message size conversion failed: {err}")))
+    }
+
+    pub(crate) fn close(&self) {
+        self.message_slots.close();
+        self.byte_slots.close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::FutureExt;
+
+    use super::*;
+
+    fn message(size: usize) -> TopicWriterMessage {
+        TopicWriterMessage::builder().data(vec![0; size]).build()
+    }
+
+    fn nonzero(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).unwrap()
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn allows_inflight_capacity_above_single_message_limit() {
+        let capacity = MAX_MESSAGE_SIZE_BYTES + 1;
+        assert!(CapacityLimiter::new(nonzero(1), nonzero(capacity)).is_ok());
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn rejects_message_above_single_message_limit() {
+        let capacity = MAX_MESSAGE_SIZE_BYTES + 1;
+        let limiter = CapacityLimiter::new(nonzero(1), nonzero(capacity)).unwrap();
+
+        let err = limiter
+            .try_acquire(capacity)
+            .err()
+            .expect("oversized message is rejected");
+        let message = err.to_string();
+        assert!(message.contains(&format!("size={capacity}")));
+        assert!(message.contains(&format!("limit={MAX_MESSAGE_SIZE_BYTES}")));
+    }
+
+    #[tokio::test]
+    async fn waits_for_message_capacity() {
+        let limiter = CapacityLimiter::new(nonzero(1), nonzero(2)).unwrap();
+        let permit = limiter.admit(message(1)).await.unwrap();
+
+        let mut waiting = Box::pin(limiter.admit(message(1)));
+        assert!(waiting.as_mut().now_or_never().is_none());
+
+        drop(permit);
+        waiting.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn waits_for_byte_capacity() {
+        let limiter = CapacityLimiter::new(nonzero(2), nonzero(1)).unwrap();
+        let permit = limiter.admit(message(1)).await.unwrap();
+
+        let mut waiting = Box::pin(limiter.admit(message(1)));
+        assert!(waiting.as_mut().now_or_never().is_none());
+
+        drop(permit);
+        waiting.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_message_occupies_all_byte_capacity() {
+        let limiter = CapacityLimiter::new(nonzero(2), nonzero(5)).unwrap();
+        let permit = limiter.admit(message(10)).await.unwrap();
+
+        let mut waiting = Box::pin(limiter.admit(message(1)));
+        assert!(waiting.as_mut().now_or_never().is_none());
+
+        drop(permit);
+        waiting.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_releases_message_capacity() {
+        let limiter = CapacityLimiter::new(nonzero(2), nonzero(1)).unwrap();
+        let byte_capacity = limiter.admit(message(1)).await.unwrap();
+
+        let mut waiting = Box::pin(limiter.admit(message(1)));
+        assert!(waiting.as_mut().now_or_never().is_none());
+        drop(waiting);
+
+        let permit = limiter.try_admit(message(0)).unwrap();
+        drop((permit, byte_capacity));
+    }
+
+    #[tokio::test]
+    async fn close_wakes_waiters() {
+        let limiter = CapacityLimiter::new(nonzero(1), nonzero(1)).unwrap();
+        let _permit = limiter.admit(message(1)).await.unwrap();
+        let waiting = limiter.admit(message(1));
+
+        limiter.close();
+
+        let err = waiting.await.err().expect("closed limiter rejects waiter");
+        assert!(err.to_string().contains("closed for new messages"));
+    }
+}

--- a/ydb/src/client_topic/topicwriter/message_queue.rs
+++ b/ydb/src/client_topic/topicwriter/message_queue.rs
@@ -3,6 +3,7 @@ use std::{collections::VecDeque, mem::swap};
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
 use crate::client_topic::topicwriter::capacity_limiter::CapacityPermit;
+use crate::client_topic::topicwriter::writer_options::AutoFlushSettings;
 use crate::{YdbError, YdbResult};
 
 pub(crate) struct QueuedMessage {
@@ -69,18 +70,20 @@ impl MessageQueue {
     pub(crate) fn append_message_to_send_buffer(
         &mut self,
         send_buffer: &mut Vec<MessageData>,
-        threshold: usize,
+        send_buffer_bytes: &mut usize,
+        settings: AutoFlushSettings,
     ) -> AppendMessageToSendBufferResult {
         let Some(message) = self.messages.pop_front() else {
             return AppendMessageToSendBufferResult::CouldNotGetMessage;
         };
+        *send_buffer_bytes += message.data.data.len();
         send_buffer.push(message.data.clone());
         self.sent_messages.push_back(message);
 
-        if send_buffer.len() < threshold {
-            AppendMessageToSendBufferResult::UnderThreshold
-        } else {
+        if send_buffer.len() >= settings.messages() || *send_buffer_bytes >= settings.bytes() {
             AppendMessageToSendBufferResult::Full
+        } else {
+            AppendMessageToSendBufferResult::UnderThreshold
         }
     }
 
@@ -118,10 +121,13 @@ impl MessageQueue {
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
+    use std::time::Duration;
 
     use super::*;
     use crate::client_topic::topicwriter::capacity_limiter::CapacityLimiter;
-    use crate::client_topic::topicwriter::test_helpers::create_message as create_message_data;
+    use crate::client_topic::topicwriter::test_helpers::{
+        auto_flush_settings, create_message as create_message_data,
+    };
 
     fn create_message(seq_no: i64, data: Vec<u8>) -> QueuedMessage {
         let limiter = CapacityLimiter::new(
@@ -190,7 +196,12 @@ mod tests {
         q.add_message(create_message(1, vec![10])).unwrap();
 
         let mut buffer = Vec::new();
-        let result = q.append_message_to_send_buffer(&mut buffer, 10);
+        let mut buffer_bytes = 0;
+        let result = q.append_message_to_send_buffer(
+            &mut buffer,
+            &mut buffer_bytes,
+            auto_flush_settings(10, 10, Duration::ZERO),
+        );
 
         assert!(matches!(
             result,
@@ -199,6 +210,7 @@ mod tests {
         assert_eq!(buffer.len(), 1);
         assert_eq!(buffer[0].seq_no, 1);
         assert_eq!(buffer[0].data, vec![10]);
+        assert_eq!(buffer_bytes, 1);
         assert!(q.messages.is_empty());
         assert_eq!(q.sent_messages.len(), 1);
         assert_eq!(q.sent_messages[0].data.seq_no, 1);
@@ -208,8 +220,13 @@ mod tests {
     fn append_message_to_send_buffer_returns_could_not_get_message_when_empty() {
         let mut q = MessageQueue::new();
         let mut buffer = Vec::new();
+        let mut buffer_bytes = 0;
 
-        let result = q.append_message_to_send_buffer(&mut buffer, 10);
+        let result = q.append_message_to_send_buffer(
+            &mut buffer,
+            &mut buffer_bytes,
+            auto_flush_settings(10, 10, Duration::ZERO),
+        );
 
         assert!(matches!(
             result,
@@ -225,17 +242,69 @@ mod tests {
         q.add_message(create_message(2, vec![])).unwrap();
 
         let mut buffer = Vec::new();
+        let mut buffer_bytes = 0;
         assert!(matches!(
-            q.append_message_to_send_buffer(&mut buffer, 2),
+            q.append_message_to_send_buffer(
+                &mut buffer,
+                &mut buffer_bytes,
+                auto_flush_settings(2, 10, Duration::ZERO),
+            ),
             AppendMessageToSendBufferResult::UnderThreshold
         ));
         assert!(matches!(
-            q.append_message_to_send_buffer(&mut buffer, 2),
+            q.append_message_to_send_buffer(
+                &mut buffer,
+                &mut buffer_bytes,
+                auto_flush_settings(2, 10, Duration::ZERO),
+            ),
             AppendMessageToSendBufferResult::Full
         ));
         assert_eq!(buffer.len(), 2);
         assert_eq!(buffer[0].seq_no, 1);
         assert_eq!(buffer[1].seq_no, 2);
+    }
+
+    #[test]
+    fn append_message_to_send_buffer_returns_full_at_byte_threshold() {
+        let mut q = MessageQueue::new();
+        q.add_message(create_message(1, vec![0; 2])).unwrap();
+        q.add_message(create_message(2, vec![0; 3])).unwrap();
+
+        let mut buffer = Vec::new();
+        let mut buffer_bytes = 0;
+        let settings = auto_flush_settings(10, 5, Duration::ZERO);
+        assert!(matches!(
+            q.append_message_to_send_buffer(&mut buffer, &mut buffer_bytes, settings),
+            AppendMessageToSendBufferResult::UnderThreshold
+        ));
+        assert!(matches!(
+            q.append_message_to_send_buffer(&mut buffer, &mut buffer_bytes, settings),
+            AppendMessageToSendBufferResult::Full
+        ));
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer_bytes, 5);
+    }
+
+    #[test]
+    fn append_message_to_send_buffer_flushes_after_crossing_byte_threshold() {
+        let mut q = MessageQueue::new();
+        q.add_message(create_message(1, vec![0; 3])).unwrap();
+        q.add_message(create_message(2, vec![0; 3])).unwrap();
+
+        let mut buffer = Vec::new();
+        let mut buffer_bytes = 0;
+        let settings = auto_flush_settings(10, 5, Duration::ZERO);
+        assert!(matches!(
+            q.append_message_to_send_buffer(&mut buffer, &mut buffer_bytes, settings),
+            AppendMessageToSendBufferResult::UnderThreshold
+        ));
+        assert!(matches!(
+            q.append_message_to_send_buffer(&mut buffer, &mut buffer_bytes, settings),
+            AppendMessageToSendBufferResult::Full
+        ));
+        assert_eq!(buffer.len(), 2);
+        assert_eq!(buffer_bytes, 6);
+        assert!(q.messages.is_empty());
     }
 
     #[test]

--- a/ydb/src/client_topic/topicwriter/message_queue.rs
+++ b/ydb/src/client_topic/topicwriter/message_queue.rs
@@ -2,13 +2,28 @@ use std::{collections::VecDeque, mem::swap};
 
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
+use crate::client_topic::topicwriter::capacity_limiter::CapacityPermit;
 use crate::{YdbError, YdbResult};
+
+pub(crate) struct QueuedMessage {
+    data: MessageData,
+    _capacity: CapacityPermit,
+}
+
+impl QueuedMessage {
+    pub(crate) fn new(data: MessageData, capacity: CapacityPermit) -> Self {
+        Self {
+            data,
+            _capacity: capacity,
+        }
+    }
+}
 
 pub(crate) struct MessageQueue {
     // Messages awaiting to be sent
-    messages: VecDeque<MessageData>,
+    messages: VecDeque<QueuedMessage>,
     // Messages awaiting to be acknowledged
-    sent_messages: VecDeque<MessageData>,
+    sent_messages: VecDeque<QueuedMessage>,
     // Sequence number of the last message that has been added to the queue
     last_added_seq_no: Option<i64>,
 }
@@ -29,8 +44,8 @@ impl MessageQueue {
         }
     }
 
-    pub(crate) fn add_message(&mut self, message: MessageData) -> YdbResult<()> {
-        let seq_no = message.seq_no;
+    pub(crate) fn add_message(&mut self, message: QueuedMessage) -> YdbResult<()> {
+        let seq_no = message.data.seq_no;
         self.check_message_seq_no(seq_no)?;
 
         self.last_added_seq_no = Some(seq_no);
@@ -59,7 +74,7 @@ impl MessageQueue {
         let Some(message) = self.messages.pop_front() else {
             return AppendMessageToSendBufferResult::CouldNotGetMessage;
         };
-        send_buffer.push(message.clone());
+        send_buffer.push(message.data.clone());
         self.sent_messages.push_back(message);
 
         if send_buffer.len() < threshold {
@@ -76,10 +91,10 @@ impl MessageQueue {
             )));
         };
 
-        if message.seq_no != seq_no {
+        if message.data.seq_no != seq_no {
             return Err(YdbError::custom(format!(
                 "acknowledge_message: seq_no mismatch: expected_seq_no={} actual_seq_no={}",
-                message.seq_no, seq_no,
+                message.data.seq_no, seq_no,
             )));
         }
 
@@ -102,8 +117,22 @@ impl MessageQueue {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use super::*;
-    use crate::client_topic::topicwriter::test_helpers::create_message;
+    use crate::client_topic::topicwriter::capacity_limiter::CapacityLimiter;
+    use crate::client_topic::topicwriter::test_helpers::create_message as create_message_data;
+
+    fn create_message(seq_no: i64, data: Vec<u8>) -> QueuedMessage {
+        let limiter = CapacityLimiter::new(
+            NonZeroUsize::MIN,
+            NonZeroUsize::new(data.len()).unwrap_or(NonZeroUsize::MIN),
+        )
+        .unwrap();
+        let capacity = limiter.try_acquire(data.len()).unwrap();
+
+        QueuedMessage::new(create_message_data(seq_no, data), capacity)
+    }
 
     fn move_all_pending_to_sent(q: &mut MessageQueue) {
         q.sent_messages.append(&mut q.messages);
@@ -124,10 +153,10 @@ mod tests {
         q.add_message(create_message(11, vec![4, 5])).unwrap();
 
         assert_eq!(q.messages.len(), 2);
-        assert_eq!(q.messages[0].seq_no, 10);
-        assert_eq!(q.messages[0].data, vec![1, 2, 3]);
-        assert_eq!(q.messages[1].seq_no, 11);
-        assert_eq!(q.messages[1].data, vec![4, 5]);
+        assert_eq!(q.messages[0].data.seq_no, 10);
+        assert_eq!(q.messages[0].data.data, vec![1, 2, 3]);
+        assert_eq!(q.messages[1].data.seq_no, 11);
+        assert_eq!(q.messages[1].data.data, vec![4, 5]);
         assert_eq!(q.last_added_seq_no, Some(11));
     }
 
@@ -172,7 +201,7 @@ mod tests {
         assert_eq!(buffer[0].data, vec![10]);
         assert!(q.messages.is_empty());
         assert_eq!(q.sent_messages.len(), 1);
-        assert_eq!(q.sent_messages[0].seq_no, 1);
+        assert_eq!(q.sent_messages[0].data.seq_no, 1);
     }
 
     #[test]
@@ -222,8 +251,8 @@ mod tests {
         assert_eq!(q.messages.len(), 0);
         assert!(q.messages.is_empty());
         assert_eq!(q.sent_messages.len(), 2);
-        assert_eq!(q.sent_messages[0].seq_no, 6);
-        assert_eq!(q.sent_messages[1].seq_no, 7);
+        assert_eq!(q.sent_messages[0].data.seq_no, 6);
+        assert_eq!(q.sent_messages[1].data.seq_no, 7);
         assert_eq!(q.last_added_seq_no, Some(7));
     }
 
@@ -278,10 +307,10 @@ mod tests {
 
         assert!(q.sent_messages.is_empty());
         assert_eq!(q.messages.len(), 5);
-        assert_eq!(q.messages[0].seq_no, 1);
-        assert_eq!(q.messages[1].seq_no, 2);
-        assert_eq!(q.messages[2].seq_no, 3);
-        assert_eq!(q.messages[3].seq_no, 4);
-        assert_eq!(q.messages[4].seq_no, 5);
+        assert_eq!(q.messages[0].data.seq_no, 1);
+        assert_eq!(q.messages[1].data.seq_no, 2);
+        assert_eq!(q.messages[2].data.seq_no, 3);
+        assert_eq!(q.messages[3].data.seq_no, 4);
+        assert_eq!(q.messages[4].data.seq_no, 5);
     }
 }

--- a/ydb/src/client_topic/topicwriter/mod.rs
+++ b/ydb/src/client_topic/topicwriter/mod.rs
@@ -1,3 +1,4 @@
+mod capacity_limiter;
 pub mod connection;
 pub mod message;
 pub mod message_queue;

--- a/ydb/src/client_topic/topicwriter/mod.rs
+++ b/ydb/src/client_topic/topicwriter/mod.rs
@@ -8,6 +8,7 @@ pub mod queue;
 pub mod reception_queue;
 pub mod reconnector;
 pub mod stream_writer;
+mod write_request;
 pub mod writer;
 pub mod writer_options;
 pub mod writer_tx;

--- a/ydb/src/client_topic/topicwriter/queue.rs
+++ b/ydb/src/client_topic/topicwriter/queue.rs
@@ -1,13 +1,18 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures_util::FutureExt;
 use tokio::sync::{Mutex, Notify, RwLock, oneshot};
 use tokio::time::{Instant, sleep_until};
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
+use crate::client_topic::topicwriter::capacity_limiter::{
+    AdmittedMessage, CapacityLimiter, CapacityPermit,
+};
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::client_topic::topicwriter::message_queue::{
-    AppendMessageToSendBufferResult, MessageQueue,
+    AppendMessageToSendBufferResult, MessageQueue, QueuedMessage,
 };
 use crate::client_topic::topicwriter::message_write_status::{
     MessageWriteStatus, MessageWriteStatusValidator, WriteAck,
@@ -18,31 +23,29 @@ use crate::{YdbError, YdbResult};
 #[derive(Clone)]
 pub(crate) struct Queue {
     inner: Arc<Mutex<QueueInner>>,
+    capacity_limiter: CapacityLimiter,
 
     new_message_added: Arc<Notify>,
+    flush_requested: Arc<Notify>,
     last_acknowledged_seq_no: Arc<RwLock<Option<i64>>>,
     message_acknowledged: Arc<Notify>,
 }
 
 impl Queue {
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::new_with_status_validator(
-            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
-            false,
-        )
-    }
-
     pub(crate) fn new_with_status_validator(
         status_validator: MessageWriteStatusValidator,
         auto_seq_no: bool,
-    ) -> Self {
-        Self {
+        max_inflight_messages: NonZeroUsize,
+        max_inflight_bytes: NonZeroUsize,
+    ) -> YdbResult<Self> {
+        Ok(Self {
             inner: Arc::new(Mutex::new(QueueInner::new(status_validator, auto_seq_no))),
+            capacity_limiter: CapacityLimiter::new(max_inflight_messages, max_inflight_bytes)?,
             new_message_added: Arc::new(Notify::new()),
+            flush_requested: Arc::new(Notify::new()),
             last_acknowledged_seq_no: Arc::new(RwLock::new(None)),
             message_acknowledged: Arc::new(Notify::new()),
-        }
+        })
     }
 
     pub(crate) async fn initialize_last_seq_no(&self, last_seq_no: i64) -> YdbResult<()> {
@@ -61,9 +64,22 @@ impl Queue {
         message: TopicWriterMessage,
         ack_sender: Option<oneshot::Sender<YdbResult<MessageWriteStatus>>>,
     ) -> YdbResult<()> {
+        let admission = self.capacity_limiter.admit(message);
+        tokio::pin!(admission);
+        let (message, was_blocked) = match admission.as_mut().now_or_never() {
+            Some(result) => (result?, false),
+            None => {
+                self.flush_requested.notify_one();
+                (admission.await?, true)
+            }
+        };
         let mut inner = self.inner.lock().await;
         inner.add_message(message, ack_sender)?;
         self.new_message_added.notify_one();
+        if was_blocked {
+            // Flush the newly admitted message while later capacity waiters are still blocked.
+            self.flush_requested.notify_one();
+        }
         Ok(())
     }
 
@@ -135,6 +151,7 @@ impl Queue {
             // Wait for new messages or timeout
             tokio::select! {
                 biased;
+                _ = self.flush_requested.notified() => break,
                 _ = self.new_message_added.notified() => {}
                 _ = sleep_until(timeout) => break,
             }
@@ -151,6 +168,7 @@ impl Queue {
     pub(crate) async fn close_for_new_messages(&self) {
         let mut inner = self.inner.lock().await;
         inner.is_open_for_new_messages = false;
+        self.capacity_limiter.close();
     }
 
     pub(crate) async fn reset_progress(&self) {
@@ -194,9 +212,10 @@ impl QueueInner {
 
     fn add_message(
         &mut self,
-        mut message: TopicWriterMessage,
+        mut admitted: AdmittedMessage,
         ack_sender: Option<oneshot::Sender<YdbResult<MessageWriteStatus>>>,
     ) -> YdbResult<()> {
+        let message = admitted.message_mut();
         let message_seq_no = match (self.auto_seq_no, message.seq_no) {
             (true, Some(_)) => Err(YdbError::custom(
                 "explicitly specifying message.seq_no is only allowed if auto_seq_no is disabled",
@@ -213,8 +232,9 @@ impl QueueInner {
         }?;
         message.seq_no = Some(message_seq_no);
 
+        let (message, capacity) = admitted.into_parts();
         let message = message.try_into()?;
-        self.enqueue_message(message, ack_sender)?;
+        self.enqueue_message(message, ack_sender, capacity)?;
         self.last_seq_no_assigned = Some(message_seq_no);
 
         Ok(())
@@ -224,6 +244,7 @@ impl QueueInner {
         &mut self,
         message: MessageData,
         ack_sender: Option<oneshot::Sender<YdbResult<MessageWriteStatus>>>,
+        capacity: CapacityPermit,
     ) -> YdbResult<()> {
         if !self.is_open_for_new_messages {
             return Err(YdbError::custom("message queue is closed for new messages"));
@@ -231,7 +252,8 @@ impl QueueInner {
 
         let seq_no = message.seq_no;
 
-        self.message_queue.add_message(message)?;
+        self.message_queue
+            .add_message(QueuedMessage::new(message, capacity))?;
 
         self.reception_queue
             .add_ticket(ReceptionTicket::new(seq_no, ack_sender));
@@ -281,6 +303,21 @@ mod tests {
     use super::*;
     use crate::client_topic::topicwriter::message_write_status::expect_transactional_write_status;
     use crate::client_topic::topicwriter::test_helpers::write_ack;
+    use crate::client_topic::topicwriter::writer_options::{
+        DEFAULT_MAX_INFLIGHT_BYTES, DEFAULT_MAX_INFLIGHT_MESSAGES,
+    };
+
+    impl Queue {
+        fn new() -> Self {
+            Self::new_with_status_validator(
+                crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+                false,
+                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
+                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+            )
+            .unwrap()
+        }
+    }
 
     fn create_message(seq_no: i64, data: Vec<u8>) -> TopicWriterMessage {
         TopicWriterMessage::builder()
@@ -294,7 +331,10 @@ mod tests {
         let q = Queue::new_with_status_validator(
             crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
             true,
-        );
+            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
+            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+        )
+        .unwrap();
         q.initialize_last_seq_no(1).await.unwrap();
 
         let queue_lock = q.inner.lock().await;
@@ -312,6 +352,79 @@ mod tests {
         let messages = q.get_messages_to_send(1, Duration::ZERO).await;
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].seq_no, 2);
+    }
+
+    #[tokio::test]
+    async fn capacity_is_held_until_acknowledgement() {
+        let q = Queue::new_with_status_validator(
+            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+            false,
+            NonZeroUsize::new(2).unwrap(),
+            NonZeroUsize::new(5).unwrap(),
+        )
+        .unwrap();
+        q.add_message(create_message(1, vec![0; 3]), None)
+            .await
+            .unwrap();
+        let messages = q.get_messages_to_send(1, Duration::ZERO).await;
+        assert_eq!(messages.len(), 1);
+
+        let mut blocked_write = Box::pin(q.add_message(create_message(2, vec![0; 3]), None));
+        assert!(blocked_write.as_mut().now_or_never().is_none());
+
+        q.acknowledge_message(write_ack(1)).await.unwrap();
+        blocked_write.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn capacity_waiters_keep_flushing_partial_batches() {
+        let q = Queue::new_with_status_validator(
+            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+            false,
+            NonZeroUsize::new(2).unwrap(),
+            NonZeroUsize::new(1).unwrap(),
+        )
+        .unwrap();
+        q.add_message(create_message(1, vec![0]), None)
+            .await
+            .unwrap();
+        let send_period = Duration::from_secs(3600);
+
+        let mut first_batch = Box::pin(q.get_messages_to_send(2, send_period));
+        assert!(first_batch.as_mut().now_or_never().is_none());
+
+        let mut second_write = Box::pin(q.add_message(create_message(2, vec![0]), None));
+        assert!(second_write.as_mut().now_or_never().is_none());
+        let mut third_write = Box::pin(q.add_message(create_message(3, vec![0]), None));
+        assert!(third_write.as_mut().now_or_never().is_none());
+
+        let messages = timeout(Duration::from_millis(100), first_batch)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 1);
+
+        // Consume the notification stored by the second capacity waiter.
+        let messages = timeout(
+            Duration::from_millis(100),
+            q.get_messages_to_send(2, send_period),
+        )
+        .await
+        .unwrap();
+        assert!(messages.is_empty());
+
+        let second_batch = q.get_messages_to_send(2, send_period);
+        q.acknowledge_message(write_ack(1)).await.unwrap();
+        second_write.await.unwrap();
+
+        let messages = timeout(Duration::from_millis(100), second_batch)
+            .await
+            .unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].seq_no, 2);
+
+        assert!(third_write.as_mut().now_or_never().is_none());
+        q.acknowledge_message(write_ack(2)).await.unwrap();
+        third_write.await.unwrap();
     }
 
     #[tokio::test]
@@ -586,7 +699,13 @@ mod tests {
 
     #[tokio::test]
     async fn flush_returns_status_validation_error_observed_before_flush() {
-        let q = Queue::new_with_status_validator(expect_transactional_write_status, false);
+        let q = Queue::new_with_status_validator(
+            expect_transactional_write_status,
+            false,
+            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
+            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+        )
+        .unwrap();
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
@@ -600,10 +719,15 @@ mod tests {
 
     #[tokio::test]
     async fn flush_returns_status_validation_error_observed_during_flush() {
-        let q = Arc::new(Queue::new_with_status_validator(
-            expect_transactional_write_status,
-            false,
-        ));
+        let q = Arc::new(
+            Queue::new_with_status_validator(
+                expect_transactional_write_status,
+                false,
+                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
+                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+            )
+            .unwrap(),
+        );
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();

--- a/ydb/src/client_topic/topicwriter/queue.rs
+++ b/ydb/src/client_topic/topicwriter/queue.rs
@@ -186,6 +186,47 @@ impl Queue {
     }
 }
 
+#[cfg(test)]
+const TEST_INFLIGHT_MESSAGES: usize = 1000;
+#[cfg(test)]
+const TEST_INFLIGHT_BYTES: usize = 20 * crate::byte_units::MiB;
+
+#[cfg(test)]
+impl Queue {
+    fn new() -> Self {
+        Self::with_flow_control(
+            false,
+            TEST_INFLIGHT_MESSAGES,
+            TEST_INFLIGHT_BYTES,
+            10,
+            TEST_INFLIGHT_BYTES,
+            std::time::Duration::from_millis(20),
+        )
+    }
+
+    fn with_flow_control(
+        auto_seq_no: bool,
+        inflight_messages: usize,
+        inflight_bytes: usize,
+        auto_flush_messages: usize,
+        auto_flush_bytes: usize,
+        auto_flush_interval: std::time::Duration,
+    ) -> Self {
+        Self::new_with_status_validator(
+            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+            auto_seq_no,
+            crate::client_topic::topicwriter::test_helpers::writer_flow_control(
+                inflight_messages,
+                inflight_bytes,
+                auto_flush_messages,
+                auto_flush_bytes,
+                auto_flush_interval,
+            ),
+        )
+        .unwrap()
+    }
+}
+
 struct QueueInner {
     message_queue: MessageQueue,
     reception_queue: ReceptionQueue,
@@ -300,44 +341,6 @@ mod tests {
     use super::*;
     use crate::client_topic::topicwriter::message_write_status::expect_transactional_write_status;
     use crate::client_topic::topicwriter::test_helpers::{write_ack, writer_flow_control};
-    use crate::client_topic::topicwriter::writer_options::{
-        DEFAULT_MAX_INFLIGHT_BYTES, DEFAULT_MAX_INFLIGHT_MESSAGES,
-    };
-
-    impl Queue {
-        fn new() -> Self {
-            Self::with_flow_control(
-                false,
-                DEFAULT_MAX_INFLIGHT_MESSAGES,
-                DEFAULT_MAX_INFLIGHT_BYTES,
-                10,
-                DEFAULT_MAX_INFLIGHT_BYTES,
-                Duration::from_millis(20),
-            )
-        }
-
-        fn with_flow_control(
-            auto_seq_no: bool,
-            inflight_messages: usize,
-            inflight_bytes: usize,
-            auto_flush_messages: usize,
-            auto_flush_bytes: usize,
-            auto_flush_interval: Duration,
-        ) -> Self {
-            Self::new_with_status_validator(
-                crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
-                auto_seq_no,
-                writer_flow_control(
-                    inflight_messages,
-                    inflight_bytes,
-                    auto_flush_messages,
-                    auto_flush_bytes,
-                    auto_flush_interval,
-                ),
-            )
-            .unwrap()
-        }
-    }
 
     fn create_message(seq_no: i64, data: Vec<u8>) -> TopicWriterMessage {
         TopicWriterMessage::builder()
@@ -350,10 +353,10 @@ mod tests {
     async fn add_message_is_cancellation_safe() {
         let q = Queue::with_flow_control(
             true,
-            DEFAULT_MAX_INFLIGHT_MESSAGES,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_MESSAGES,
+            TEST_INFLIGHT_BYTES,
             1,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_BYTES,
             Duration::ZERO,
         );
         q.initialize_last_seq_no(1).await.unwrap();
@@ -391,7 +394,7 @@ mod tests {
         blocked_write.await.unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn capacity_waiter_flushes_partial_batches() {
         let q = Queue::with_flow_control(false, 10, 10, 10, 10, Duration::from_secs(3600));
         q.add_message(create_message(1, vec![0; 7]), None)
@@ -415,6 +418,41 @@ mod tests {
             .expect("the admitted capacity waiter must flush without waiting for the interval");
         assert_eq!(second_batch.len(), 1);
         assert_eq!(second_batch[0].seq_no, 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn capacity_waiters_keep_flushing_partial_batches() {
+        let q = Queue::with_flow_control(false, 10, 10, 10, 10, Duration::from_secs(3600));
+        q.add_message(create_message(1, vec![0; 10]), None)
+            .await
+            .unwrap();
+
+        let first_batch = q.get_messages_to_send().await;
+        assert_eq!(first_batch.len(), 1);
+        assert_eq!(first_batch[0].seq_no, 1);
+
+        let mut second_write = Box::pin(q.add_message(create_message(2, vec![0; 7]), None));
+        assert!(second_write.as_mut().now_or_never().is_none());
+        let mut third_write = Box::pin(q.add_message(create_message(3, vec![0; 7]), None));
+        assert!(third_write.as_mut().now_or_never().is_none());
+
+        let empty_batch = timeout(Duration::from_millis(100), q.get_messages_to_send())
+            .await
+            .expect("capacity waiters must request a flush");
+        assert!(empty_batch.is_empty());
+
+        q.acknowledge_message(write_ack(1)).await.unwrap();
+        second_write.await.unwrap();
+
+        let second_batch = timeout(Duration::from_millis(100), q.get_messages_to_send())
+            .await
+            .expect("the admitted capacity waiter must request another flush");
+        assert_eq!(second_batch.len(), 1);
+        assert_eq!(second_batch[0].seq_no, 2);
+
+        assert!(third_write.as_mut().now_or_never().is_none());
+        q.acknowledge_message(write_ack(2)).await.unwrap();
+        third_write.await.unwrap();
     }
 
     #[tokio::test]
@@ -506,10 +544,10 @@ mod tests {
     async fn get_messages_to_send_with_zero_duration_drains_messages() {
         let q = Queue::with_flow_control(
             false,
-            DEFAULT_MAX_INFLIGHT_MESSAGES,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_MESSAGES,
+            TEST_INFLIGHT_BYTES,
             10,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_BYTES,
             Duration::ZERO,
         );
         q.add_message(create_message(1, vec![]), None)
@@ -540,10 +578,10 @@ mod tests {
     async fn get_messages_to_send_respects_threshold() {
         let q = Arc::new(Queue::with_flow_control(
             false,
-            DEFAULT_MAX_INFLIGHT_MESSAGES,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_MESSAGES,
+            TEST_INFLIGHT_BYTES,
             2,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_BYTES,
             Duration::from_millis(50),
         ));
         let q_collect = Arc::clone(&q);
@@ -568,10 +606,10 @@ mod tests {
     async fn get_messages_to_send_second_call_drains_remaining() {
         let q = Arc::new(Queue::with_flow_control(
             false,
-            DEFAULT_MAX_INFLIGHT_MESSAGES,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_MESSAGES,
+            TEST_INFLIGHT_BYTES,
             2,
-            DEFAULT_MAX_INFLIGHT_BYTES,
+            TEST_INFLIGHT_BYTES,
             Duration::from_millis(50),
         ));
         let q1 = Arc::clone(&q);
@@ -696,10 +734,10 @@ mod tests {
             expect_transactional_write_status,
             false,
             writer_flow_control(
-                DEFAULT_MAX_INFLIGHT_MESSAGES,
-                DEFAULT_MAX_INFLIGHT_BYTES,
+                TEST_INFLIGHT_MESSAGES,
+                TEST_INFLIGHT_BYTES,
                 10,
-                DEFAULT_MAX_INFLIGHT_BYTES,
+                TEST_INFLIGHT_BYTES,
                 Duration::from_millis(20),
             ),
         )
@@ -722,10 +760,10 @@ mod tests {
                 expect_transactional_write_status,
                 false,
                 writer_flow_control(
-                    DEFAULT_MAX_INFLIGHT_MESSAGES,
-                    DEFAULT_MAX_INFLIGHT_BYTES,
+                    TEST_INFLIGHT_MESSAGES,
+                    TEST_INFLIGHT_BYTES,
                     10,
-                    DEFAULT_MAX_INFLIGHT_BYTES,
+                    TEST_INFLIGHT_BYTES,
                     Duration::from_millis(20),
                 ),
             )

--- a/ydb/src/client_topic/topicwriter/queue.rs
+++ b/ydb/src/client_topic/topicwriter/queue.rs
@@ -1,6 +1,4 @@
-use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::Duration;
 
 use futures_util::FutureExt;
 use tokio::sync::{Mutex, Notify, RwLock, oneshot};
@@ -18,12 +16,14 @@ use crate::client_topic::topicwriter::message_write_status::{
     MessageWriteStatus, MessageWriteStatusValidator, WriteAck,
 };
 use crate::client_topic::topicwriter::reception_queue::{ReceptionQueue, ReceptionTicket};
+use crate::client_topic::topicwriter::writer_options::{AutoFlushSettings, WriterFlowControl};
 use crate::{YdbError, YdbResult};
 
 #[derive(Clone)]
 pub(crate) struct Queue {
     inner: Arc<Mutex<QueueInner>>,
     capacity_limiter: CapacityLimiter,
+    auto_flush: AutoFlushSettings,
 
     new_message_added: Arc<Notify>,
     flush_requested: Arc<Notify>,
@@ -35,12 +35,13 @@ impl Queue {
     pub(crate) fn new_with_status_validator(
         status_validator: MessageWriteStatusValidator,
         auto_seq_no: bool,
-        max_inflight_messages: NonZeroUsize,
-        max_inflight_bytes: NonZeroUsize,
+        flow_control: WriterFlowControl,
     ) -> YdbResult<Self> {
+        let inflight = flow_control.inflight();
         Ok(Self {
             inner: Arc::new(Mutex::new(QueueInner::new(status_validator, auto_seq_no))),
-            capacity_limiter: CapacityLimiter::new(max_inflight_messages, max_inflight_bytes)?,
+            capacity_limiter: CapacityLimiter::new(inflight.messages(), inflight.bytes())?,
+            auto_flush: flow_control.auto_flush(),
             new_message_added: Arc::new(Notify::new()),
             flush_requested: Arc::new(Notify::new()),
             last_acknowledged_seq_no: Arc::new(RwLock::new(None)),
@@ -77,7 +78,7 @@ impl Queue {
         inner.add_message(message, ack_sender)?;
         self.new_message_added.notify_one();
         if was_blocked {
-            // Flush the newly admitted message while later capacity waiters are still blocked.
+            // Send this message while later capacity waiters are still blocked.
             self.flush_requested.notify_one();
         }
         Ok(())
@@ -116,30 +117,26 @@ impl Queue {
     async fn append_message_to_send_buffer(
         &self,
         send_buffer: &mut Vec<MessageData>,
-        threshold: usize,
+        send_buffer_bytes: &mut usize,
     ) -> AppendMessageToSendBufferResult {
         let mut inner = self.inner.lock().await;
-        inner
-            .message_queue
-            .append_message_to_send_buffer(send_buffer, threshold)
+        inner.message_queue.append_message_to_send_buffer(
+            send_buffer,
+            send_buffer_bytes,
+            self.auto_flush,
+        )
     }
 
-    pub(crate) async fn get_messages_to_send(
-        &self,
-        threshold: usize,
-        duration: Duration,
-    ) -> Vec<MessageData> {
+    pub(crate) async fn get_messages_to_send(&self) -> Vec<MessageData> {
         let mut messages = Vec::new();
-        if threshold == 0 {
-            return messages;
-        }
+        let mut message_bytes = 0;
 
-        let timeout = Instant::now() + duration;
+        let timeout = Instant::now() + self.auto_flush.interval();
         loop {
             // Append while we can
             loop {
                 match self
-                    .append_message_to_send_buffer(&mut messages, threshold)
+                    .append_message_to_send_buffer(&mut messages, &mut message_bytes)
                     .await
                 {
                     AppendMessageToSendBufferResult::Full => return messages,
@@ -302,18 +299,41 @@ mod tests {
 
     use super::*;
     use crate::client_topic::topicwriter::message_write_status::expect_transactional_write_status;
-    use crate::client_topic::topicwriter::test_helpers::write_ack;
+    use crate::client_topic::topicwriter::test_helpers::{write_ack, writer_flow_control};
     use crate::client_topic::topicwriter::writer_options::{
         DEFAULT_MAX_INFLIGHT_BYTES, DEFAULT_MAX_INFLIGHT_MESSAGES,
     };
 
     impl Queue {
         fn new() -> Self {
+            Self::with_flow_control(
+                false,
+                DEFAULT_MAX_INFLIGHT_MESSAGES,
+                DEFAULT_MAX_INFLIGHT_BYTES,
+                10,
+                DEFAULT_MAX_INFLIGHT_BYTES,
+                Duration::from_millis(20),
+            )
+        }
+
+        fn with_flow_control(
+            auto_seq_no: bool,
+            inflight_messages: usize,
+            inflight_bytes: usize,
+            auto_flush_messages: usize,
+            auto_flush_bytes: usize,
+            auto_flush_interval: Duration,
+        ) -> Self {
             Self::new_with_status_validator(
                 crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
-                false,
-                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
-                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+                auto_seq_no,
+                writer_flow_control(
+                    inflight_messages,
+                    inflight_bytes,
+                    auto_flush_messages,
+                    auto_flush_bytes,
+                    auto_flush_interval,
+                ),
             )
             .unwrap()
         }
@@ -328,13 +348,14 @@ mod tests {
 
     #[tokio::test]
     async fn add_message_is_cancellation_safe() {
-        let q = Queue::new_with_status_validator(
-            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+        let q = Queue::with_flow_control(
             true,
-            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
-            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
-        )
-        .unwrap();
+            DEFAULT_MAX_INFLIGHT_MESSAGES,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            1,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            Duration::ZERO,
+        );
         q.initialize_last_seq_no(1).await.unwrap();
 
         let queue_lock = q.inner.lock().await;
@@ -349,24 +370,18 @@ mod tests {
         let message = TopicWriterMessage::builder().data(vec![]).build();
         q.add_message(message, None).await.unwrap();
 
-        let messages = q.get_messages_to_send(1, Duration::ZERO).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].seq_no, 2);
     }
 
     #[tokio::test]
     async fn capacity_is_held_until_acknowledgement() {
-        let q = Queue::new_with_status_validator(
-            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
-            false,
-            NonZeroUsize::new(2).unwrap(),
-            NonZeroUsize::new(5).unwrap(),
-        )
-        .unwrap();
+        let q = Queue::with_flow_control(false, 2, 5, 1, 5, Duration::ZERO);
         q.add_message(create_message(1, vec![0; 3]), None)
             .await
             .unwrap();
-        let messages = q.get_messages_to_send(1, Duration::ZERO).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 1);
 
         let mut blocked_write = Box::pin(q.add_message(create_message(2, vec![0; 3]), None));
@@ -377,54 +392,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn capacity_waiters_keep_flushing_partial_batches() {
-        let q = Queue::new_with_status_validator(
-            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
-            false,
-            NonZeroUsize::new(2).unwrap(),
-            NonZeroUsize::new(1).unwrap(),
-        )
-        .unwrap();
-        q.add_message(create_message(1, vec![0]), None)
+    async fn capacity_waiter_flushes_partial_batches() {
+        let q = Queue::with_flow_control(false, 10, 10, 10, 10, Duration::from_secs(3600));
+        q.add_message(create_message(1, vec![0; 7]), None)
             .await
             .unwrap();
-        let send_period = Duration::from_secs(3600);
 
-        let mut first_batch = Box::pin(q.get_messages_to_send(2, send_period));
-        assert!(first_batch.as_mut().now_or_never().is_none());
+        let mut blocked_write = Box::pin(q.add_message(create_message(2, vec![0; 4]), None));
+        assert!(blocked_write.as_mut().now_or_never().is_none());
 
-        let mut second_write = Box::pin(q.add_message(create_message(2, vec![0]), None));
-        assert!(second_write.as_mut().now_or_never().is_none());
-        let mut third_write = Box::pin(q.add_message(create_message(3, vec![0]), None));
-        assert!(third_write.as_mut().now_or_never().is_none());
-
-        let messages = timeout(Duration::from_millis(100), first_batch)
+        let first_batch = timeout(Duration::from_millis(100), q.get_messages_to_send())
             .await
-            .unwrap();
-        assert_eq!(messages.len(), 1);
+            .expect("capacity pressure must flush the buffered partial batch");
+        assert_eq!(first_batch.len(), 1);
+        assert_eq!(first_batch[0].seq_no, 1);
 
-        // Consume the notification stored by the second capacity waiter.
-        let messages = timeout(
-            Duration::from_millis(100),
-            q.get_messages_to_send(2, send_period),
-        )
-        .await
-        .unwrap();
-        assert!(messages.is_empty());
-
-        let second_batch = q.get_messages_to_send(2, send_period);
         q.acknowledge_message(write_ack(1)).await.unwrap();
-        second_write.await.unwrap();
+        blocked_write.await.unwrap();
 
-        let messages = timeout(Duration::from_millis(100), second_batch)
+        let second_batch = timeout(Duration::from_millis(100), q.get_messages_to_send())
+            .await
+            .expect("the admitted capacity waiter must flush without waiting for the interval");
+        assert_eq!(second_batch.len(), 1);
+        assert_eq!(second_batch[0].seq_no, 2);
+    }
+
+    #[tokio::test]
+    async fn get_messages_to_send_flushes_at_byte_threshold() {
+        let q = Queue::with_flow_control(false, 10, 10, 10, 5, Duration::from_secs(3600));
+        let q_collect = q.clone();
+        let collect_handle = tokio::spawn(async move { q_collect.get_messages_to_send().await });
+
+        q.add_message(create_message(1, vec![0; 2]), None)
             .await
             .unwrap();
-        assert_eq!(messages.len(), 1);
-        assert_eq!(messages[0].seq_no, 2);
+        q.add_message(create_message(2, vec![0; 3]), None)
+            .await
+            .unwrap();
 
-        assert!(third_write.as_mut().now_or_never().is_none());
-        q.acknowledge_message(write_ack(2)).await.unwrap();
-        third_write.await.unwrap();
+        let messages = timeout(Duration::from_millis(100), collect_handle)
+            .await
+            .expect("byte threshold must flush without waiting for the interval")
+            .expect("collector task must not panic");
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].seq_no, 1);
+        assert_eq!(messages[1].seq_no, 2);
     }
 
     #[tokio::test]
@@ -449,11 +461,7 @@ mod tests {
         let q = Arc::new(Queue::new());
 
         let q_collect = Arc::clone(&q);
-        let collect_handle = tokio::spawn(async move {
-            q_collect
-                .get_messages_to_send(10, Duration::from_millis(50))
-                .await
-        });
+        let collect_handle = tokio::spawn(async move { q_collect.get_messages_to_send().await });
         q.add_message(create_message(1, vec![10]), None)
             .await
             .unwrap();
@@ -473,7 +481,7 @@ mod tests {
     #[tokio::test]
     async fn get_messages_to_send_empty_queue_times_out_empty() {
         let q = Queue::new();
-        let msgs = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let msgs = q.get_messages_to_send().await;
         assert!(msgs.is_empty());
     }
 
@@ -487,7 +495,7 @@ mod tests {
             .await
             .unwrap();
 
-        let msgs = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let msgs = q.get_messages_to_send().await;
 
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].seq_no, 1);
@@ -496,48 +504,29 @@ mod tests {
 
     #[tokio::test]
     async fn get_messages_to_send_with_zero_duration_drains_messages() {
-        let q = Queue::new();
+        let q = Queue::with_flow_control(
+            false,
+            DEFAULT_MAX_INFLIGHT_MESSAGES,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            10,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            Duration::ZERO,
+        );
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
 
-        let msgs = q.get_messages_to_send(10, Duration::ZERO).await;
+        let msgs = q.get_messages_to_send().await;
 
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].seq_no, 1);
     }
 
     #[tokio::test]
-    async fn get_messages_to_send_with_zero_threshold_doesnt_move_messages_to_sent() {
-        let q = Queue::new();
-        q.add_message(create_message(1, vec![]), None)
-            .await
-            .unwrap();
-        q.add_message(create_message(2, vec![]), None)
-            .await
-            .unwrap();
-
-        let msgs = q.get_messages_to_send(0, Duration::from_millis(50)).await;
-        assert!(msgs.is_empty());
-
-        let err = q.acknowledge_message(write_ack(1)).await.unwrap_err();
-        assert!(err.to_string().contains("queue is empty"));
-
-        let msgs = q.get_messages_to_send(10, Duration::from_millis(20)).await;
-        assert_eq!(msgs.len(), 2);
-        assert_eq!(msgs[0].seq_no, 1);
-        assert_eq!(msgs[1].seq_no, 2);
-    }
-
-    #[tokio::test]
     async fn get_messages_to_send_collects_messages_added_during_call() {
         let q = Arc::new(Queue::new());
         let q_collect = Arc::clone(&q);
-        let collect_handle = tokio::spawn(async move {
-            q_collect
-                .get_messages_to_send(10, Duration::from_millis(50))
-                .await
-        });
+        let collect_handle = tokio::spawn(async move { q_collect.get_messages_to_send().await });
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
@@ -549,13 +538,16 @@ mod tests {
 
     #[tokio::test]
     async fn get_messages_to_send_respects_threshold() {
-        let q = Arc::new(Queue::new());
+        let q = Arc::new(Queue::with_flow_control(
+            false,
+            DEFAULT_MAX_INFLIGHT_MESSAGES,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            2,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            Duration::from_millis(50),
+        ));
         let q_collect = Arc::clone(&q);
-        let collect_handle = tokio::spawn(async move {
-            q_collect
-                .get_messages_to_send(2, Duration::from_millis(50))
-                .await
-        });
+        let collect_handle = tokio::spawn(async move { q_collect.get_messages_to_send().await });
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
@@ -574,12 +566,16 @@ mod tests {
 
     #[tokio::test]
     async fn get_messages_to_send_second_call_drains_remaining() {
-        let q = Arc::new(Queue::new());
+        let q = Arc::new(Queue::with_flow_control(
+            false,
+            DEFAULT_MAX_INFLIGHT_MESSAGES,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            2,
+            DEFAULT_MAX_INFLIGHT_BYTES,
+            Duration::from_millis(50),
+        ));
         let q1 = Arc::clone(&q);
-        let h1 =
-            tokio::spawn(
-                async move { q1.get_messages_to_send(2, Duration::from_millis(50)).await },
-            );
+        let h1 = tokio::spawn(async move { q1.get_messages_to_send().await });
         q.add_message(create_message(11, vec![]), None)
             .await
             .unwrap();
@@ -593,10 +589,7 @@ mod tests {
         assert_eq!(first.len(), 2);
 
         let q2 = Arc::clone(&q);
-        let h2 =
-            tokio::spawn(
-                async move { q2.get_messages_to_send(10, Duration::from_millis(50)).await },
-            );
+        let h2 = tokio::spawn(async move { q2.get_messages_to_send().await });
         let second = h2.await.unwrap();
         assert_eq!(second.len(), 1);
         assert_eq!(second[0].seq_no, 13);
@@ -617,7 +610,7 @@ mod tests {
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
-        let messages = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 1);
 
         let err = q.acknowledge_message(write_ack(99)).await.unwrap_err();
@@ -636,12 +629,12 @@ mod tests {
         q.add_message(create_message(2, vec![]), None)
             .await
             .unwrap();
-        let first_batch = q.get_messages_to_send(1, Duration::from_millis(20)).await;
-        assert_eq!(first_batch.len(), 1);
+        let first_batch = q.get_messages_to_send().await;
+        assert_eq!(first_batch.len(), 2);
 
         q.reset_progress().await;
 
-        let msgs = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let msgs = q.get_messages_to_send().await;
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].seq_no, 1);
         assert_eq!(msgs[1].seq_no, 2);
@@ -661,7 +654,7 @@ mod tests {
             q_wait.wait_for_messages_to_be_acknowledged().await;
         });
 
-        let messages = q.get_messages_to_send(20, Duration::from_millis(50)).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 5);
 
         for i in 1..=5 {
@@ -685,7 +678,7 @@ mod tests {
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
-        let msgs = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let msgs = q.get_messages_to_send().await;
         assert_eq!(msgs.len(), 1);
 
         q.acknowledge_message(write_ack(1)).await.unwrap();
@@ -702,14 +695,19 @@ mod tests {
         let q = Queue::new_with_status_validator(
             expect_transactional_write_status,
             false,
-            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
-            NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+            writer_flow_control(
+                DEFAULT_MAX_INFLIGHT_MESSAGES,
+                DEFAULT_MAX_INFLIGHT_BYTES,
+                10,
+                DEFAULT_MAX_INFLIGHT_BYTES,
+                Duration::from_millis(20),
+            ),
         )
         .unwrap();
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
-        let messages = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 1);
 
         q.acknowledge_message(write_ack(1)).await.unwrap();
@@ -723,15 +721,20 @@ mod tests {
             Queue::new_with_status_validator(
                 expect_transactional_write_status,
                 false,
-                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_MESSAGES).unwrap(),
-                NonZeroUsize::new(DEFAULT_MAX_INFLIGHT_BYTES).unwrap(),
+                writer_flow_control(
+                    DEFAULT_MAX_INFLIGHT_MESSAGES,
+                    DEFAULT_MAX_INFLIGHT_BYTES,
+                    10,
+                    DEFAULT_MAX_INFLIGHT_BYTES,
+                    Duration::from_millis(20),
+                ),
             )
             .unwrap(),
         );
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
-        let messages = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 1);
 
         let q_flush = Arc::clone(&q);
@@ -753,7 +756,7 @@ mod tests {
         q.add_message(create_message(1, vec![]), None)
             .await
             .unwrap();
-        let messages = q.get_messages_to_send(10, Duration::from_millis(20)).await;
+        let messages = q.get_messages_to_send().await;
         assert_eq!(messages.len(), 1);
 
         let q_flush = Arc::clone(&q);

--- a/ydb/src/client_topic/topicwriter/reconnector.rs
+++ b/ydb/src/client_topic/topicwriter/reconnector.rs
@@ -68,10 +68,13 @@ pub(crate) struct Reconnector {
 
 impl Reconnector {
     pub(crate) async fn new(params: ReconnectorParams) -> YdbResult<Self> {
+        let inflight_limits = params.writer_options.inflight_limits()?;
         let queue = Queue::new_with_status_validator(
             params.status_validator,
             params.writer_options.auto_seq_no,
-        );
+            inflight_limits.messages,
+            inflight_limits.bytes,
+        )?;
         let cancellation_token = params.cancellation_token;
 
         let (init_tx, init_rx) = oneshot::channel();
@@ -341,6 +344,7 @@ impl ReconnectionLoop {
 
         if let Some(final_error) = final_result {
             self.update_status(ReconnectorStatus::FinishedWithError(final_error.clone()));
+            self.helper.queue.close_for_new_messages().await;
             self.helper
                 .queue
                 .notify_reception_tickets(final_error.clone())

--- a/ydb/src/client_topic/topicwriter/reconnector.rs
+++ b/ydb/src/client_topic/topicwriter/reconnector.rs
@@ -18,6 +18,7 @@ use crate::client_topic::topicwriter::message_write_status::{
 };
 use crate::client_topic::topicwriter::queue::Queue;
 use crate::client_topic::topicwriter::stream_writer::StreamWriter;
+use crate::client_topic::topicwriter::write_request::WriteRequestSettings;
 use crate::client_topic::topicwriter::writer_options::{TopicWriterOptions, WriterFlowControl};
 use crate::errors::NeedRetry;
 use crate::grpc_connection_manager::GrpcConnectionManager;
@@ -69,6 +70,10 @@ pub(crate) struct Reconnector {
 impl Reconnector {
     pub(crate) async fn new(params: ReconnectorParams) -> YdbResult<Self> {
         let flow_control = WriterFlowControl::try_from(&params.writer_options)?;
+        let write_request_settings = WriteRequestSettings::new(
+            params.tx_identity,
+            params.connection_manager.max_message_size(),
+        )?;
         let queue = Queue::new_with_status_validator(
             params.status_validator,
             params.writer_options.auto_seq_no,
@@ -88,7 +93,7 @@ impl Reconnector {
                 producer_id: params.producer_id,
                 queue: queue.clone(),
                 executor: params.executor,
-                tx_identity: params.tx_identity,
+                write_request_settings,
             },
             params.fatal_error_tx,
             init_tx,
@@ -194,7 +199,7 @@ struct ReconnectionHelper {
     cancellation_token: CancellationToken,
     producer_id: String,
     executor: Arc<dyn Executor>,
-    tx_identity: Option<TransactionIdentity>,
+    write_request_settings: WriteRequestSettings,
 }
 
 struct RecreateStreamWriterResult {
@@ -221,7 +226,7 @@ impl ReconnectionHelper {
                 error_sender,
                 server_codecs,
                 self.executor.clone(),
-                self.tx_identity.clone(),
+                self.write_request_settings.clone(),
             )
             .await?,
             connection_info: init_response,

--- a/ydb/src/client_topic/topicwriter/reconnector.rs
+++ b/ydb/src/client_topic/topicwriter/reconnector.rs
@@ -18,7 +18,7 @@ use crate::client_topic::topicwriter::message_write_status::{
 };
 use crate::client_topic::topicwriter::queue::Queue;
 use crate::client_topic::topicwriter::stream_writer::StreamWriter;
-use crate::client_topic::topicwriter::writer_options::TopicWriterOptions;
+use crate::client_topic::topicwriter::writer_options::{TopicWriterOptions, WriterFlowControl};
 use crate::errors::NeedRetry;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::grpc_stream_wrapper::AsyncGrpcStreamWrapper;
@@ -68,12 +68,11 @@ pub(crate) struct Reconnector {
 
 impl Reconnector {
     pub(crate) async fn new(params: ReconnectorParams) -> YdbResult<Self> {
-        let inflight_limits = params.writer_options.inflight_limits()?;
+        let flow_control = WriterFlowControl::try_from(&params.writer_options)?;
         let queue = Queue::new_with_status_validator(
             params.status_validator,
             params.writer_options.auto_seq_no,
-            inflight_limits.messages,
-            inflight_limits.bytes,
+            flow_control,
         )?;
         let cancellation_token = params.cancellation_token;
 

--- a/ydb/src/client_topic/topicwriter/stream_writer.rs
+++ b/ydb/src/client_topic/topicwriter/stream_writer.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinSet;
@@ -36,19 +35,15 @@ impl StreamWriter {
             stream_write_message::FromServer,
         >,
         queue: Queue,
-        error_tx: oneshot::Sender<YdbError>,
+        error_sender: oneshot::Sender<YdbError>,
         server_codecs: Vec<Codec>,
         executor: Arc<dyn Executor>,
         tx_identity: Option<TransactionIdentity>,
     ) -> YdbResult<Self> {
         let cancellation_token = CancellationToken::new();
-        // The chunk size is also the flush threshold, so it must not exceed inflight capacity.
-        let message_chunk_size = writer_options
-            .write_request_messages_chunk_size
-            .clamp(1, writer_options.max_inflight_messages);
 
         // Both loops share the same oneshot error channel.
-        let shared_error_tx = Arc::new(Mutex::new(Some(error_tx)));
+        let shared_error_tx = Arc::new(Mutex::new(Some(error_sender)));
 
         let mut codec_registry = CodecRegistry::new();
         for enc in &writer_options.extra_encoders {
@@ -73,8 +68,6 @@ impl StreamWriter {
             cancellation_token.clone(),
             shared_error_tx.clone(),
             queue.clone(),
-            message_chunk_size,
-            writer_options.write_request_send_messages_period,
             batch_tx,
         ));
 
@@ -105,14 +98,12 @@ impl StreamWriter {
         cancellation_token: CancellationToken,
         error_tx: Arc<Mutex<Option<oneshot::Sender<YdbError>>>>,
         queue: Queue,
-        chunk_size: usize,
-        period: Duration,
         batch_tx: mpsc::UnboundedSender<Vec<MessageData>>,
     ) {
         loop {
             tokio::select! {
                 _ = cancellation_token.cancelled() => { return; }
-                messages = queue.get_messages_to_send(chunk_size, period) => {
+                messages = queue.get_messages_to_send() => {
                     if messages.is_empty() {
                         continue;
                     }

--- a/ydb/src/client_topic/topicwriter/stream_writer.rs
+++ b/ydb/src/client_topic/topicwriter/stream_writer.rs
@@ -5,16 +5,18 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{trace, warn};
 
-use ydb_grpc::ydb_proto::topic::TransactionIdentity;
 use ydb_grpc::ydb_proto::topic::stream_write_message;
-use ydb_grpc::ydb_proto::topic::stream_write_message::WriteRequest;
-use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage;
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
-use crate::client_topic::compression::{CodecRegistry, CompressionWorker, Executor};
+use crate::client_topic::compression::{
+    CodecRegistry, CompressedChunk, CompressionWorker, Executor,
+};
 use crate::client_topic::list_types::Codec;
 use crate::client_topic::topicwriter::message_write_status::WriteAck;
 use crate::client_topic::topicwriter::queue::Queue;
+use crate::client_topic::topicwriter::write_request::{
+    PendingWriteRequest, TryAddMessage, WriteRequestSettings,
+};
 use crate::client_topic::topicwriter::writer_options::TopicWriterOptions;
 use crate::grpc_wrapper::grpc_stream_wrapper::AsyncGrpcStreamWrapper;
 use crate::grpc_wrapper::raw_topic_service::stream_write::RawServerMessage;
@@ -28,7 +30,7 @@ pub(crate) struct StreamWriter {
 }
 
 impl StreamWriter {
-    pub(crate) async fn new(
+    pub(super) async fn new(
         writer_options: TopicWriterOptions,
         stream: AsyncGrpcStreamWrapper<
             stream_write_message::FromClient,
@@ -38,7 +40,7 @@ impl StreamWriter {
         error_sender: oneshot::Sender<YdbError>,
         server_codecs: Vec<Codec>,
         executor: Arc<dyn Executor>,
-        tx_identity: Option<TransactionIdentity>,
+        write_request_settings: WriteRequestSettings,
     ) -> YdbResult<Self> {
         let cancellation_token = CancellationToken::new();
 
@@ -58,7 +60,8 @@ impl StreamWriter {
         )?;
 
         let (batch_tx, batch_rx) = mpsc::unbounded_channel::<Vec<MessageData>>();
-        let (compressed_tx, compressed_rx) = mpsc::unbounded_channel::<YdbResult<WriteRequest>>();
+        let (compressed_tx, compressed_rx) =
+            mpsc::unbounded_channel::<YdbResult<CompressedChunk>>();
 
         let request_stream = stream.clone_sender();
 
@@ -78,7 +81,7 @@ impl StreamWriter {
             shared_error_tx.clone(),
             compressed_rx,
             request_stream,
-            tx_identity,
+            write_request_settings,
         ));
 
         tasks.spawn(StreamWriter::receive_messages_loop(
@@ -123,26 +126,24 @@ impl StreamWriter {
     async fn grpc_send_loop(
         cancellation_token: CancellationToken,
         error_tx: Arc<Mutex<Option<oneshot::Sender<YdbError>>>>,
-        mut compressed_rx: mpsc::UnboundedReceiver<YdbResult<WriteRequest>>,
+        mut compressed_rx: mpsc::UnboundedReceiver<YdbResult<CompressedChunk>>,
         request_stream: mpsc::UnboundedSender<stream_write_message::FromClient>,
-        tx_identity: Option<TransactionIdentity>,
+        write_request_settings: WriteRequestSettings,
     ) {
+        let mut pending_request = None;
+
         loop {
             tokio::select! {
                 _ = cancellation_token.cancelled() => { return; }
                 next = compressed_rx.recv() => {
                     let Some(chunk_result) = next else { return; };
-                    let result = chunk_result.and_then(|mut write_request| {
-                        write_request.tx = tx_identity.clone();
-                        if write_request.messages.is_empty() {
-                            return Ok(());
-                        }
-                        trace!("sending topic message to grpc stream");
-                        request_stream
-                            .send(stream_write_message::FromClient {
-                                client_message: Some(ClientMessage::WriteRequest(write_request)),
-                            })
-                            .map_err(|err| YdbError::Transport(err.to_string()))
+                    let result = chunk_result.and_then(|chunk| {
+                        StreamWriter::send_compressed_chunk(
+                            &request_stream,
+                            &write_request_settings,
+                            &mut pending_request,
+                            chunk,
+                        )
                     });
 
                     let Err(err) = result else { continue; };
@@ -155,6 +156,68 @@ impl StreamWriter {
                 }
             }
         }
+    }
+
+    fn send_compressed_chunk(
+        request_stream: &mpsc::UnboundedSender<stream_write_message::FromClient>,
+        settings: &WriteRequestSettings,
+        pending_request: &mut Option<PendingWriteRequest>,
+        chunk: CompressedChunk,
+    ) -> YdbResult<()> {
+        let CompressedChunk {
+            messages,
+            codec,
+            ends_batch,
+        } = chunk;
+
+        if let Some(request) = pending_request.as_ref()
+            && request.codec() != codec
+        {
+            return Err(YdbError::custom(format!(
+                "compression codec changed before the topic write batch ended: previous_codec={}, next_codec={}",
+                request.codec().code,
+                codec.code,
+            )));
+        }
+
+        for message in messages {
+            match pending_request.take() {
+                None => {
+                    *pending_request = Some(PendingWriteRequest::new(settings, codec, message)?);
+                }
+                Some(mut request) => match request.try_add(message) {
+                    TryAddMessage::Added => {
+                        *pending_request = Some(request);
+                    }
+                    TryAddMessage::RequestFull(message) => {
+                        StreamWriter::send_write_request(request_stream, request)?;
+                        *pending_request =
+                            Some(PendingWriteRequest::new(settings, codec, message)?);
+                    }
+                },
+            }
+        }
+
+        if ends_batch {
+            let Some(request) = pending_request.take() else {
+                return Err(YdbError::custom(
+                    "compressed topic write batch ended without messages",
+                ));
+            };
+            StreamWriter::send_write_request(request_stream, request)?;
+        }
+
+        Ok(())
+    }
+
+    fn send_write_request(
+        request_stream: &mpsc::UnboundedSender<stream_write_message::FromClient>,
+        request: PendingWriteRequest,
+    ) -> YdbResult<()> {
+        trace!("sending topic message to grpc stream");
+        request_stream
+            .send(request.into_grpc_message()?)
+            .map_err(|err| YdbError::Transport(err.to_string()))
     }
 
     async fn receive_messages_loop(
@@ -245,5 +308,152 @@ impl StreamWriter {
 
         trace!("stream writer stopped");
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost::Message;
+    use tokio::sync::mpsc::error::TryRecvError;
+    use ydb_grpc::ydb_proto::topic::stream_write_message::WriteRequest;
+    use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage;
+
+    use super::*;
+    use crate::client_topic::topicwriter::write_request::WRITE_REQUEST_SIZE_RESERVE_BYTES;
+
+    fn message(seq_no: i64, data_size: usize) -> MessageData {
+        MessageData {
+            seq_no,
+            data: vec![0; data_size],
+            ..Default::default()
+        }
+    }
+
+    fn chunk(messages: Vec<MessageData>, ends_batch: bool) -> CompressedChunk {
+        CompressedChunk {
+            messages,
+            codec: Codec::RAW,
+            ends_batch,
+        }
+    }
+
+    fn settings(max_write_request_size: usize) -> WriteRequestSettings {
+        WriteRequestSettings::new(
+            None,
+            WRITE_REQUEST_SIZE_RESERVE_BYTES + max_write_request_size,
+        )
+        .unwrap()
+    }
+
+    fn write_request(message: stream_write_message::FromClient) -> WriteRequest {
+        match message.client_message.unwrap() {
+            ClientMessage::WriteRequest(request) => request,
+            other => panic!("expected write request, got {other:?}"),
+        }
+    }
+
+    fn encoded_size(messages: Vec<MessageData>) -> usize {
+        stream_write_message::FromClient {
+            client_message: Some(ClientMessage::WriteRequest(WriteRequest {
+                messages,
+                codec: Codec::RAW.code,
+                tx: None,
+            })),
+        }
+        .encoded_len()
+    }
+
+    #[test]
+    fn combines_compression_chunks_until_batch_ends() {
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let mut pending = None;
+        let settings = settings(1024);
+
+        StreamWriter::send_compressed_chunk(
+            &request_tx,
+            &settings,
+            &mut pending,
+            chunk(vec![message(1, 8)], false),
+        )
+        .unwrap();
+        assert!(matches!(request_rx.try_recv(), Err(TryRecvError::Empty)));
+
+        StreamWriter::send_compressed_chunk(
+            &request_tx,
+            &settings,
+            &mut pending,
+            chunk(vec![message(2, 8)], true),
+        )
+        .unwrap();
+
+        let request = write_request(request_rx.try_recv().unwrap());
+        assert_eq!(
+            request
+                .messages
+                .into_iter()
+                .map(|message| message.seq_no)
+                .collect::<Vec<_>>(),
+            vec![1, 2],
+        );
+        assert!(pending.is_none());
+        assert!(matches!(request_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn splits_logical_batch_at_encoded_size_limit() {
+        let first = message(1, 8);
+        let second = message(2, 8);
+        let one_message_size = encoded_size(vec![first.clone()]);
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let mut pending = None;
+
+        StreamWriter::send_compressed_chunk(
+            &request_tx,
+            &settings(one_message_size),
+            &mut pending,
+            chunk(vec![first, second], true),
+        )
+        .unwrap();
+
+        let first_request = request_rx.try_recv().unwrap();
+        let second_request = request_rx.try_recv().unwrap();
+        assert_eq!(first_request.encoded_len(), one_message_size);
+        assert_eq!(second_request.encoded_len(), one_message_size);
+        assert_eq!(write_request(first_request).messages[0].seq_no, 1);
+        assert_eq!(write_request(second_request).messages[0].seq_no, 2);
+        assert!(pending.is_none());
+        assert!(matches!(request_rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[test]
+    fn does_not_combine_separate_logical_batches() {
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let mut pending = None;
+        let settings = settings(1024);
+
+        StreamWriter::send_compressed_chunk(
+            &request_tx,
+            &settings,
+            &mut pending,
+            chunk(vec![message(1, 8)], true),
+        )
+        .unwrap();
+        StreamWriter::send_compressed_chunk(
+            &request_tx,
+            &settings,
+            &mut pending,
+            chunk(vec![message(2, 8)], true),
+        )
+        .unwrap();
+
+        assert_eq!(
+            write_request(request_rx.try_recv().unwrap()).messages[0].seq_no,
+            1,
+        );
+        assert_eq!(
+            write_request(request_rx.try_recv().unwrap()).messages[0].seq_no,
+            2,
+        );
+        assert!(matches!(request_rx.try_recv(), Err(TryRecvError::Empty)));
     }
 }

--- a/ydb/src/client_topic/topicwriter/stream_writer.rs
+++ b/ydb/src/client_topic/topicwriter/stream_writer.rs
@@ -42,6 +42,10 @@ impl StreamWriter {
         tx_identity: Option<TransactionIdentity>,
     ) -> YdbResult<Self> {
         let cancellation_token = CancellationToken::new();
+        // The chunk size is also the flush threshold, so it must not exceed inflight capacity.
+        let message_chunk_size = writer_options
+            .write_request_messages_chunk_size
+            .clamp(1, writer_options.max_inflight_messages);
 
         // Both loops share the same oneshot error channel.
         let shared_error_tx = Arc::new(Mutex::new(Some(error_tx)));
@@ -69,7 +73,7 @@ impl StreamWriter {
             cancellation_token.clone(),
             shared_error_tx.clone(),
             queue.clone(),
-            writer_options.write_request_messages_chunk_size,
+            message_chunk_size,
             writer_options.write_request_send_messages_period,
             batch_tx,
         ));

--- a/ydb/src/client_topic/topicwriter/test_helpers.rs
+++ b/ydb/src/client_topic/topicwriter/test_helpers.rs
@@ -1,6 +1,38 @@
+use std::time::Duration;
+
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
 use crate::client_topic::topicwriter::message_write_status::{MessageWriteStatus, WriteAck};
+use crate::client_topic::topicwriter::writer_options::{
+    AutoFlushSettings, TopicWriterOptions, WriterFlowControl,
+};
+
+pub(crate) fn writer_flow_control(
+    inflight_messages: usize,
+    inflight_bytes: usize,
+    auto_flush_messages: usize,
+    auto_flush_bytes: usize,
+    auto_flush_interval: Duration,
+) -> WriterFlowControl {
+    let options = TopicWriterOptions::builder()
+        .topic_path("test-topic")
+        .max_inflight_messages(inflight_messages)
+        .max_inflight_bytes(inflight_bytes)
+        .auto_flush_messages(auto_flush_messages)
+        .auto_flush_bytes(auto_flush_bytes)
+        .auto_flush_interval(auto_flush_interval)
+        .build();
+
+    WriterFlowControl::try_from(&options).unwrap()
+}
+
+pub(crate) fn auto_flush_settings(
+    messages: usize,
+    bytes: usize,
+    interval: Duration,
+) -> AutoFlushSettings {
+    writer_flow_control(messages, bytes, messages, bytes, interval).auto_flush()
+}
 
 pub(crate) fn create_message(seq_no: i64, data: Vec<u8>) -> MessageData {
     MessageData {

--- a/ydb/src/client_topic/topicwriter/write_request.rs
+++ b/ydb/src/client_topic/topicwriter/write_request.rs
@@ -1,0 +1,256 @@
+use prost::Message;
+use ydb_grpc::ydb_proto::topic::TransactionIdentity;
+use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage;
+use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
+use ydb_grpc::ydb_proto::topic::stream_write_message::{FromClient, WriteRequest};
+
+use crate::client_topic::list_types::Codec;
+use crate::{YdbError, YdbResult};
+
+// Safety margin required for topic write requests by
+// https://github.com/ydb-platform/ydb-rs-sdk/issues/602.
+pub(super) const WRITE_REQUEST_SIZE_RESERVE_BYTES: usize = 4 * 1024;
+
+// The `messages` field in WriteRequest and the `write_request` variant in FromClient both have
+// single-byte protobuf keys. Tests compare the calculated size with prost's actual encoded size.
+const LENGTH_DELIMITED_FIELD_KEY_SIZE: usize = 1;
+
+#[derive(Clone)]
+pub(super) struct WriteRequestSettings {
+    tx_identity: Option<TransactionIdentity>,
+    max_write_request_size: usize,
+}
+
+impl WriteRequestSettings {
+    pub(super) fn new(
+        tx_identity: Option<TransactionIdentity>,
+        grpc_max_message_size: usize,
+    ) -> YdbResult<Self> {
+        let Some(max_write_request_size) = grpc_max_message_size
+            .checked_sub(WRITE_REQUEST_SIZE_RESERVE_BYTES)
+            .filter(|size| *size > 0)
+        else {
+            return Err(YdbError::custom(format!(
+                "gRPC max message size must exceed the topic write request reserve: max_message_size={grpc_max_message_size}, reserve={WRITE_REQUEST_SIZE_RESERVE_BYTES}",
+            )));
+        };
+
+        Ok(Self {
+            tx_identity,
+            max_write_request_size,
+        })
+    }
+}
+
+pub(super) enum TryAddMessage {
+    Added,
+    RequestFull(MessageData),
+}
+
+pub(super) struct PendingWriteRequest {
+    request: WriteRequest,
+    write_request_encoded_len: usize,
+    max_write_request_size: usize,
+}
+
+impl PendingWriteRequest {
+    pub(super) fn new(
+        settings: &WriteRequestSettings,
+        codec: Codec,
+        first_message: MessageData,
+    ) -> YdbResult<Self> {
+        let mut request = WriteRequest {
+            messages: Vec::with_capacity(1),
+            codec: codec.code,
+            tx: settings.tx_identity.clone(),
+        };
+        let base_encoded_len = request.encoded_len();
+        let message_encoded_len = length_delimited_field_encoded_len(first_message.encoded_len());
+        let write_request_encoded_len = base_encoded_len + message_encoded_len;
+        let encoded_len = length_delimited_field_encoded_len(write_request_encoded_len);
+
+        if encoded_len > settings.max_write_request_size {
+            return Err(YdbError::custom(format!(
+                "topic writer message exceeds the gRPC write request size limit: seq_no={}, encoded_size={encoded_len}, limit={}",
+                first_message.seq_no, settings.max_write_request_size,
+            )));
+        }
+
+        request.messages.push(first_message);
+
+        Ok(Self {
+            request,
+            write_request_encoded_len,
+            max_write_request_size: settings.max_write_request_size,
+        })
+    }
+
+    pub(super) fn codec(&self) -> Codec {
+        Codec {
+            code: self.request.codec,
+        }
+    }
+
+    pub(super) fn try_add(&mut self, message: MessageData) -> TryAddMessage {
+        let message_encoded_len = length_delimited_field_encoded_len(message.encoded_len());
+        let write_request_encoded_len = self.write_request_encoded_len + message_encoded_len;
+        let encoded_len = length_delimited_field_encoded_len(write_request_encoded_len);
+
+        if encoded_len > self.max_write_request_size {
+            return TryAddMessage::RequestFull(message);
+        }
+
+        self.request.messages.push(message);
+        self.write_request_encoded_len = write_request_encoded_len;
+        TryAddMessage::Added
+    }
+
+    pub(super) fn into_grpc_message(self) -> YdbResult<FromClient> {
+        let message = FromClient {
+            client_message: Some(ClientMessage::WriteRequest(self.request)),
+        };
+        let encoded_size = message.encoded_len();
+
+        if encoded_size > self.max_write_request_size {
+            return Err(YdbError::custom(format!(
+                "topic write request exceeds the configured size limit: encoded_size={encoded_size}, limit={}",
+                self.max_write_request_size,
+            )));
+        }
+
+        Ok(message)
+    }
+}
+
+fn length_delimited_field_encoded_len(value_encoded_len: usize) -> usize {
+    LENGTH_DELIMITED_FIELD_KEY_SIZE
+        + prost::length_delimiter_len(value_encoded_len)
+        + value_encoded_len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message(seq_no: i64, data_size: usize) -> MessageData {
+        MessageData {
+            seq_no,
+            data: vec![0; data_size],
+            ..Default::default()
+        }
+    }
+
+    fn settings(max_write_request_size: usize) -> WriteRequestSettings {
+        WriteRequestSettings::new(
+            None,
+            WRITE_REQUEST_SIZE_RESERVE_BYTES + max_write_request_size,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn rejects_grpc_limit_without_write_request_capacity() {
+        let result = WriteRequestSettings::new(None, WRITE_REQUEST_SIZE_RESERVE_BYTES);
+
+        assert!(matches!(
+            result,
+            Err(YdbError::Custom(message))
+                if message == format!(
+                    "gRPC max message size must exceed the topic write request reserve: max_message_size={}, reserve={}",
+                    WRITE_REQUEST_SIZE_RESERVE_BYTES,
+                    WRITE_REQUEST_SIZE_RESERVE_BYTES,
+                )
+        ));
+    }
+
+    #[test]
+    fn rejects_single_message_above_limit() {
+        let message = message(42, 8);
+        let request = WriteRequest {
+            messages: vec![message.clone()],
+            codec: Codec::RAW.code,
+            tx: None,
+        };
+        let encoded_size = FromClient {
+            client_message: Some(ClientMessage::WriteRequest(request)),
+        }
+        .encoded_len();
+        let limit = encoded_size - 1;
+
+        let result = PendingWriteRequest::new(&settings(limit), Codec::RAW, message);
+
+        assert!(matches!(
+            result,
+            Err(YdbError::Custom(message))
+                if message == format!(
+                    "topic writer message exceeds the gRPC write request size limit: seq_no=42, encoded_size={encoded_size}, limit={limit}",
+                )
+        ));
+    }
+
+    #[test]
+    fn returns_message_when_request_is_full() {
+        let first = message(1, 8);
+        let second = message(2, 8);
+        let request = WriteRequest {
+            messages: vec![first.clone()],
+            codec: Codec::RAW.code,
+            tx: None,
+        };
+        let one_message_size = FromClient {
+            client_message: Some(ClientMessage::WriteRequest(request)),
+        }
+        .encoded_len();
+        let mut pending =
+            PendingWriteRequest::new(&settings(one_message_size), Codec::RAW, first).unwrap();
+
+        let result = pending.try_add(second);
+
+        assert!(matches!(
+            result,
+            TryAddMessage::RequestFull(message) if message.seq_no == 2
+        ));
+        let message = pending.into_grpc_message().unwrap();
+        assert_eq!(message.encoded_len(), one_message_size);
+    }
+
+    #[test]
+    fn calculated_size_matches_complete_protobuf_message() {
+        let tx_identity = TransactionIdentity {
+            id: "transaction".to_string(),
+            session: "session".to_string(),
+        };
+        let settings =
+            WriteRequestSettings::new(Some(tx_identity), WRITE_REQUEST_SIZE_RESERVE_BYTES + 1024)
+                .unwrap();
+        let mut pending = PendingWriteRequest::new(&settings, Codec::GZIP, message(1, 8)).unwrap();
+        assert!(matches!(
+            pending.try_add(message(2, 16)),
+            TryAddMessage::Added
+        ));
+        let calculated_size = length_delimited_field_encoded_len(pending.write_request_encoded_len);
+
+        let message = pending.into_grpc_message().unwrap();
+
+        assert_eq!(message.encoded_len(), calculated_size);
+    }
+
+    #[test]
+    fn finalization_rejects_request_above_limit() {
+        let settings = settings(1024);
+        let mut pending = PendingWriteRequest::new(&settings, Codec::RAW, message(1, 8)).unwrap();
+        let encoded_size = length_delimited_field_encoded_len(pending.write_request_encoded_len);
+        let limit = encoded_size - 1;
+        pending.max_write_request_size = limit;
+
+        let result = pending.into_grpc_message();
+
+        assert!(matches!(
+            result,
+            Err(YdbError::Custom(message))
+                if message == format!(
+                    "topic write request exceeds the configured size limit: encoded_size={encoded_size}, limit={limit}",
+                )
+        ));
+    }
+}

--- a/ydb/src/client_topic/topicwriter/write_request.rs
+++ b/ydb/src/client_topic/topicwriter/write_request.rs
@@ -4,12 +4,13 @@ use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 use ydb_grpc::ydb_proto::topic::stream_write_message::{FromClient, WriteRequest};
 
+use crate::byte_units::KiB;
 use crate::client_topic::list_types::Codec;
 use crate::{YdbError, YdbResult};
 
 // Safety margin required for topic write requests by
 // https://github.com/ydb-platform/ydb-rs-sdk/issues/602.
-pub(super) const WRITE_REQUEST_SIZE_RESERVE_BYTES: usize = 4 * 1024;
+pub(super) const WRITE_REQUEST_SIZE_RESERVE_BYTES: usize = 4 * KiB;
 
 // The `messages` field in WriteRequest and the `write_request` variant in FromClient both have
 // single-byte protobuf keys. Tests compare the calculated size with prost's actual encoded size.
@@ -148,59 +149,40 @@ mod tests {
         .unwrap()
     }
 
+    fn encoded_request_size(messages: Vec<MessageData>) -> usize {
+        FromClient {
+            client_message: Some(ClientMessage::WriteRequest(WriteRequest {
+                messages,
+                codec: Codec::RAW.code,
+                tx: None,
+            })),
+        }
+        .encoded_len()
+    }
+
     #[test]
     fn rejects_grpc_limit_without_write_request_capacity() {
         let result = WriteRequestSettings::new(None, WRITE_REQUEST_SIZE_RESERVE_BYTES);
 
-        assert!(matches!(
-            result,
-            Err(YdbError::Custom(message))
-                if message == format!(
-                    "gRPC max message size must exceed the topic write request reserve: max_message_size={}, reserve={}",
-                    WRITE_REQUEST_SIZE_RESERVE_BYTES,
-                    WRITE_REQUEST_SIZE_RESERVE_BYTES,
-                )
-        ));
+        assert!(result.is_err());
     }
 
     #[test]
     fn rejects_single_message_above_limit() {
         let message = message(42, 8);
-        let request = WriteRequest {
-            messages: vec![message.clone()],
-            codec: Codec::RAW.code,
-            tx: None,
-        };
-        let encoded_size = FromClient {
-            client_message: Some(ClientMessage::WriteRequest(request)),
-        }
-        .encoded_len();
+        let encoded_size = encoded_request_size(vec![message.clone()]);
         let limit = encoded_size - 1;
 
         let result = PendingWriteRequest::new(&settings(limit), Codec::RAW, message);
 
-        assert!(matches!(
-            result,
-            Err(YdbError::Custom(message))
-                if message == format!(
-                    "topic writer message exceeds the gRPC write request size limit: seq_no=42, encoded_size={encoded_size}, limit={limit}",
-                )
-        ));
+        assert!(result.is_err());
     }
 
     #[test]
     fn returns_message_when_request_is_full() {
         let first = message(1, 8);
         let second = message(2, 8);
-        let request = WriteRequest {
-            messages: vec![first.clone()],
-            codec: Codec::RAW.code,
-            tx: None,
-        };
-        let one_message_size = FromClient {
-            client_message: Some(ClientMessage::WriteRequest(request)),
-        }
-        .encoded_len();
+        let one_message_size = encoded_request_size(vec![first.clone()]);
         let mut pending =
             PendingWriteRequest::new(&settings(one_message_size), Codec::RAW, first).unwrap();
 
@@ -245,12 +227,6 @@ mod tests {
 
         let result = pending.into_grpc_message();
 
-        assert!(matches!(
-            result,
-            Err(YdbError::Custom(message))
-                if message == format!(
-                    "topic write request exceeds the configured size limit: encoded_size={encoded_size}, limit={limit}",
-                )
-        ));
+        assert!(result.is_err());
     }
 }

--- a/ydb/src/client_topic/topicwriter/writer_options.rs
+++ b/ydb/src/client_topic/topicwriter/writer_options.rs
@@ -4,14 +4,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::YdbError;
+use crate::byte_units::MiB;
 use crate::client_topic::compression::{CodecSelection, CompressionEncoder};
 use crate::client_topic::topicwriter::partitioning::PartitioningStrategy;
 use crate::retry_settings::RetrySettings;
-
-pub(crate) const DEFAULT_MAX_INFLIGHT_MESSAGES: usize = 1000;
-pub(crate) const DEFAULT_MAX_INFLIGHT_BYTES: usize = 20 * 1024 * 1024;
-pub(crate) const DEFAULT_AUTO_FLUSH_MESSAGES: usize = 1000;
-pub(crate) const DEFAULT_AUTO_FLUSH_BYTES: usize = 20 * 1024 * 1024;
 
 #[derive(Clone, Copy)]
 pub(crate) struct InflightLimits {
@@ -91,11 +87,11 @@ pub struct TopicWriterOptions {
     // automatic flushing
     /// Number of buffered messages that triggers an automatic flush. Must be greater than zero
     /// and must not exceed `max_inflight_messages`. The default is **1,000**.
-    #[builder(default = DEFAULT_AUTO_FLUSH_MESSAGES)]
+    #[builder(default = 1000)]
     pub(crate) auto_flush_messages: usize,
     /// Total payload size of buffered messages that triggers an automatic flush. Must be greater
     /// than zero and must not exceed `max_inflight_bytes`. The default is **20 MiB**.
-    #[builder(default = DEFAULT_AUTO_FLUSH_BYTES)]
+    #[builder(default = 20 * MiB)]
     pub(crate) auto_flush_bytes: usize,
     /// Maximum interval before a partial batch is flushed automatically. The default is **1 ms**.
     #[builder(default = Duration::from_millis(1))]
@@ -107,13 +103,17 @@ pub struct TopicWriterOptions {
     /// Maximum number of messages accepted by the writer but not yet acknowledged by the
     /// server. Writes wait for capacity after reaching this limit. Must be greater than zero.
     /// The default is **1,000**.
-    #[builder(default = DEFAULT_MAX_INFLIGHT_MESSAGES)]
+    #[builder(default = 1000)]
     pub(crate) max_inflight_messages: usize,
-    /// Maximum total payload size of messages accepted by the writer but not yet acknowledged by
-    /// the server. Writes wait for capacity after reaching this limit. The default is **20 MiB**.
-    /// A single larger message is allowed and consumes the entire byte capacity until it is
-    /// acknowledged. Must be greater than zero.
-    #[builder(default = DEFAULT_MAX_INFLIGHT_BYTES)]
+    /// Soft limit on the total payload size of messages accepted by the writer but not yet
+    /// acknowledged by the server. When there is insufficient byte capacity for a new message,
+    /// the write waits until capacity becomes available.
+    ///
+    /// A single message larger than this limit is still accepted to guarantee progress. As a
+    /// result, the actual payload size in flight may temporarily exceed the configured limit.
+    ///
+    /// Must be greater than zero. The default is **20 MiB**.
+    #[builder(default = 20 * MiB)]
     pub(crate) max_inflight_bytes: usize,
 
     #[builder(default = RetrySettings::with_default_backoff(), setters(vis = "pub(crate)"))]
@@ -178,11 +178,7 @@ mod tests {
             .max_inflight_messages(0)
             .build();
 
-        assert!(matches!(
-            WriterFlowControl::try_from(&options),
-            Err(YdbError::Custom(message))
-                if message == "max_inflight_messages must be greater than zero"
-        ));
+        assert!(WriterFlowControl::try_from(&options).is_err());
     }
 
     #[test]
@@ -192,11 +188,7 @@ mod tests {
             .max_inflight_bytes(0)
             .build();
 
-        assert!(matches!(
-            WriterFlowControl::try_from(&options),
-            Err(YdbError::Custom(message))
-                if message == "max_inflight_bytes must be greater than zero"
-        ));
+        assert!(WriterFlowControl::try_from(&options).is_err());
     }
 
     #[test]
@@ -206,11 +198,7 @@ mod tests {
             .auto_flush_messages(0)
             .build();
 
-        assert!(matches!(
-            WriterFlowControl::try_from(&options),
-            Err(YdbError::Custom(message))
-                if message == "auto_flush_messages must be greater than zero"
-        ));
+        assert!(WriterFlowControl::try_from(&options).is_err());
     }
 
     #[test]
@@ -220,11 +208,7 @@ mod tests {
             .auto_flush_bytes(0)
             .build();
 
-        assert!(matches!(
-            WriterFlowControl::try_from(&options),
-            Err(YdbError::Custom(message))
-                if message == "auto_flush_bytes must be greater than zero"
-        ));
+        assert!(WriterFlowControl::try_from(&options).is_err());
     }
 
     #[test]
@@ -235,11 +219,7 @@ mod tests {
             .max_inflight_messages(10)
             .build();
 
-        assert!(matches!(
-            WriterFlowControl::try_from(&options),
-            Err(YdbError::Custom(message))
-                if message == "auto_flush_messages must not exceed max_inflight_messages: auto_flush_messages=11, max_inflight_messages=10"
-        ));
+        assert!(WriterFlowControl::try_from(&options).is_err());
     }
 
     #[test]
@@ -250,10 +230,6 @@ mod tests {
             .max_inflight_bytes(10)
             .build();
 
-        assert!(matches!(
-            WriterFlowControl::try_from(&options),
-            Err(YdbError::Custom(message))
-                if message == "auto_flush_bytes must not exceed max_inflight_bytes: auto_flush_bytes=11, max_inflight_bytes=10"
-        ));
+        assert!(WriterFlowControl::try_from(&options).is_err());
     }
 }

--- a/ydb/src/client_topic/topicwriter/writer_options.rs
+++ b/ydb/src/client_topic/topicwriter/writer_options.rs
@@ -1,10 +1,20 @@
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::client_topic::compression::{CodecSelection, CompressionEncoder};
 use crate::client_topic::topicwriter::partitioning::PartitioningStrategy;
 use crate::retry_settings::RetrySettings;
+use crate::{YdbError, YdbResult};
+
+pub(crate) const DEFAULT_MAX_INFLIGHT_MESSAGES: usize = 1000;
+pub(crate) const DEFAULT_MAX_INFLIGHT_BYTES: usize = 20 * 1024 * 1024;
+
+pub(crate) struct InflightLimits {
+    pub(crate) messages: NonZeroUsize,
+    pub(crate) bytes: NonZeroUsize,
+}
 
 #[derive(bon::Builder, Clone)]
 pub struct TopicWriterOptions {
@@ -36,6 +46,19 @@ pub struct TopicWriterOptions {
     #[builder(default = Duration::from_secs(3))]
     pub(crate) flush_timeout: Duration,
 
+    // write buffer limits
+    /// Maximum number of messages accepted by the writer but not yet acknowledged by the
+    /// server. Writes wait for capacity after reaching this limit. Must be greater than zero.
+    /// The default is **1,000**.
+    #[builder(default = DEFAULT_MAX_INFLIGHT_MESSAGES)]
+    pub(crate) max_inflight_messages: usize,
+    /// Maximum total payload size of messages accepted by the writer but not yet acknowledged by
+    /// the server. Writes wait for capacity after reaching this limit. The default is **20 MiB**.
+    /// A single larger message is allowed and consumes the entire byte capacity until it is
+    /// acknowledged. Must be greater than zero.
+    #[builder(default = DEFAULT_MAX_INFLIGHT_BYTES)]
+    pub(crate) max_inflight_bytes: usize,
+
     #[builder(default = RetrySettings::with_default_backoff(), setters(vis = "pub(crate)"))]
     pub(crate) retry_settings: RetrySettings,
 }
@@ -44,5 +67,43 @@ impl<S: topic_writer_options_builder::State> TopicWriterOptionsBuilder<S> {
     pub fn add_encoder<E: CompressionEncoder + 'static>(mut self, encoder: E) -> Self {
         self.extra_encoders.push(Arc::new(encoder));
         self
+    }
+}
+
+impl TopicWriterOptions {
+    pub(crate) fn inflight_limits(&self) -> YdbResult<InflightLimits> {
+        let messages = NonZeroUsize::new(self.max_inflight_messages)
+            .ok_or_else(|| YdbError::custom("max_inflight_messages must be greater than zero"))?;
+        let bytes = NonZeroUsize::new(self.max_inflight_bytes)
+            .ok_or_else(|| YdbError::custom("max_inflight_bytes must be greater than zero"))?;
+
+        Ok(InflightLimits { messages, bytes })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero_max_inflight_messages() {
+        let options = TopicWriterOptions::builder()
+            .topic_path("topic")
+            .max_inflight_messages(0)
+            .build();
+
+        let err = options.inflight_limits().err().unwrap();
+        assert!(err.to_string().contains("max_inflight_messages"));
+    }
+
+    #[test]
+    fn rejects_zero_max_inflight_bytes() {
+        let options = TopicWriterOptions::builder()
+            .topic_path("topic")
+            .max_inflight_bytes(0)
+            .build();
+
+        let err = options.inflight_limits().err().unwrap();
+        assert!(err.to_string().contains("max_inflight_bytes"));
     }
 }

--- a/ydb/src/client_topic/topicwriter/writer_options.rs
+++ b/ydb/src/client_topic/topicwriter/writer_options.rs
@@ -3,17 +3,67 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::YdbError;
 use crate::client_topic::compression::{CodecSelection, CompressionEncoder};
 use crate::client_topic::topicwriter::partitioning::PartitioningStrategy;
 use crate::retry_settings::RetrySettings;
-use crate::{YdbError, YdbResult};
 
 pub(crate) const DEFAULT_MAX_INFLIGHT_MESSAGES: usize = 1000;
 pub(crate) const DEFAULT_MAX_INFLIGHT_BYTES: usize = 20 * 1024 * 1024;
+pub(crate) const DEFAULT_AUTO_FLUSH_MESSAGES: usize = 1000;
+pub(crate) const DEFAULT_AUTO_FLUSH_BYTES: usize = 20 * 1024 * 1024;
 
+#[derive(Clone, Copy)]
 pub(crate) struct InflightLimits {
-    pub(crate) messages: NonZeroUsize,
-    pub(crate) bytes: NonZeroUsize,
+    messages: NonZeroUsize,
+    bytes: NonZeroUsize,
+}
+
+impl InflightLimits {
+    pub(crate) fn messages(self) -> NonZeroUsize {
+        self.messages
+    }
+
+    pub(crate) fn bytes(self) -> NonZeroUsize {
+        self.bytes
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct AutoFlushSettings {
+    messages: NonZeroUsize,
+    bytes: NonZeroUsize,
+    interval: Duration,
+}
+
+impl AutoFlushSettings {
+    pub(crate) fn messages(self) -> usize {
+        self.messages.get()
+    }
+
+    pub(crate) fn bytes(self) -> usize {
+        self.bytes.get()
+    }
+
+    pub(crate) fn interval(self) -> Duration {
+        self.interval
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct WriterFlowControl {
+    inflight: InflightLimits,
+    auto_flush: AutoFlushSettings,
+}
+
+impl WriterFlowControl {
+    pub(crate) fn inflight(self) -> InflightLimits {
+        self.inflight
+    }
+
+    pub(crate) fn auto_flush(self) -> AutoFlushSettings {
+        self.auto_flush
+    }
 }
 
 #[derive(bon::Builder, Clone)]
@@ -38,11 +88,18 @@ pub struct TopicWriterOptions {
     #[builder(default)]
     pub(crate) codec_selector: CodecSelection,
 
-    // internal write-loop tuning
-    #[builder(default = 1000)]
-    pub(crate) write_request_messages_chunk_size: usize,
+    // automatic flushing
+    /// Number of buffered messages that triggers an automatic flush. Must be greater than zero
+    /// and must not exceed `max_inflight_messages`. The default is **1,000**.
+    #[builder(default = DEFAULT_AUTO_FLUSH_MESSAGES)]
+    pub(crate) auto_flush_messages: usize,
+    /// Total payload size of buffered messages that triggers an automatic flush. Must be greater
+    /// than zero and must not exceed `max_inflight_bytes`. The default is **20 MiB**.
+    #[builder(default = DEFAULT_AUTO_FLUSH_BYTES)]
+    pub(crate) auto_flush_bytes: usize,
+    /// Maximum interval before a partial batch is flushed automatically. The default is **1 ms**.
     #[builder(default = Duration::from_millis(1))]
-    pub(crate) write_request_send_messages_period: Duration,
+    pub(crate) auto_flush_interval: Duration,
     #[builder(default = Duration::from_secs(3))]
     pub(crate) flush_timeout: Duration,
 
@@ -70,14 +127,43 @@ impl<S: topic_writer_options_builder::State> TopicWriterOptionsBuilder<S> {
     }
 }
 
-impl TopicWriterOptions {
-    pub(crate) fn inflight_limits(&self) -> YdbResult<InflightLimits> {
-        let messages = NonZeroUsize::new(self.max_inflight_messages)
-            .ok_or_else(|| YdbError::custom("max_inflight_messages must be greater than zero"))?;
-        let bytes = NonZeroUsize::new(self.max_inflight_bytes)
-            .ok_or_else(|| YdbError::custom("max_inflight_bytes must be greater than zero"))?;
+impl TryFrom<&TopicWriterOptions> for WriterFlowControl {
+    type Error = YdbError;
 
-        Ok(InflightLimits { messages, bytes })
+    fn try_from(options: &TopicWriterOptions) -> Result<Self, Self::Error> {
+        let inflight_messages = NonZeroUsize::new(options.max_inflight_messages)
+            .ok_or_else(|| YdbError::custom("max_inflight_messages must be greater than zero"))?;
+        let inflight_bytes = NonZeroUsize::new(options.max_inflight_bytes)
+            .ok_or_else(|| YdbError::custom("max_inflight_bytes must be greater than zero"))?;
+        let auto_flush_messages = NonZeroUsize::new(options.auto_flush_messages)
+            .ok_or_else(|| YdbError::custom("auto_flush_messages must be greater than zero"))?;
+        let auto_flush_bytes = NonZeroUsize::new(options.auto_flush_bytes)
+            .ok_or_else(|| YdbError::custom("auto_flush_bytes must be greater than zero"))?;
+
+        if auto_flush_messages > inflight_messages {
+            return Err(YdbError::custom(format!(
+                "auto_flush_messages must not exceed max_inflight_messages: auto_flush_messages={}, max_inflight_messages={}",
+                auto_flush_messages, inflight_messages,
+            )));
+        }
+        if auto_flush_bytes > inflight_bytes {
+            return Err(YdbError::custom(format!(
+                "auto_flush_bytes must not exceed max_inflight_bytes: auto_flush_bytes={}, max_inflight_bytes={}",
+                auto_flush_bytes, inflight_bytes,
+            )));
+        }
+
+        Ok(Self {
+            inflight: InflightLimits {
+                messages: inflight_messages,
+                bytes: inflight_bytes,
+            },
+            auto_flush: AutoFlushSettings {
+                messages: auto_flush_messages,
+                bytes: auto_flush_bytes,
+                interval: options.auto_flush_interval,
+            },
+        })
     }
 }
 
@@ -92,8 +178,11 @@ mod tests {
             .max_inflight_messages(0)
             .build();
 
-        let err = options.inflight_limits().err().unwrap();
-        assert!(err.to_string().contains("max_inflight_messages"));
+        assert!(matches!(
+            WriterFlowControl::try_from(&options),
+            Err(YdbError::Custom(message))
+                if message == "max_inflight_messages must be greater than zero"
+        ));
     }
 
     #[test]
@@ -103,7 +192,68 @@ mod tests {
             .max_inflight_bytes(0)
             .build();
 
-        let err = options.inflight_limits().err().unwrap();
-        assert!(err.to_string().contains("max_inflight_bytes"));
+        assert!(matches!(
+            WriterFlowControl::try_from(&options),
+            Err(YdbError::Custom(message))
+                if message == "max_inflight_bytes must be greater than zero"
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_auto_flush_messages() {
+        let options = TopicWriterOptions::builder()
+            .topic_path("topic")
+            .auto_flush_messages(0)
+            .build();
+
+        assert!(matches!(
+            WriterFlowControl::try_from(&options),
+            Err(YdbError::Custom(message))
+                if message == "auto_flush_messages must be greater than zero"
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_auto_flush_bytes() {
+        let options = TopicWriterOptions::builder()
+            .topic_path("topic")
+            .auto_flush_bytes(0)
+            .build();
+
+        assert!(matches!(
+            WriterFlowControl::try_from(&options),
+            Err(YdbError::Custom(message))
+                if message == "auto_flush_bytes must be greater than zero"
+        ));
+    }
+
+    #[test]
+    fn rejects_auto_flush_messages_above_inflight_limit() {
+        let options = TopicWriterOptions::builder()
+            .topic_path("topic")
+            .auto_flush_messages(11)
+            .max_inflight_messages(10)
+            .build();
+
+        assert!(matches!(
+            WriterFlowControl::try_from(&options),
+            Err(YdbError::Custom(message))
+                if message == "auto_flush_messages must not exceed max_inflight_messages: auto_flush_messages=11, max_inflight_messages=10"
+        ));
+    }
+
+    #[test]
+    fn rejects_auto_flush_bytes_above_inflight_limit() {
+        let options = TopicWriterOptions::builder()
+            .topic_path("topic")
+            .auto_flush_bytes(11)
+            .max_inflight_bytes(10)
+            .build();
+
+        assert!(matches!(
+            WriterFlowControl::try_from(&options),
+            Err(YdbError::Custom(message))
+                if message == "auto_flush_bytes must not exceed max_inflight_bytes: auto_flush_bytes=11, max_inflight_bytes=10"
+        ));
     }
 }

--- a/ydb/src/grpc_connection_manager.rs
+++ b/ydb/src/grpc_connection_manager.rs
@@ -87,4 +87,8 @@ impl<BalancerT, ConnectionT: Connection> GrpcConnectionManagerGeneric<BalancerT,
     pub(crate) fn database(&self) -> &String {
         &self.database
     }
+
+    pub(crate) fn max_message_size(&self) -> usize {
+        self.opts.max_message_size
+    }
 }

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -41,6 +41,7 @@
 
 extern crate core;
 
+mod byte_units;
 pub(crate) mod client;
 mod client_builder;
 pub(crate) mod client_common;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Writer has no backpressure on writes. If server acquires messages slower than user writes arrives, memory overflow is possible.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: close #565

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- Writer has configurable limits of messages in flight -- by message count and by bytes count. 
- Message, which exceeds maximum bytes count in flight, acquires all permits on bytes.
- When any message waits on buffer capacity, notify is send to flush the message buffer.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
