### PR TITLE
fix: add backpressure and cancellation to the topic writer pipeline

### DIFF
--- a/ydb/src/client_topic/compression/compression_worker.rs
+++ b/ydb/src/client_topic/compression/compression_worker.rs
@@ -7,12 +7,13 @@ use crate::{YdbError, YdbResult};
 use std::{num::NonZeroUsize, sync::Arc};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 use ydb_grpc::ydb_proto::topic::stream_write_message::WriteRequest;
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
 type ChunkResult = YdbResult<WriteRequest>;
-type InputRx = mpsc::UnboundedReceiver<Vec<MessageData>>;
-type OutputTx = mpsc::UnboundedSender<ChunkResult>;
+type InputRx = mpsc::Receiver<Vec<MessageData>>;
+type OutputTx = mpsc::Sender<ChunkResult>;
 
 pub(crate) struct CompressionWorker {
     codec_selector: CodecSelector,
@@ -48,7 +49,13 @@ impl CompressionWorker {
         })
     }
 
-    pub(crate) fn spawn_into(self, tasks: &mut JoinSet<()>, mut rx: InputRx, tx: OutputTx) {
+    pub(crate) fn spawn_into(
+        self,
+        tasks: &mut JoinSet<()>,
+        mut rx: InputRx,
+        tx: OutputTx,
+        cancellation_token: CancellationToken,
+    ) {
         let CompressionWorker {
             mut codec_selector,
             codec_registry,
@@ -57,9 +64,20 @@ impl CompressionWorker {
             parallelism,
         } = self;
 
+        let schedule_cancellation = cancellation_token.clone();
         tasks.spawn(async move {
-            while let Some(mut batch) = rx.recv().await {
-                codec_selector.step(&batch).await;
+            loop {
+                let Some(mut batch) = (tokio::select! {
+                    _ = schedule_cancellation.cancelled() => return,
+                    batch = rx.recv() => batch,
+                }) else {
+                    return;
+                };
+
+                tokio::select! {
+                    _ = schedule_cancellation.cancelled() => return,
+                    _ = codec_selector.step(&batch) => {}
+                }
                 let codec = codec_selector.codec();
                 let chunk_size =
                     (batch.len() / parallelism).clamp(1, super::MAX_MESSAGES_PER_CHUNK);
@@ -70,21 +88,36 @@ impl CompressionWorker {
 
                     let registry = codec_registry.clone();
 
-                    queue
-                        .submit(Box::new(move || compress_batch(chunk, codec, registry)))
-                        .await;
+                    tokio::select! {
+                        _ = schedule_cancellation.cancelled() => return,
+                        _ = queue.submit(Box::new(move || compress_batch(chunk, codec, registry))) => {}
+                    }
                 }
             }
         });
 
         tasks.spawn(async move {
-            while let Some(result_tx) = results_rx.recv().await {
-                let result = result_tx
-                    .await
-                    .unwrap_or(Err(YdbError::custom("executor compression task panicked")));
+            loop {
+                let Some(result_rx) = (tokio::select! {
+                    _ = cancellation_token.cancelled() => return,
+                    result_rx = results_rx.recv() => result_rx,
+                }) else {
+                    return;
+                };
 
-                if tx.send(result).is_err() {
-                    break;
+                let result = tokio::select! {
+                    _ = cancellation_token.cancelled() => return,
+                    result = result_rx => result.unwrap_or(Err(YdbError::custom(
+                        "executor compression task panicked",
+                    ))),
+                };
+
+                let sent = tokio::select! {
+                    _ = cancellation_token.cancelled() => return,
+                    sent = tx.send(result) => sent,
+                };
+                if sent.is_err() {
+                    return;
                 }
             }
         });
@@ -119,4 +152,92 @@ fn compress_batch(
         codec: codec.code,
         tx: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::client_topic::compression::Executor;
+
+    struct HoldingExecutor {
+        tasks: Mutex<Vec<Box<dyn FnOnce() + Send + 'static>>>,
+    }
+
+    impl HoldingExecutor {
+        fn new() -> Self {
+            Self {
+                tasks: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn task_count(&self) -> usize {
+            self.tasks.lock().expect("holding executor lock").len()
+        }
+    }
+
+    impl Executor for HoldingExecutor {
+        fn available_parallelism(&self) -> NonZeroUsize {
+            NonZeroUsize::MIN
+        }
+
+        fn spawn(&self, task: Box<dyn FnOnce() + Send + 'static>) {
+            self.tasks.lock().expect("holding executor lock").push(task);
+        }
+    }
+
+    fn message(seq_no: i64) -> MessageData {
+        MessageData {
+            seq_no,
+            created_at: None,
+            data: Vec::new(),
+            uncompressed_size: 0,
+            metadata_items: Vec::new(),
+            partitioning: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_scheduler_waiting_for_a_worker_slot() {
+        let executor = Arc::new(HoldingExecutor::new());
+        let worker = CompressionWorker::new(
+            CodecSelection::Fixed(Codec::RAW),
+            Arc::new(CodecRegistry::new()),
+            executor.clone(),
+            vec![Codec::RAW],
+        )
+        .expect("raw codec should be supported");
+        let (input_tx, input_rx) = mpsc::channel(2);
+        let (output_tx, _output_rx) = mpsc::channel(1);
+        let cancellation = CancellationToken::new();
+        let mut tasks = JoinSet::new();
+
+        worker.spawn_into(&mut tasks, input_rx, output_tx, cancellation.clone());
+        input_tx
+            .send(vec![message(1)])
+            .await
+            .expect("worker input should be open");
+        input_tx
+            .send(vec![message(2)])
+            .await
+            .expect("worker input should be open");
+
+        timeout(Duration::from_millis(50), async {
+            while executor.task_count() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first compression task should occupy the only worker slot");
+
+        cancellation.cancel();
+        timeout(Duration::from_millis(50), tasks.join_next())
+            .await
+            .expect("cancellation should stop the compression worker");
+    }
 }

--- a/ydb/src/client_topic/topicwriter/message_queue.rs
+++ b/ydb/src/client_topic/topicwriter/message_queue.rs
@@ -98,6 +98,10 @@ impl MessageQueue {
     pub(crate) fn last_added_seq_no(&self) -> Option<i64> {
         self.last_added_seq_no
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.messages.len() + self.sent_messages.len()
+    }
 }
 
 #[cfg(test)]

--- a/ydb/src/client_topic/topicwriter/queue.rs
+++ b/ydb/src/client_topic/topicwriter/queue.rs
@@ -14,30 +14,52 @@ use crate::client_topic::topicwriter::message_write_status::{
 use crate::client_topic::topicwriter::reception_queue::{ReceptionQueue, ReceptionTicket};
 use crate::{YdbError, YdbResult};
 
+const DEFAULT_MAX_BUFFERED_MESSAGES: usize = 16_000;
+
 #[derive(Clone)]
 pub(crate) struct Queue {
     inner: Arc<Mutex<QueueInner>>,
 
     new_message_added: Arc<Notify>,
+    message_removed_or_closed: Arc<Notify>,
     last_acknowledged_seq_no: Arc<RwLock<Option<i64>>>,
     message_acknowledged: Arc<Notify>,
+    max_buffered_messages: usize,
 }
 
 impl Queue {
     #[cfg(test)]
     pub(crate) fn new() -> Self {
-        Self::new_with_status_validator(
+        Self::new_inner(
             crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+            DEFAULT_MAX_BUFFERED_MESSAGES,
         )
     }
 
     pub(crate) fn new_with_status_validator(status_validator: MessageWriteStatusValidator) -> Self {
+        Self::new_inner(status_validator, DEFAULT_MAX_BUFFERED_MESSAGES)
+    }
+
+    fn new_inner(
+        status_validator: MessageWriteStatusValidator,
+        max_buffered_messages: usize,
+    ) -> Self {
         Self {
             inner: Arc::new(Mutex::new(QueueInner::new(status_validator))),
             new_message_added: Arc::new(Notify::new()),
+            message_removed_or_closed: Arc::new(Notify::new()),
             last_acknowledged_seq_no: Arc::new(RwLock::new(None)),
             message_acknowledged: Arc::new(Notify::new()),
+            max_buffered_messages: max_buffered_messages.max(1),
         }
+    }
+
+    #[cfg(test)]
+    fn new_with_max_buffered_messages(max_buffered_messages: usize) -> Self {
+        Self::new_inner(
+            crate::client_topic::topicwriter::message_write_status::accept_any_write_status,
+            max_buffered_messages,
+        )
     }
 
     pub(crate) async fn add_message(
@@ -45,10 +67,25 @@ impl Queue {
         message: MessageData,
         ack_sender: Option<oneshot::Sender<YdbResult<MessageWriteStatus>>>,
     ) -> YdbResult<()> {
-        let mut inner = self.inner.lock().await;
-        inner.add_message(message, ack_sender)?;
-        self.new_message_added.notify_one();
-        Ok(())
+        loop {
+            let notified = self.message_removed_or_closed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
+                let mut inner = self.inner.lock().await;
+                if !inner.is_open_for_new_messages {
+                    return Err(YdbError::custom("message queue is closed for new messages"));
+                }
+                if inner.message_queue.len() < self.max_buffered_messages {
+                    inner.add_message(message, ack_sender)?;
+                    self.new_message_added.notify_one();
+                    return Ok(());
+                }
+            }
+
+            notified.await;
+        }
     }
 
     pub(crate) async fn acknowledge_message(&self, write_ack: WriteAck) -> YdbResult<()> {
@@ -58,6 +95,7 @@ impl Queue {
 
         *self.last_acknowledged_seq_no.write().await = Some(seq_no);
         self.message_acknowledged.notify_one();
+        self.message_removed_or_closed.notify_one();
 
         Ok(())
     }
@@ -129,12 +167,17 @@ impl Queue {
 
     pub(crate) async fn notify_reception_tickets(&self, error: YdbError) {
         let mut inner = self.inner.lock().await;
+        inner.is_open_for_new_messages = false;
         inner.reception_queue.send_error_to_tickets_and_clear(error);
+        drop(inner);
+        self.message_removed_or_closed.notify_waiters();
     }
 
     pub(crate) async fn close_for_new_messages(&self) {
         let mut inner = self.inner.lock().await;
         inner.is_open_for_new_messages = false;
+        drop(inner);
+        self.message_removed_or_closed.notify_waiters();
     }
 
     pub(crate) async fn reset_progress(&self) {
@@ -248,6 +291,37 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("closed for new messages"));
+    }
+
+    #[tokio::test]
+    async fn add_message_waits_for_capacity_until_an_ack_releases_a_slot() {
+        let q = Arc::new(Queue::new_with_max_buffered_messages(1));
+        q.add_message(create_message(1, vec![]), None)
+            .await
+            .unwrap();
+
+        let q_for_second_message = q.clone();
+        let mut second_message = tokio::spawn(async move {
+            q_for_second_message
+                .add_message(create_message(2, vec![]), None)
+                .await
+        });
+
+        assert!(
+            timeout(Duration::from_millis(20), &mut second_message)
+                .await
+                .is_err(),
+            "queue accepted a second in-flight message despite its capacity"
+        );
+
+        let sent = q.get_messages_to_send(1, Duration::ZERO).await;
+        assert_eq!(sent.len(), 1);
+        q.acknowledge_message(write_ack(1)).await.unwrap();
+
+        second_message
+            .await
+            .unwrap()
+            .expect("acknowledgement should release queue capacity");
     }
 
     #[tokio::test]

--- a/ydb/src/client_topic/topicwriter/stream_writer.rs
+++ b/ydb/src/client_topic/topicwriter/stream_writer.rs
@@ -12,7 +12,9 @@ use ydb_grpc::ydb_proto::topic::stream_write_message::WriteRequest;
 use ydb_grpc::ydb_proto::topic::stream_write_message::from_client::ClientMessage;
 use ydb_grpc::ydb_proto::topic::stream_write_message::write_request::MessageData;
 
-use crate::client_topic::compression::{CodecRegistry, CompressionWorker, Executor};
+use crate::client_topic::compression::{
+    CodecRegistry, CompressionWorker, Executor, OUTPUT_BACKLOG_PER_TASK,
+};
 use crate::client_topic::list_types::Codec;
 use crate::client_topic::topicwriter::message_write_status::WriteAck;
 use crate::client_topic::topicwriter::queue::Queue;
@@ -54,12 +56,17 @@ impl StreamWriter {
         let worker = CompressionWorker::new(
             writer_options.codec_selector,
             Arc::new(codec_registry),
-            executor,
+            executor.clone(),
             server_codecs,
         )?;
 
-        let (batch_tx, batch_rx) = mpsc::unbounded_channel::<Vec<MessageData>>();
-        let (compressed_tx, compressed_rx) = mpsc::unbounded_channel::<YdbResult<WriteRequest>>();
+        let compression_backlog = executor
+            .available_parallelism()
+            .saturating_mul(OUTPUT_BACKLOG_PER_TASK)
+            .get();
+        let (batch_tx, batch_rx) = mpsc::channel::<Vec<MessageData>>(compression_backlog);
+        let (compressed_tx, compressed_rx) =
+            mpsc::channel::<YdbResult<WriteRequest>>(compression_backlog);
 
         let request_stream = stream.clone_sender();
 
@@ -74,7 +81,12 @@ impl StreamWriter {
             batch_tx,
         ));
 
-        worker.spawn_into(&mut tasks, batch_rx, compressed_tx);
+        worker.spawn_into(
+            &mut tasks,
+            batch_rx,
+            compressed_tx,
+            cancellation_token.clone(),
+        );
 
         tasks.spawn(StreamWriter::grpc_send_loop(
             cancellation_token.clone(),
@@ -103,7 +115,7 @@ impl StreamWriter {
         queue: Queue,
         chunk_size: usize,
         period: Duration,
-        batch_tx: mpsc::UnboundedSender<Vec<MessageData>>,
+        batch_tx: mpsc::Sender<Vec<MessageData>>,
     ) {
         loop {
             tokio::select! {
@@ -112,7 +124,11 @@ impl StreamWriter {
                     if messages.is_empty() {
                         continue;
                     }
-                    if batch_tx.send(messages).is_err() {
+                    let batch_sent = tokio::select! {
+                        _ = cancellation_token.cancelled() => return,
+                        result = batch_tx.send(messages) => result,
+                    };
+                    if batch_sent.is_err() {
                         let err = YdbError::custom("compression worker input channel closed");
                         warn!("error sending message in topic writer write_messages_loop: {}", &err);
                         if let Err(send_err) = StreamWriter::loop_iteration_error(cancellation_token, error_tx, err).await {
@@ -128,7 +144,7 @@ impl StreamWriter {
     async fn grpc_send_loop(
         cancellation_token: CancellationToken,
         error_tx: Arc<Mutex<Option<oneshot::Sender<YdbError>>>>,
-        mut compressed_rx: mpsc::UnboundedReceiver<YdbResult<WriteRequest>>,
+        mut compressed_rx: mpsc::Receiver<YdbResult<WriteRequest>>,
         request_stream: mpsc::UnboundedSender<stream_write_message::FromClient>,
         tx_identity: Option<TransactionIdentity>,
     ) {


### PR DESCRIPTION
## Problem

The topic writer pipeline had no backpressure anywhere along its length:

- `Queue::add_message` accepted messages unconditionally.
- The batch channel feeding the compression worker was `mpsc::unbounded_channel`.
- The channel carrying compressed requests back out was unbounded too.

A producer writing faster than the network drains grows all three without limit, so the failure mode is memory exhaustion rather than a slowed-down caller.

Separately, the compression worker's two loops only exited when their channels closed. Nothing observed the writer's `CancellationToken`, so a worker parked on `queue.submit` or on `tx.send` could outlive a cancelled writer.

## Change

**Bound the queue.** `Queue` gains a `max_buffered_messages` cap (16 000 by default, counting queued plus in-flight-to-server messages via a new `MessageQueue::len`). At capacity, `add_message` waits on a `message_removed_or_closed` notifier instead of accepting. Acknowledgements release capacity; `close_for_new_messages` and `notify_reception_tickets` wake every waiter via `notify_waiters` so nobody is stranded when the queue shuts down. The wait re-checks `is_open_for_new_messages`, so a caller blocked on a full queue that then closes gets an error rather than a hang.

**Bound the channels.** Both the batch and compressed-request channels become `mpsc::channel`, sized `available_parallelism() * OUTPUT_BACKLOG_PER_TASK`. Because a bounded `send` can now block, `write_messages_loop` selects it against the cancellation token.

**Make compression cancellable.** Every await in both worker loops — receive, `codec_selector.step`, `queue.submit`, and the output `send` — is selected against the cancellation token, so cancelling the writer stops the worker instead of leaving it parked.

## Tests

- `add_message_waits_for_capacity_until_an_ack_releases_a_slot` fills a queue of capacity 1, asserts a second `add_message` does not complete, then acknowledges the first and asserts the second is admitted.
- `cancellation_stops_scheduler_waiting_for_a_worker_slot` uses a `HoldingExecutor` that never runs the work it is handed, so the scheduler blocks on the single worker slot; cancelling must still unwind the task within 50 ms.

## Note for reviewers

16 000 is a default with no configuration knob attached. If it should be reachable through `WriterOptions`, or aligned with an existing limit, that is a straightforward follow-up. Related: #565 (TopicWriter `write` MaxInFlight) and #563 (cancellation safety) look adjacent to this work.

## Verification

```
cargo fmt --check
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo test --workspace     # 216 passed, 88 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
