### PR TITLE
dev: replace unmaintained derivative crate with manual impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,17 +493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,7 +3926,6 @@ dependencies = [
  "bon",
  "chrono",
  "decimal-rs",
- "derivative",
  "derive_builder",
  "flate2",
  "futures-util",

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -29,7 +29,6 @@ chrono = { version = "0.4", default-features = false, features = [
     "serde",
 ] }
 decimal-rs = { version = "0.1", features = ["serde"] }
-derivative = "2"
 bon = "3"
 derive_builder = "0.12.0"
 futures-util = "0.3"

--- a/ydb/src/connection_pool.rs
+++ b/ydb/src/connection_pool.rs
@@ -1,11 +1,11 @@
 use crate::{GrpcOptions, YdbError, YdbResult};
-use derivative::Derivative;
 use futures_util::FutureExt;
 use futures_util::stream::FuturesUnordered;
 use http::Uri;
 use http::uri::{Authority, Scheme};
 use itertools::Either;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::{Debug, Formatter};
 use std::net::IpAddr;
 use std::sync::Arc;
 use std::task::Poll;
@@ -92,16 +92,22 @@ pub(crate) struct RacyRoundRobin {
     state: tokio::sync::Mutex<RacyRoundRobinState>,
 }
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 struct RacyRoundRobinState {
     addrs: HashSet<IpAddr>,
 
-    #[derivative(Debug = "ignore")]
     connections: VecDeque<ConnectionTask>,
     first_connection: ReadyConnection,
-    #[derivative(Debug = "ignore")]
     tried_connections: VecDeque<ConnectionTask>,
+}
+
+impl Debug for RacyRoundRobinState {
+    // The connection queues are skipped: `ConnectionTask` is not `Debug`.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RacyRoundRobinState")
+            .field("addrs", &self.addrs)
+            .field("first_connection", &self.first_connection)
+            .finish()
+    }
 }
 
 type ConnectionTask = Either<PendingConnection, ReadyConnection>;

--- a/ydb/src/connection_pool.rs
+++ b/ydb/src/connection_pool.rs
@@ -387,3 +387,45 @@ mod tests {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod racy_round_robin_state_tests {
+    use super::*;
+
+    /// `Debug` is hand-written because `ConnectionTask` is not `Debug`. Pin the
+    /// fields it reports, and that the two queues stay out of the output.
+    #[tokio::test]
+    async fn debug_reports_addrs_without_connection_queues() {
+        let addr: IpAddr = "127.0.0.1".parse().expect("valid address");
+        // `connect_lazy` does not touch the network.
+        let channel = Endpoint::from_static("http://127.0.0.1:2136").connect_lazy();
+
+        let state = RacyRoundRobinState {
+            addrs: HashSet::from([addr]),
+            connections: VecDeque::new(),
+            first_connection: (channel, addr),
+            tried_connections: VecDeque::new(),
+        };
+
+        let rendered = format!("{state:?}");
+
+        assert!(
+            rendered.starts_with("RacyRoundRobinState {"),
+            "unexpected shape: {rendered}"
+        );
+        assert!(rendered.contains("addrs"), "addrs missing: {rendered}");
+        assert!(
+            rendered.contains("127.0.0.1"),
+            "address missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("first_connection"),
+            "first_connection missing: {rendered}"
+        );
+
+        assert!(
+            !rendered.contains("tried_connections"),
+            "tried_connections must stay out of Debug: {rendered}"
+        );
+    }
+}

--- a/ydb/src/grpc_connection_manager.rs
+++ b/ydb/src/grpc_connection_manager.rs
@@ -6,8 +6,8 @@ use crate::grpc_wrapper::raw_services::{GrpcServiceForDiscovery, Service};
 use crate::grpc_wrapper::runtime_interceptors::{InterceptedChannel, MultiInterceptor};
 use crate::load_balancer::{LoadBalancer, SharedLoadBalancer};
 use crate::{GrpcOptions, YdbResult};
-use derivative::Derivative;
 use http::Uri;
+use std::fmt::{Debug, Formatter};
 use tracing::instrument;
 
 pub(crate) type GrpcConnectionManager = GrpcConnectionManagerGeneric<SharedLoadBalancer, Simple>;
@@ -17,15 +17,42 @@ pub(crate) type DiscoveryConnectionManager =
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct NoBalancer;
 
-#[derive(Derivative)]
-#[derivative(Clone(bound = "BalancerT: Clone"), Debug)]
 pub(crate) struct GrpcConnectionManagerGeneric<BalancerT, ConnectionT: Connection> {
     balancer: BalancerT,
     connections_pool: Arc<ConnectionPool<ConnectionT>>,
-    #[derivative(Debug = "ignore")]
     interceptor: MultiInterceptor,
     database: String,
     opts: GrpcOptions,
+}
+
+// `ConnectionT` is behind an `Arc`, so cloning does not require it to be
+// `Clone` - only the balancer does.
+impl<BalancerT: Clone, ConnectionT: Connection> Clone
+    for GrpcConnectionManagerGeneric<BalancerT, ConnectionT>
+{
+    fn clone(&self) -> Self {
+        Self {
+            balancer: self.balancer.clone(),
+            connections_pool: self.connections_pool.clone(),
+            interceptor: self.interceptor.clone(),
+            database: self.database.clone(),
+            opts: self.opts.clone(),
+        }
+    }
+}
+
+impl<BalancerT: Debug, ConnectionT: Connection + Debug> Debug
+    for GrpcConnectionManagerGeneric<BalancerT, ConnectionT>
+{
+    // `interceptor` is skipped: `MultiInterceptor` is not `Debug`.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GrpcConnectionManagerGeneric")
+            .field("balancer", &self.balancer)
+            .field("connections_pool", &self.connections_pool)
+            .field("database", &self.database)
+            .field("opts", &self.opts)
+            .finish()
+    }
 }
 
 impl<BalancerT, ConnectionT: Connection> GrpcConnectionManagerGeneric<BalancerT, ConnectionT> {

--- a/ydb/src/grpc_connection_manager.rs
+++ b/ydb/src/grpc_connection_manager.rs
@@ -119,3 +119,82 @@ impl<BalancerT, ConnectionT: Connection> GrpcConnectionManagerGeneric<BalancerT,
         self.opts.max_message_size
     }
 }
