### PR TITLE
fix: correct ydb crate metadata for crates.io

### DIFF
--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -5,8 +5,13 @@ version = "0.17.1"
 authors = ["rekby <timofey.koolin@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0"
-description = "Crate contains generated low-level grpc code from YDB API protobuf, used as base for ydb crate"
+description = "Official Rust SDK for YDB - an open-source distributed SQL database"
 repository = "https://github.com/ydb-platform/ydb-rs-sdk/tree/master/ydb"
+homepage = "https://ydb.tech"
+documentation = "https://docs.rs/ydb"
+readme = "README.md"
+keywords = ["ydb", "database", "sql", "client", "async"]
+categories = ["database", "asynchronous", "api-bindings"]
 rust-version.workspace = true
 
 [lints]

--- a/ydb/README.md
+++ b/ydb/README.md
@@ -2,13 +2,13 @@
 [Documentation](https://docs.rs/ydb)
 
 Rust SDK for YDB.
-Supported rust: 1.85 and newer.
+Supported rust: 1.88 and newer.
 
 
 Integration tests, with dependency from real YDB database mark as ignored.
 For run it:
 1. Set YDB_CONNECTION_STRING env
-2. run cargo test -- --ignored
+2. run cargo test -- --include-ignored
 
 ### Cargo feature force-exhaustive-all
 


### PR DESCRIPTION
## Problem

`ydb/Cargo.toml` carried a verbatim copy of `ydb-grpc`'s description, so crates.io advertises the SDK as:

> Crate contains generated low-level grpc code from YDB API protobuf, used as base for ydb crate

The crate also had no `keywords`, `categories`, `homepage`, `documentation` or `readme`, so it does not appear in any crates.io category or keyword search.

## Change

- Description now says what the crate is.
- Added `homepage`, `documentation`, `readme`, `keywords` (5, the crates.io maximum) and `categories` (`database`, `asynchronous`, `api-bindings`).
- `ydb/README.md` said "Supported rust: 1.85 and newer" (the workspace requires 1.88) and told readers to run integration tests with `--ignored`, which no longer selects them; both corrected.

## Verification

```
cargo metadata --no-deps      # all fields resolve as intended
cargo package --list -p ydb   # no readme-path warning
cargo fmt --check && cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
