### PR TITLE
fix: wake coordination waiters when the session stream fails

### DIFF
--- a/ydb/src/client_coordination/session/controller.rs
+++ b/ydb/src/client_coordination/session/controller.rs
@@ -16,6 +16,7 @@ pub trait IdentifiedMessage {
 
 pub struct RequestController<Response: IdentifiedMessage> {
     last_req_id: atomic::AtomicU64,
+    closed: atomic::AtomicBool,
     messages_sender: mpsc::UnboundedSender<SessionRequest>,
     active_requests: Arc<Mutex<HashMap<u64, tokio::sync::mpsc::UnboundedSender<Response>>>>,
 }
@@ -24,6 +25,7 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
     pub fn new(messages_sender: mpsc::UnboundedSender<SessionRequest>) -> Self {
         Self {
             last_req_id: atomic::AtomicU64::new(0),
+            closed: atomic::AtomicBool::new(false),
             messages_sender,
             active_requests: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -33,6 +35,12 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
         &self,
         mut req: Request,
     ) -> YdbResult<tokio::sync::mpsc::UnboundedReceiver<Response>> {
+        if self.closed.load(atomic::Ordering::Acquire) {
+            return Err(YdbError::Custom(
+                "coordination session is closed".to_string(),
+            ));
+        }
+
         let curr_id = self.last_req_id.fetch_add(1, atomic::Ordering::AcqRel);
 
         let (tx, rx): (
@@ -41,7 +49,14 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
         ) = tokio::sync::mpsc::unbounded_channel();
 
         req.set_id(curr_id);
-        self.active_requests.lock().await.insert(curr_id, tx);
+        let mut active_requests = self.active_requests.lock().await;
+        if self.closed.load(atomic::Ordering::Acquire) {
+            return Err(YdbError::Custom(
+                "coordination session is closed".to_string(),
+            ));
+        }
+        active_requests.insert(curr_id, tx);
+        drop(active_requests);
 
         if self
             .messages_sender
@@ -55,6 +70,11 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
         }
 
         Ok(rx)
+    }
+
+    pub async fn close(&self) {
+        self.closed.store(true, atomic::Ordering::Release);
+        self.active_requests.lock().await.clear();
     }
 
     pub async fn get_response(&self, response: Response) -> YdbResult<()> {
@@ -131,5 +151,39 @@ mod tests {
             .await
             .expect("response should be routed to its waiter");
         assert!(response_rx.recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn closing_controller_unblocks_in_flight_request() {
+        let (messages_tx, _messages_rx) = mpsc::unbounded_channel();
+        let controller = RequestController::<RawCreateSemaphoreResult>::new(messages_tx);
+
+        let mut response_rx = controller
+            .send(RawCreateSemaphoreRequest::new(
+                "semaphore".to_string(),
+                1,
+                Vec::new(),
+            ))
+            .await
+            .expect("request should be accepted before close");
+
+        controller.close().await;
+
+        assert!(
+            timeout(Duration::from_millis(50), response_rx.recv())
+                .await
+                .expect("closing the controller should wake in-flight callers")
+                .is_none()
+        );
+        assert!(
+            controller
+                .send(RawCreateSemaphoreRequest::new(
+                    "semaphore".to_string(),
+                    1,
+                    Vec::new(),
+                ))
+                .await
+                .is_err()
+        );
     }
 }

--- a/ydb/src/client_coordination/session/controller.rs
+++ b/ydb/src/client_coordination/session/controller.rs
@@ -41,15 +41,17 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
         ) = tokio::sync::mpsc::unbounded_channel();
 
         req.set_id(curr_id);
-        self.messages_sender
+        self.active_requests.lock().await.insert(curr_id, tx);
+
+        if self
+            .messages_sender
             .send(SessionRequest {
                 request: Some(req.into()),
             })
-            .map_err(|_| YdbError::Custom("can't send".to_string()))?;
-
+            .is_err()
         {
-            let mut active_requests = self.active_requests.lock().await;
-            active_requests.insert(curr_id, tx);
+            self.active_requests.lock().await.remove(&curr_id);
+            return Err(YdbError::Custom("can't send".to_string()));
         }
 
         Ok(rx)
@@ -68,5 +70,66 @@ impl<Response: IdentifiedMessage> RequestController<Response> {
             }
         };
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::grpc_wrapper::raw_coordination_service::session::create_semaphore::{
+        RawCreateSemaphoreRequest, RawCreateSemaphoreResult,
+    };
+
+    #[tokio::test]
+    async fn registers_waiter_before_dispatching_request() {
+        let (messages_tx, mut messages_rx) = mpsc::unbounded_channel();
+        let controller = Arc::new(RequestController::<RawCreateSemaphoreResult>::new(
+            messages_tx,
+        ));
+
+        let registration_lock = controller.active_requests.lock().await;
+        let send_controller = controller.clone();
+        let send_task = tokio::spawn(async move {
+            send_controller
+                .send(RawCreateSemaphoreRequest::new(
+                    "semaphore".to_string(),
+                    1,
+                    Vec::new(),
+                ))
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(50), messages_rx.recv())
+                .await
+                .is_err(),
+            "request was dispatched before its response waiter was registered"
+        );
+
+        drop(registration_lock);
+
+        let mut response_rx = send_task
+            .await
+            .expect("send task should not panic")
+            .expect("request should be accepted");
+        let message = messages_rx
+            .recv()
+            .await
+            .expect("registered request should be dispatched");
+        let req_id = match message.request {
+            Some(session_request::Request::CreateSemaphore(request)) => request.req_id,
+            other => panic!("unexpected request: {other:?}"),
+        };
+
+        controller
+            .get_response(RawCreateSemaphoreResult { req_id })
+            .await
+            .expect("response should be routed to its waiter");
+        assert!(response_rx.recv().await.is_some());
     }
 }

