### PR TITLE
docs: document core public API and guard it with deny(missing_docs)

### DIFF
--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -32,6 +32,10 @@ impl YdbOrCustomerError {
         Self::Customer(Arc::new(Box::new(err)))
     }
 
+    /// Flatten into a [`YdbError`]
+    ///
+    /// A customer error is rendered through its [`Display`] impl and wrapped
+    /// into [`YdbError::Custom`].
     pub fn to_ydb_error(self) -> YdbError {
         match self {
             Self::YDB(err) => err,
@@ -255,14 +259,34 @@ impl YdbStatusError {
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
 pub enum YdbIssueSeverity {
+    /// Level 0, the most severe level the server defines
+    ///
+    /// The SDK does not tell it apart from [`Self::Error`]: neither level
+    /// takes part in any retry or error handling decision here, and both mean
+    /// the same thing to a caller - the issue is an error reported by the
+    /// server. Whether the operation itself failed is decided by
+    /// [`YdbStatusError::operation_status`], not by this field.
     #[default]
     Fatal,
+
+    /// Level 1, an error reported by the server
+    ///
+    /// See [`Self::Fatal`] on how the two relate.
     Error,
+
+    /// Level 2, the issue did not stop the operation
     Warning,
+
+    /// Level 3, informational message
     Info,
 
-    // no use Unknown for own logic (use for debug/log only) - for prevent broke your code when new level will be defined.
-    // use convert to u32 for temporary use int code and ask a maintainer to add new level as explicit value
+    /// A level this SDK version does not know about, with the raw number the
+    /// server sent
+    ///
+    /// Do not build own logic on it, use it for debug and logs only - that way
+    /// a newly defined level does not break your code. Convert to `u32` to
+    /// work with the raw number meanwhile, and ask a maintainer to add the new
+    /// level as an explicit variant.
     Unknown(u32),
 }
 
@@ -298,7 +322,15 @@ impl From<u32> for YdbIssueSeverity {
 #[cfg_attr(not(feature = "force-exhaustive-all"), non_exhaustive)]
 // Combine with YdbStatusError?
 pub struct YdbIssue {
+    /// Numeric code of the issue, as reported by the server
+    ///
+    /// A low level diagnostic value. It is more stable than the message, but
+    /// nothing guarantees that a given scenario keeps reporting a given code,
+    /// so do not build logic on it - use
+    /// [`YdbStatusError::operation_status`] for that.
     pub issue_code: u32,
+
+    /// Human readable description of the issue
     pub message: String,
 
     /// Recursive issues, explained current problems

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -49,14 +49,17 @@ pub(crate) mod client_topic;
 pub(crate) mod connection_pool;
 mod credentials;
 pub(crate) mod discovery;
+#[deny(missing_docs)]
 mod errors;
 mod grpc;
 pub(crate) mod grpc_connection_manager;
 mod grpc_options;
 mod grpc_wrapper;
 mod load_balancer;
+#[deny(missing_docs)]
 mod pub_traits;
 pub(crate) mod query;
+#[deny(missing_docs)]
 pub(crate) mod result;
 mod retry_settings;
 mod session;
@@ -92,6 +95,7 @@ pub mod traces;
 mod trait_operation;
 mod types;
 mod types_converters;
+#[deny(missing_docs)]
 pub(crate) mod waiter;
 
 #[cfg(test)]

--- a/ydb/src/pub_traits.rs
+++ b/ydb/src/pub_traits.rs
@@ -6,6 +6,10 @@ use std::time::{Duration, Instant};
 
 pub(crate) const DEFAULT_TOKEN_RENEW_INTERVAL: Duration = Duration::from_secs(3600); // 1 hour
 
+/// An auth token together with the moment it should be renewed
+///
+/// Returned by [`Credentials::create_token`]. The SDK caches the token and
+/// refreshes it in background once `next_renew` passes.
 #[derive(Debug, Clone)]
 pub struct TokenInfo {
     pub(crate) token: SecretString,
@@ -26,16 +30,27 @@ impl TokenInfo {
     }
 }
 
+/// Source of auth tokens for the driver
+///
+/// Implement it to plug a custom auth scheme into
+/// [`ClientBuilder::with_credentials`](crate::ClientBuilder::with_credentials).
+/// The SDK ships implementations for static tokens, user/password, external
+/// commands and cloud metadata services - see the crate root for the full list.
 pub trait Credentials: Send + Sync {
-    // may not cache result and can block for some time (command execute, network request)
-    // if always called from thread, available to block
-    // successfully result will cache until TokenInfo.next_renew,
-    // then create_token called in background.
-    // cached token will use until successfully return again
-    // and TokenInfo.next_renew reserve until token expire for renew it
-    // and for retry errors
+    /// Produce a fresh token
+    ///
+    /// The implementation may block (spawn a command, make a network request);
+    /// it is called from a thread where blocking is allowed.
+    ///
+    /// A successful result is cached until the returned renewal deadline, after
+    /// which `create_token` is called again in background. While renewal keeps
+    /// failing the previously cached token stays in use, so `next_renew`
+    /// should leave room before the real expiration for retries.
     fn create_token(&self) -> YdbResult<TokenInfo>;
 
+    /// Short description used in logs and in the `Debug` output
+    ///
+    /// Must not leak the token itself.
     fn debug_string(&self) -> String {
         "some credentials".to_string()
     }

--- a/ydb/src/result.rs
+++ b/ydb/src/result.rs
@@ -7,6 +7,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec::IntoIter;
 
+/// One result set of a query - a column schema plus the rows that match it
+///
+/// A single query can return several result sets; see
+/// [`QueryStream`](crate::QueryStream) for reading them one by one, or
+/// [`QueryClient::query_result_set`](crate::QueryClient::query_result_set)
+/// when exactly one is expected.
 #[derive(Debug, Default)]
 pub struct ResultSet {
     columns: Vec<crate::types::Column>,
@@ -20,6 +26,7 @@ impl ResultSet {
         &self.columns
     }
 
+    /// Consume the result set and iterate over its rows
     pub fn rows(self) -> ResultSetRowsIter {
         ResultSetRowsIter {
             columns: Arc::new(self.columns),
@@ -28,6 +35,9 @@ impl ResultSet {
         }
     }
 
+    /// Whether the server cut the result set off at its row limit
+    ///
+    /// When `true`, more rows matched the query than were returned.
     #[allow(dead_code)]
     pub fn is_truncated(&self) -> bool {
         self.raw_result_set.truncated
@@ -65,6 +75,11 @@ impl IntoIterator for ResultSet {
     }
 }
 
+/// A single row of a [`ResultSet`]
+///
+/// Fields are taken out of the row by name or by index. Each field can be
+/// removed only once, which lets the row hand out owned [`Value`]s without
+/// cloning.
 #[derive(Debug)]
 pub struct Row {
     columns: Arc<Vec<crate::types::Column>>,
@@ -73,6 +88,10 @@ pub struct Row {
 }
 
 impl Row {
+    /// Take a field out of the row by column name
+    ///
+    /// Returns an error if there is no such column, or if the field was
+    /// already removed.
     pub fn remove_field_by_name(&mut self, name: &str) -> errors::YdbResult<Value> {
         if let Some(&index) = self.columns_by_name.get(name) {
             return self.remove_field(index);
@@ -80,6 +99,10 @@ impl Row {
         Err(YdbError::Custom("field not found".into()))
     }
 
+    /// Take a field out of the row by zero-based column index
+    ///
+    /// Returns an error if the index is out of range, or if the field was
+    /// already removed.
     pub fn remove_field(&mut self, index: usize) -> errors::YdbResult<Value> {
         match self.raw_values.remove(&index) {
             Some(val) => Ok(Value::try_from(RawTypedValue {
@@ -91,6 +114,7 @@ impl Row {
     }
 }
 
+/// Iterator over the rows of a [`ResultSet`], created by [`ResultSet::rows`]
 pub struct ResultSetRowsIter {
     columns: Arc<Vec<crate::types::Column>>,
     columns_by_name: Arc<HashMap<String, usize>>,

--- a/ydb/src/waiter.rs
+++ b/ydb/src/waiter.rs
@@ -3,8 +3,17 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::watch;
 
+/// Something that becomes ready asynchronously
+///
+/// Implemented by the driver background components - the token cache,
+/// discovery and the load balancers. The driver awaits all of them while
+/// connecting, so the first request does not race initialization.
 #[async_trait::async_trait]
 pub trait Waiter: Send + Sync {
+    /// Wait until ready
+    ///
+    /// Implementations return immediately once readiness has been reached at
+    /// least once, and return an error if the component failed to become ready.
     async fn wait(&self) -> YdbResult<()>;
 }
 


### PR DESCRIPTION
## Problem

Building with `-W missing_docs` reports **497** undocumented public items, spread across most
modules. docs.rs therefore shows bare signatures for the types a user meets on their first query.

## Change

Document the core surface and make it non-regressable:

- **`errors.rs`** — `YdbOrCustomerError::to_ydb_error`, the five `YdbIssueSeverity` variants, the
  `YdbIssue` `issue_code`/`message` fields.
- **`result.rs`** — `ResultSet` with `rows`/`is_truncated`, `Row` with both `remove_field*`
  methods, `ResultSetRowsIter`.
- **`pub_traits.rs`** — `TokenInfo`, `Credentials` and both trait methods.
- **`waiter.rs`** — `Waiter` and `Waiter::wait`.

Then `#[deny(missing_docs)]` on those four module declarations in `lib.rs`, so the documented
surface cannot regress.

Where an item already carried implementation notes as plain `//` comments — `create_token`
(caching, background renewal, behaviour while renewal keeps failing) and `YdbIssueSeverity::Unknown`
(use for logs only, ask a maintainer to add the level) — those notes *become* the rustdoc rather
than being duplicated beside it. They were invisible on docs.rs before.

Per review, `issue_code` and the severity levels are documented as diagnostics rather than as
something to branch on: the code is more stable than the message but is not guaranteed per
scenario, and the SDK itself never reads `severity` — so neither replaces
`YdbStatusError::operation_status` in caller logic, and `Fatal` and `Error` are not presented as
if the SDK distinguished them.

That covers 21 of the 497 items. The other modules stay unguarded and can be converted one at a
time by the same pattern — the largest remaining are `client_topic/list_types.rs` (72 items),
`client_topic/client.rs` (46) and `table_requests.rs` (41).

## Verification

- `-W missing_docs` goes from 497 warnings to **476**, with **0** left in the four guarded
  modules.
- The guard bites: deleting one doc comment fails the build with
  `error: missing documentation for a method`.
- No new broken intra-doc links. `cargo doc -p ydb --no-deps` reports 24 warnings, all
  pre-existing and all in other modules (14 in `client_query/builders.rs`); none in the four
  touched files.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc
  -- -D warnings`, `cargo test --workspace` (383 passed, 92 ignored) and `cargo test --doc -p ydb`
  (31 passed) all pass.

Rebased onto current `master`.
