### PR TITLE
fix: move mockall and tracing-test to dev-dependencies

### DIFF
--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -33,7 +33,6 @@ itertools = "0.10"
 jsonwebtoken = "9.3"
 time = "0.3"
 num = "0.4"
-mockall = "0.14"
 once_cell = "1.8"
 prost = { workspace = true }
 prost-types = { workspace = true }
@@ -52,7 +51,6 @@ tokio = { version = "1.22", features = ["full"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-util = "0.7.8"
 tracing = "0.1"
-tracing-test = "0.2.1"
 tracing-subscriber = "0.3"
 tonic = { workspace = true }
 tower = "0.4"
@@ -69,10 +67,12 @@ chrono = { version = "0.4", default-features = false, features = [
     "std",
 ] }
 lazy_static = "1.4"
+mockall = "0.14"
 ntest = "0.7"
 opentelemetry = "0.32.0"
 opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.32.1"
 tokio = { version = "1.22", features = ["test-util"] }
 tracing-opentelemetry = "0.33.0"
+tracing-test = "0.2.1"
 uuid = { version = "1.17.0", features = ["v4"] }

--- a/ydb/src/load_balancer/mod.rs
+++ b/ydb/src/load_balancer/mod.rs
@@ -15,13 +15,14 @@ pub mod static_balancer;
 pub(crate) use shared_balancer::SharedLoadBalancer;
 pub(crate) use static_balancer::StaticLoadBalancer;
 
-#[mockall::automock]
+#[cfg_attr(test, mockall::automock)]
 pub(crate) trait LoadBalancer: Send + Sync + Waiter {
     fn endpoint(&self, service: Service) -> YdbResult<Uri>;
     fn set_discovery_state(&mut self, discovery_state: &Arc<DiscoveryState>) -> YdbResult<()>;
     fn waiter(&self) -> Box<dyn Waiter>; // need for wait ready in without read lock
 }
 
+#[cfg(test)]
 #[async_trait::async_trait]
 impl Waiter for MockLoadBalancer {
     async fn wait(&self) -> YdbResult<()> {


### PR DESCRIPTION
## Problem

`mockall` and `tracing-test` were declared in `[dependencies]`, so every downstream consumer of `ydb` compiled them and their proc-macro trees in normal (non-test) builds.

- `tracing-test` is referenced only from `*_test.rs` modules.
- `mockall` was reachable from non-test builds solely because `#[mockall::automock]` on the `LoadBalancer` trait was unconditional.

## Change

- Gate the mock behind `#[cfg_attr(test, mockall::automock)]`, and put `#[cfg(test)]` on the `impl Waiter for MockLoadBalancer` that consumes the generated type.
- Move both crates to `[dev-dependencies]`.

No source change is needed anywhere else — `MockLoadBalancer` is only used from `load_balancer/balancer_test.rs`, which is already `#[cfg(test)]`.

## Effect

`cargo tree -p ydb -e normal` drops from **292 to 276** crates.

`Cargo.lock` is deliberately untouched: moving a dependency between sections does not require a lock change.

## Verification

```
cargo check -p ydb --all-targets --locked
cargo fmt --check && cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace     # 214 passed, 88 ignored — same as master
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
