### PR TITLE
docs: document all 25 examples in examples/README.md

### DIFF
--- a/ydb/examples/README.md
+++ b/ydb/examples/README.md
@@ -1,7 +1,15 @@
 # YDB SDK Examples
 
+Run any example with:
+
+```bash
+cargo run --example <name>
+```
+
 ## Common dependencies for examples
 All examples (but listed below) need local ydb started with docker-compose up with docker-compose.yaml from repository root dir.
+
+Examples read `YDB_CONNECTION_STRING` where noted; the rest connect to `grpc://localhost:2136/local`.
 
 ## Table Service API layers
 
@@ -12,6 +20,66 @@ All examples (but listed below) need local ydb started with docker-compose up wi
 | `query-service-*` | `QueryClient` | Query Service (implicit sessions, streaming, tx modes) |
 
 YQL (including DDL) and multi-statement transactions use [`QueryClient`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html) with default [`TxMode::Implicit`](https://docs.rs/ydb/latest/ydb/enum.TxMode.html). `TableClient` covers typed DDL RPCs (`create_table`, …), describe, copy/rename, and sessionless `ReadRows` / `BulkUpsert`.
+
+## Query Service
+
+| Example | What it shows |
+|---------|---------------|
+| `query-service-basic` | One-shot `exec` / `query_row` / `query_result_set`, parameters, `.optional()`, `.typed::<T>()` |
+| `query-service-transaction` | `retry_tx` with `AsyncFnMut(&mut Transaction)`; staying generic over `QueryExecutor` |
+| `query-service-stream` | Multi-result-set streaming inside `retry_tx` |
+| `query-service-tx-modes` | Transaction isolation modes (`TxMode::Implicit` and explicit `BeginTx`) |
+| `query-service-script` | Long-running script: start operation, poll until ready, paginate with `FetchScriptResults` |
+| `vector-search` | Vector search with YQL Knn UDFs |
+| `container-types` | Container values — `List`, `Struct`, `Tuple`, `Optional` |
+| `basic-select-upsert` | Select and upsert inside `retry_tx` |
+| `basic-upsert-many-rows` | Writing many rows in one request |
+| `basic` | Series/seasons/episodes sample schema, bulk load via `AS_TABLE`, snapshot streaming reads — see [basic/README.md](basic/README.md) |
+
+## Table Service
+
+| Example | What it shows |
+|---------|---------------|
+| `basic-read-rows` | Sessionless `ReadRows` point lookups |
+| `basic-bulk-upsert` | Sessionless `BulkUpsert` batch writes |
+
+## Topics
+
+| Example | What it shows |
+|---------|---------------|
+| `topic-writer` | Producing messages to a topic |
+| `topic-reader-retry` | Consuming messages with reconnect/retry handling |
+| `topic-read-in-transaction-example` | Reading topic messages inside a transaction |
+
+## Coordination
+
+| Example | What it shows |
+|---------|---------------|
+| `mutex` | Distributed mutex built on a coordination semaphore |
+
+## Operations
+
+| Example | What it shows |
+|---------|---------------|
+| `operation-service-example` | Listing, polling, forgetting and cancelling long-running server operations |
+
+## Authentication
+
+| Example | What it shows | Extra requirements |
+|---------|---------------|--------------------|
+| `auth-token` | Static access token via `AccessTokenCredentials` | — |
+| `auth-static-credentials` | User/password via `StaticCredentials` | — |
+| `auth-env-connection-string` | Connection string taken from the environment | `YDB_CONNECTION_STRING` |
+| `auth-yc-cmdline` | Token produced by an external command | see below |
+| `auth-ycloud-metadata` | Token from the VM metadata service | see below |
+| `auth-ycloud-serviceaccount` | Service account key file | `YDB_CONNECTION_STRING`, `YDB_SERVICE_ACCOUNT_KEY_FILE_CREDENTIALS` |
+
+## Observability
+
+| Example | What it shows |
+|---------|---------------|
+| `basic-logs` | Enabling verbose `tracing` output |
+| `tracing-select-upsert` | Instrumenting queries with `tracing` spans |
 
 ## Additional dependencies for some examples
 ### auth-yc-cmdline

--- a/ydb/examples/basic/README.md
+++ b/ydb/examples/basic/README.md
@@ -6,7 +6,7 @@ data via `AS_TABLE`, and reads series rows with snapshot read-only streaming.
 
 ```bash
 export YDB_CONNECTION_STRING=grpc://localhost:2136/local
-cargo run --example basic_query_series
+cargo run --example basic
 ```
 
-Requires a local YDB (see repository `docker-compose.yaml`) and Rust 1.85+.
+Requires a local YDB (see repository `docker-compose.yaml`) and Rust 1.88+.


### PR DESCRIPTION
## Problem

`ydb/examples/README.md` listed 8 of the 25 `cargo run --example` targets. Every topic, coordination, operation, auth and observability example was undiscoverable from the docs.

Separately, `ydb/examples/basic/README.md` instructed readers to run:

```bash
cargo run --example basic_query_series
```

No such target exists — the example is registered as `basic`, so the documented command fails.

## Change

- Group all 25 examples by the API they demonstrate, each with a one-line description and the environment variables it needs. The existing "Table Service API layers" table and the extra-dependency notes are kept as-is.
- Fix the wrong target name in `examples/basic/README.md`.
- Update the stale MSRV there (1.85 → 1.88).

## Verification

Checked mechanically that every example target reported by `cargo metadata` appears in the README — all 25 present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