+
+#[cfg(test)]
+mod manager_derive_tests {
+    use super::*;
+    use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
+
+    fn discovery_manager() -> DiscoveryConnectionManager {
+        GrpcConnectionManagerGeneric::new(
+            NoBalancer,
+            "test-database".to_string(),
+            MultiInterceptor::new(),
+            GrpcOptions::default(),
+        )
+    }
+
+    /// `Debug` is hand-written because `MultiInterceptor` is not `Debug`. Pin
+    /// the fields it reports, and that the interceptor stays out of the output.
+    #[test]
+    fn debug_reports_configuration_without_interceptor() {
+        let rendered = format!("{:?}", discovery_manager());
+
+        assert!(
+            rendered.starts_with("GrpcConnectionManagerGeneric {"),
+            "unexpected shape: {rendered}"
+        );
+        assert!(
+            rendered.contains("test-database"),
+            "database missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("balancer"),
+            "balancer missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("connections_pool"),
+            "connections_pool missing: {rendered}"
+        );
+
+        assert!(
+            !rendered.contains("interceptor"),
+            "interceptor must stay out of Debug: {rendered}"
+        );
+    }
+
+    /// `Clone` is bound on `BalancerT` only - the connection pool sits behind an
+    /// `Arc`, so a non-`Clone` `ConnectionT` must not block cloning, and clones
+    /// must keep sharing the same pool.
+    #[test]
+    fn clone_shares_the_connection_pool() {
+        let manager = discovery_manager();
+        let clone = manager.clone();
+
+        assert!(Arc::ptr_eq(
+            &manager.connections_pool,
+            &clone.connections_pool
+        ));
+        assert_eq!(manager.database, clone.database);
+    }
+
+    /// The same `Clone` bound has to hold for the balancer used in production.
+    #[test]
+    fn clone_works_for_the_shared_balancer_manager() {
+        let manager = GrpcConnectionManager::new(
+            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
+                Uri::from_static("http://127.0.0.1:2136/local"),
+            ))),
+            "local".to_string(),
+            MultiInterceptor::new(),
+            GrpcOptions::default(),
+        );
+
+        let clone = manager.clone();
+
+        assert!(Arc::ptr_eq(
+            &manager.connections_pool,
+            &clone.connections_pool
+        ));
+    }
+}


### PR DESCRIPTION
## Problem

`derivative` is flagged unmaintained by [RUSTSEC-2024-0388](https://rustsec.org/advisories/RUSTSEC-2024-0388) (upstream is no longer maintained; the advisory suggests `derive_more`, `derive-where` or `educe`). Every `cargo audit` run against a project depending on `ydb` reports it.

## Change

It was used for one thing: derive `Debug` while skipping fields that are not `Debug` themselves. Each use becomes a hand-written impl listing the remaining fields, which produces identical output, and the dependency is dropped.

| Type | Skipped fields |
|---|---|
| `RacyRoundRobinState` | both `ConnectionTask` queues |
| `GrpcConnectionManagerGeneric` | `interceptor` |

`GrpcConnectionManagerGeneric` also used `derivative(Clone(bound = "BalancerT: Clone"))`, so its `Clone` becomes a manual impl too, preserving the balancer-only bound — `ConnectionT` sits behind an `Arc` and does not need `Clone`. Its `Debug` keeps the `ConnectionT: Debug` bound that `derivative` generated implicitly.

No behaviour change: `derivative`'s `Debug = "ignore"` omits the field entirely, which is what `debug_struct(..).field(..).finish()` emits.

A third use, on `TableSession`, was in the branch when it was opened. `master` has since removed that struct's non-`Debug` fields in the query/table session refactor (#621), so after the rebase there is nothing left to convert there.

## Tests

`derivative(Debug = "ignore")` enforced the skipped fields structurally; a hand-written `debug_struct` chain can silently start or stop reporting a field. Nothing in the suite formatted either type before, so each now has a test pinning both halves of the contract: the fields that must appear, and the non-`Debug` fields that must not. Two further tests pin the `BalancerT: Clone`-only bound and that clones keep sharing one pool.

## Verification

```
cargo tree -p ydb -e normal -i derivative
#   error: package ID specification `derivative` did not match any packages
cargo fmt --check
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace     # 385 passed, 0 failed, 92 ignored
```

Integration tests (`#[ignore]`, need `YDB_CONNECTION_STRING`) were not run.

The `Cargo.lock` diff is exactly the removal of `derivative 2.2.0` — no incidental version bumps.