--- a/ydb/src/client_coordination/session/coordination_session.rs
+++ b/ydb/src/client_coordination/session/coordination_session.rs
@@ -46,6 +46,17 @@ struct MethodControllers {
     release_semaphore: Arc<RequestController<RawReleaseSemaphoreResult>>,
 }
 
+impl MethodControllers {
+    async fn close(&self) {
+        self.create_semaphore.close().await;
+        self.describe_semaphore.close().await;
+        self.acquire_semaphore.close().await;
+        self.update_semaphore.close().await;
+        self.delete_semaphore.close().await;
+        self.release_semaphore.close().await;
+    }
+}
+
 #[allow(dead_code)]
 pub struct CoordinationSession {
     id: u64,
@@ -128,6 +139,7 @@ impl CoordinationSession {
                 {
                     Ok(()) => {}
                     Err(_iteration_error) => {
+                        loop_controllers.close().await;
                         loop_token.cancel();
                         return;
                     }
@@ -276,7 +288,9 @@ impl CoordinationSession {
                 options.data,
             ))
             .await?;
-        let response = rx.recv().await.unwrap();
+        let response = rx.recv().await.ok_or_else(|| {
+            YdbError::Custom("coordination session closed while acquiring semaphore".to_string())
+        })?;
         if response.acquired {
             Ok(Lease::new(
                 self.method_controllers.release_semaphore.clone(),


### PR DESCRIPTION
> **Stacked on the request-registration fix.** This branch contains that commit as well, so the diff below shows both. Please merge that one first; this PR then reduces to its own commit. I could not set it as the base because it does not exist in this repository yet.

## Problem

When a coordination session's stream failed, the loop cancelled its token and returned — but nothing told the callers already waiting on a response. Their entries stayed in `active_requests`, holding a sender that would never be used, so `rx.recv()` never resolved. A caller blocked in `acquire_semaphore` during a disconnect waits forever.

`acquire_semaphore` also did:

```rust
let response = rx.recv().await.unwrap();
```

So in the one case where the channel *did* close, the caller panicked instead of getting an error.

## Change

- `RequestController::close` marks the controller closed and clears `active_requests`. Dropping the senders resolves every waiting `recv()` with `None`, so blocked callers wake up.
- `send` refuses new requests on a closed controller. The `closed` flag is checked once up front and again under the `active_requests` lock, so a `close` racing an in-flight `send` cannot leave a waiter behind after the map was cleared.
- `MethodControllers::close` fans this out across all six per-method controllers, and the session loop calls it on stream failure before cancelling its token.
- `acquire_semaphore` maps the closed channel to an error instead of unwrapping it.

## Test

`closing_controller_unblocks_in_flight_request` registers a request, closes the controller, and asserts the caller's `recv()` completes with `None` inside 50 ms rather than hanging, and that subsequent sends are rejected.

## Verification

```
cargo fmt --check
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace     # 216 passed, 88 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
