### PR TITLE
fix: register coordination response waiter before dispatching the request

### DIFF
--- a/ydb/src/client_coordination/session/controller.rs
+++ b/ydb/src/client_coordination/session/controller.rs
@@ -41,15 +41,17 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
         ) = tokio::sync::mpsc::unbounded_channel();
 
         req.set_id(curr_id);
-        self.messages_sender
+        self.active_requests.lock().await.insert(curr_id, tx);
+
+        if self
+            .messages_sender
             .send(SessionRequest {
                 request: Some(req.into()),
             })
-            .map_err(|_| YdbError::Custom("can't send".to_string()))?;
-
+            .is_err()
         {
-            let mut active_requests = self.active_requests.lock().await;
-            active_requests.insert(curr_id, tx);
+            self.active_requests.lock().await.remove(&curr_id);
+            return Err(YdbError::Custom("can't send".to_string()));
         }
 
         Ok(rx)
@@ -68,5 +70,66 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
             }
         };
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::grpc_wrapper::raw_coordination_service::session::create_semaphore::{
+        RawCreateSemaphoreRequest, RawCreateSemaphoreResult,
+    };
+
+    #[tokio::test]
+    async fn registers_waiter_before_dispatching_request() {
+        let (messages_tx, mut messages_rx) = mpsc::unbounded_channel();
+        let controller = Arc::new(RequestController::<RawCreateSemaphoreResult>::new(
+            messages_tx,
+        ));
+
+        let registration_lock = controller.active_requests.lock().await;
+        let send_controller = controller.clone();
+        let send_task = tokio::spawn(async move {
+            send_controller
+                .send(RawCreateSemaphoreRequest::new(
+                    "semaphore".to_string(),
+                    1,
+                    Vec::new(),
+                ))
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(50), messages_rx.recv())
+                .await
+                .is_err(),
+            "request was dispatched before its response waiter was registered"
+        );
+
+        drop(registration_lock);
+
+        let mut response_rx = send_task
+            .await
+            .expect("send task should not panic")
+            .expect("request should be accepted");
+        let message = messages_rx
+            .recv()
+            .await
+            .expect("registered request should be dispatched");
+        let req_id = match message.request {
+            Some(session_request::Request::CreateSemaphore(request)) => request.req_id,
+            other => panic!("unexpected request: {other:?}"),
+        };
+
+        controller
+            .get_response(RawCreateSemaphoreResult { req_id })
+            .await
+            .expect("response should be routed to its waiter");
+        assert!(response_rx.recv().await.is_some());
     }
 }


### PR DESCRIPTION
## Problem

`RequestController::send` dispatched a coordination request to the stream **before** registering the waiter that receives its response:

```rust
self.messages_sender.send(SessionRequest { .. })?;   // request goes out
{
    let mut active_requests = self.active_requests.lock().await;
    active_requests.insert(curr_id, tx);             // waiter registered after
}
```

If the server answers between those two steps, `get_response` looks up `active_requests`, finds no entry for the id, and drops the response. The caller then waits on a channel nothing will ever send to.

A second, smaller issue: when the send itself failed, the id was consumed and the error returned, but on the reordered path an already-inserted waiter would be left behind.

## Change

Register the waiter first, then send. If the send fails, remove the waiter again before returning the error, so a failed dispatch leaves no orphan entry in `active_requests`.

## Test

`registers_waiter_before_dispatching_request` holds the `active_requests` lock, starts a `send`, and asserts nothing reaches the message channel while the lock is held — i.e. dispatch cannot outrun registration. It then releases the lock and checks the request is dispatched and its response routed back to the caller.

## Verification

```
cargo fmt --check
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace     # 215 passed, 88 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
