### PR TITLE
feat: add Set container type

### DIFF
--- a/ydb/examples/container-types.rs
+++ b/ydb/examples/container-types.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "256"]
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use tokio::time::timeout;
 use ydb::{ClientBuilder, Value, YdbError, YdbResult, ydb_params};
@@ -47,6 +47,29 @@ async fn main() -> YdbResult<()> {
 
         assert_eq!(source, res);
         println!("Struct: {res:?}");
+    }
+
+    // Set - YDB transfers Set<T> as Dict<T, Void>
+    {
+        let source: HashSet<i32> = HashSet::from([1, 2, 3]);
+
+        let mut row = qc
+            .query_row("SELECT $val AS res")
+            .params(ydb_params!("$val" => source.clone()))
+            .await?;
+        let res: HashSet<i32> = row.remove_field_by_name("res")?.try_into()?;
+
+        assert_eq!(source, res);
+
+        // the server sees a real set, not an opaque value
+        let mut row = qc
+            .query_row("SELECT DictContains($val, 2) AS has")
+            .params(ydb_params!("$val" => source))
+            .await?;
+        let has: bool = row.remove_field_by_name("has")?.try_into()?;
+
+        assert!(has);
+        println!("Set: {res:?}, contains 2: {has}");
     }
 
     println!("done");

--- a/ydb/src/grpc_wrapper/raw_table_service/value/proto.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/proto.rs
@@ -55,6 +55,15 @@ impl TryFrom<ProtoValue> for RawValue {
             return Ok(Pairs(pairs?));
         };
 
+        // An entirely empty `Value` message is how the wire spells both `Void`
+        // and an empty container: `Void` has no representation of its own, and
+        // an empty list/dict carries neither items nor pairs. This decoder has
+        // no type context, so it yields `NullFlag` and lets the type-directed
+        // layer above turn it into the right empty value.
+        if value == ProtoValue::default() {
+            return Ok(NullFlag);
+        }
+
         decode_err("empty value item")
     }
 }
@@ -75,9 +84,19 @@ impl TryFrom<ydb_grpc::ydb_proto::ValuePair> for RawValuePair {
             return decode_err("empty payload value in proto pair");
         };
 
+        // `Void` has no wire representation, so the server sends it as an
+        // entirely empty `Value` message. That is how the payloads of a
+        // `Dict<T, Void>` - i.e. a `Set<T>` - arrive, and the generic value
+        // decoder would reject it as malformed.
+        let payload = if payload == ProtoValue::default() {
+            RawValue::NullFlag
+        } else {
+            payload.try_into()?
+        };
+
         Ok(RawValuePair {
             key: key.try_into()?,
-            payload: payload.try_into()?,
+            payload,
         })
     }
 }

--- a/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb.rs
@@ -9,8 +9,10 @@ use uuid::Uuid;
 
 use super::r#type::DecimalType;
 use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
-use crate::grpc_wrapper::raw_table_service::value::r#type::{RawType, StructMember, StructType};
-use crate::grpc_wrapper::raw_table_service::value::{RawTypedValue, RawValue};
+use crate::grpc_wrapper::raw_table_service::value::r#type::{
+    DictType, RawType, StructMember, StructType,
+};
+use crate::grpc_wrapper::raw_table_service::value::{RawTypedValue, RawValue, RawValuePair};
 use crate::types::YdbDecimal;
 use crate::types::{
     SECONDS_PER_DAY, signed_days_to_system_time, signed_micros_to_system_time,
@@ -187,6 +189,29 @@ impl TryFrom<crate::Value> for RawTypedValue {
                 RawTypedValue {
                     r#type: RawType::List(Box::new(type_example.r#type)),
                     value: RawValue::Items(items_res?.into_iter().map(|item| item.value).collect()),
+                }
+            }
+            // YDB has no wire type for Set: `Set<T>` travels as `Dict<T, Void>`
+            // with a null-flag payload for every key.
+            Value::Set(v) => {
+                let type_example: RawTypedValue = v.t.try_into()?;
+                let items_res: Result<Vec<RawTypedValue>, _> =
+                    v.values.into_iter().map(|item| item.try_into()).collect();
+
+                RawTypedValue {
+                    r#type: RawType::Dict(Box::new(DictType {
+                        key: type_example.r#type,
+                        payload: RawType::Void,
+                    })),
+                    value: RawValue::Pairs(
+                        items_res?
+                            .into_iter()
+                            .map(|item| RawValuePair {
+                                key: item.value,
+                                payload: RawValue::NullFlag,
+                            })
+                            .collect(),
+                    ),
                 }
             }
             Value::Struct(v) => {
@@ -389,6 +414,46 @@ impl TryFrom<RawTypedValue> for Value {
                     Err(err) => {
                         return Err(RawError::custom(format!(
                             "can't create list value from rawtype: {err}"
+                        )));
+                    }
+                }
+            }
+            // `Dict<T, Void>` is how YDB spells `Set<T>`. A dict with any other
+            // payload is a real dict, which the public API does not model yet.
+            (RawType::Dict(dict_type), v) if dict_type.payload == RawType::Void => {
+                let key_type = dict_type.key;
+                let values = match v {
+                    RawValue::NullFlag => Vec::default(),
+                    RawValue::Pairs(pairs) => {
+                        let values_res: Result<Vec<_>, _> = pairs
+                            .into_iter()
+                            .map(|pair| {
+                                RawTypedValue {
+                                    r#type: key_type.clone(),
+                                    value: pair.key,
+                                }
+                                .try_into()
+                            })
+                            .collect();
+
+                        values_res?
+                    }
+                    v => {
+                        return types_mismatch(
+                            RawType::Dict(Box::new(DictType {
+                                key: key_type,
+                                payload: RawType::Void,
+                            })),
+                            v,
+                        );
+                    }
+                };
+                let type_example = key_type.into_value_example()?;
+                match Value::set_from(type_example, values) {
+                    Ok(val) => val,
+                    Err(err) => {
+                        return Err(RawError::custom(format!(
+                            "can't create set value from rawtype: {err}"
                         )));
                     }
                 }

--- a/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb_test.rs
+++ b/ydb/src/grpc_wrapper/raw_table_service/value/value_ydb_test.rs
@@ -26,3 +26,80 @@ fn convert_ydb_raw_grpc() -> RawResult<()> {
 
     Ok(())
 }
+
+/// YDB has no wire type for Set: it must go out as `Dict<T, Void>` with a
+/// null-flag payload per key. Pin that shape - a plain `Dict` type or a
+/// non-void payload would be a different YQL type.
+#[test]
+fn set_is_encoded_as_dict_with_void_payload() -> RawResult<()> {
+    use crate::grpc_wrapper::raw_table_service::value::RawValue;
+    use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
+
+    let value = Value::set_from(Value::Int32(0), vec![Value::Int32(1), Value::Int32(2)])
+        .expect("int32 members match the example");
+
+    let raw = RawTypedValue::try_from(value)?;
+
+    match raw.r#type {
+        RawType::Dict(dict) => {
+            assert_eq!(dict.key, RawType::Int32);
+            assert_eq!(dict.payload, RawType::Void);
+        }
+        other => panic!("expected a dict type, got {other:?}"),
+    }
+
+    match raw.value {
+        RawValue::Pairs(pairs) => {
+            assert_eq!(pairs.len(), 2);
+            for pair in pairs {
+                assert!(
+                    matches!(pair.payload, RawValue::NullFlag),
+                    "set payloads must be void"
+                );
+            }
+        }
+        other => panic!("expected pairs, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// An empty set still carries its element type, so it round-trips as
+/// `Dict<T, Void>` with no pairs rather than losing the type.
+#[test]
+fn empty_set_keeps_its_element_type() -> RawResult<()> {
+    use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
+
+    let value = Value::set_from(Value::Text(String::new()), Vec::new())
+        .expect("an empty set of a known type is valid");
+    let raw = RawTypedValue::try_from(value.clone())?;
+
+    match &raw.r#type {
+        RawType::Dict(dict) => assert_eq!(dict.key, RawType::UTF8),
+        other => panic!("expected a dict type, got {other:?}"),
+    }
+
+    let restored: Value = Value::try_from(raw)?;
+    assert_eq!(restored, value);
+
+    Ok(())
+}
+
+/// A dict with a real payload is a `Dict`, not a `Set`. The public `Value`
+/// does not model dicts yet, so decoding one must fail loudly rather than
+/// silently dropping the payloads and pretending it was a set.
+#[test]
+fn dict_with_non_void_payload_is_not_decoded_as_a_set() {
+    use crate::grpc_wrapper::raw_table_service::value::r#type::{DictType, RawType};
+    use crate::grpc_wrapper::raw_table_service::value::{RawTypedValue, RawValue};
+
+    let raw = RawTypedValue {
+        r#type: RawType::Dict(Box::new(DictType {
+            key: RawType::Int32,
+            payload: RawType::UTF8,
+        })),
+        value: RawValue::Pairs(Vec::new()),
+    };
+
+    Value::try_from(raw).expect_err("a dict with a payload must not decode as a set");
+}

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -224,7 +224,8 @@ pub use crate::{
     },
     pub_traits::{Credentials, TokenInfo},
     types::{
-        Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueStruct, YdbDecimal,
+        Bytes, Sign, SignedInterval, Value, ValueList, ValueOptional, ValueSet, ValueStruct,
+        YdbDecimal,
     },
 };
 

--- a/ydb/src/types.rs
+++ b/ydb/src/types.rs
@@ -221,6 +221,7 @@ pub enum Value {
 
     Optional(Box<ValueOptional>),
     List(Box<ValueList>),
+    Set(Box<ValueSet>),
     Struct(ValueStruct),
 
     Decimal(YdbDecimal),
@@ -325,6 +326,26 @@ pub struct ValueList {
 impl Default for Box<ValueList> {
     fn default() -> Self {
         Box::new(ValueList {
+            t: Value::Bool(false),
+            values: Vec::default(),
+        })
+    }
+}
+
+/// Elements of a [`Value::Set`], with an example value describing their type.
+///
+/// YDB has no dedicated wire type for sets: `Set<T>` is transferred as
+/// `Dict<T, Void>`, so this encodes to a dict whose payloads are all `Void`.
+/// See the [YDB container types documentation](https://ydb.tech/docs/en/yql/reference/types/containers).
+#[derive(Clone, Debug, PartialEq)]
+pub struct ValueSet {
+    pub(crate) t: Value,
+    pub(crate) values: Vec<Value>,
+}
+
+impl Default for Box<ValueSet> {
+    fn default() -> Self {
+        Box::new(ValueSet {
             t: Value::Bool(false),
             values: Vec::default(),
         })
@@ -490,6 +511,55 @@ impl Value {
         })))
     }
 
+    /// Create a `Set<T>` value from an example element and the set members.
+    ///
+    /// The example describes the element type and is used to build the query
+    /// type even when `values` is empty, exactly like [`Value::list_from`].
+    /// Every member must be the same `Value` variant as the example.
+    ///
+    /// YDB represents `Set<T>` as `Dict<T, Void>`, so this value is sent as a
+    /// dict whose payloads are all `Void`.
+    ///
+    /// Elements are sent in the order given. YDB requires the keys of a dict
+    /// to be unique, so passing duplicates makes the server reject the query;
+    /// de-duplicate before calling if the source may contain repeats.
+    ///
+    /// Example:
+    /// ```
+    ///  # use ydb::{Value, YdbResult};
+    ///  # fn example() -> YdbResult<()>{
+    ///  let v = Value::set_from(0.into(), vec![1.into(), 2.into(), 3.into()])?;
+    ///  # Ok(())
+    /// # }
+    /// ```
+    pub fn set_from(example_value: Value, values: Vec<Value>) -> YdbResult<Self> {
+        for (index, value) in values.iter().enumerate() {
+            if std::mem::discriminant(&example_value) != std::mem::discriminant(value) {
+                return Err(YdbError::Custom(format!(
+                    "failed set_from: type and value has different enum-types. index: {index}, type: '{example_value:?}', value: '{value:?}'"
+                )));
+            }
+        }
+
+        if let Value::Struct(example_value_struct) = &example_value {
+            for (i, value) in values.iter().enumerate() {
+                if let Value::Struct(value_struct) = &value
+                    && value_struct.fields_name != example_value_struct.fields_name
+                {
+                    return Err(YdbError::Custom(format!(
+                        "failed set_from: fields of value struct with index `{i}`: '{:?}' is not equal to fields of example value struct: '{:?}'",
+                        value_struct.fields_name, example_value_struct.fields_name
+                    )));
+                }
+            }
+        }
+
+        Ok(Value::Set(Box::new(ValueSet {
+            t: example_value,
+            values,
+        })))
+    }
+
     pub(crate) fn optional_from(t: Value, value: Option<Value>) -> YdbResult<Self> {
         if let Some(value) = &value
             && std::mem::discriminant(&t) != std::mem::discriminant(value)
@@ -630,6 +700,14 @@ impl Value {
 
         values.push(
             Value::list_from(
+                Value::Int8(0),
+                vec![Value::Int8(1), Value::Int8(2), Value::Int8(3)],
+            )
+            .unwrap(),
+        );
+
+        values.push(
+            Value::set_from(
                 Value::Int8(0),
                 vec![Value::Int8(1), Value::Int8(2), Value::Int8(3)],
             )

--- a/ydb/src/types_converters.rs
+++ b/ydb/src/types_converters.rs
@@ -1,9 +1,10 @@
 use crate::errors::YdbError;
 use crate::types::{Bytes, Value, ValueOptional};
-use crate::{ValueList, ValueStruct, YdbResult};
+use crate::{ValueList, ValueSet, ValueStruct, YdbResult};
 use itertools::Itertools;
 use std::any::type_name;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 use std::time::SystemTime;
 
 macro_rules! simple_convert {
@@ -200,6 +201,58 @@ where
             .map(|item| item.try_into())
             .try_collect()?;
         Ok(res)
+    }
+}
+
+// From HashSet to Value::Set
+//
+// `FromIterator` already maps iterators to `Value::List`, so sets convert
+// through `From` on the concrete `HashSet` instead.
+impl<T> From<HashSet<T>> for Value
+where
+    T: Into<Value> + Default + Eq + Hash,
+{
+    fn from(from_value: HashSet<T>) -> Self {
+        let t: Value = T::default().into();
+        let values: Vec<Value> = from_value.into_iter().map(|item| item.into()).collect();
+
+        Value::Set(Box::new(ValueSet { t, values }))
+    }
+}
+
+// From Value::Set to HashSet
+impl<T> TryFrom<Value> for HashSet<T>
+where
+    T: TryFrom<Value, Error = YdbError> + Eq + Hash,
+{
+    type Error = YdbError;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        let kind_name = value.kind_static();
+        let value_set = match value {
+            Value::Set(inner) => inner,
+            _ => {
+                return Err(YdbError::from_str(format!(
+                    "can't convert from {kind_name} to HashSet"
+                )));
+            }
+        };
+
+        // Check the element type up front so an empty set of the wrong type is
+        // not silently accepted.
+        let set_item_type = value_set.t.kind_static();
+        if TryInto::<T>::try_into(value_set.t).is_err() {
+            let target_item_type = type_name::<T>();
+            return Err(YdbError::from_str(format!(
+                "can't convert set item type '{set_item_type}' to hashset item type '{target_item_type}'"
+            )));
+        };
+
+        value_set
+            .values
+            .into_iter()
+            .map(|item| item.try_into())
+            .try_collect()
     }
 }
 

--- a/ydb/src/types_test.rs
+++ b/ydb/src/types_test.rs
@@ -861,6 +861,113 @@ fn unwrap_optional(v: Value, yql_type: &str, text: &str) -> YdbResult<Value> {
     }
 }
 
+#[test]
+fn set_from_accepts_members_of_the_example_type() -> YdbResult<()> {
+    let set = Value::set_from(
+        Value::Int32(0),
+        vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)],
+    )?;
+
+    match set {
+        Value::Set(inner) => {
+            assert_eq!(inner.t, Value::Int32(0));
+            assert_eq!(inner.values.len(), 3);
+        }
+        other => panic!("expected a set, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn set_from_rejects_a_member_of_another_type() {
+    let err = Value::set_from(
+        Value::Int32(0),
+        vec![Value::Int32(1), Value::Text("2".into())],
+    )
+    .expect_err("a text member must not be accepted into Set<Int32>");
+
+    assert!(
+        err.to_string().contains("failed set_from"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn set_from_rejects_structs_with_different_fields() {
+    let example = Value::struct_from_fields(vec![("a".to_string(), Value::Int32(0))]);
+    let other = Value::struct_from_fields(vec![("b".to_string(), Value::Int32(0))]);
+
+    let err = Value::set_from(example, vec![other])
+        .expect_err("struct members must share the example's field names");
+
+    assert!(
+        err.to_string().contains("failed set_from"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn set_from_allows_an_empty_set() -> YdbResult<()> {
+    let set = Value::set_from(Value::Int32(0), Vec::new())?;
+
+    match set {
+        Value::Set(inner) => {
+            assert_eq!(inner.t, Value::Int32(0));
+            assert!(inner.values.is_empty());
+        }
+        other => panic!("expected a set, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn hashset_converts_to_and_from_set_value() -> YdbResult<()> {
+    use std::collections::HashSet;
+
+    let source: HashSet<i32> = HashSet::from([1, 2, 3]);
+    let value: Value = source.clone().into();
+
+    assert!(matches!(value, Value::Set(_)), "expected a set: {value:?}");
+
+    let restored: HashSet<i32> = value.try_into()?;
+    assert_eq!(restored, source);
+
+    Ok(())
+}
+
+#[test]
+fn hashset_conversion_rejects_a_non_set_value() {
+    use std::collections::HashSet;
+
+    let err = TryInto::<HashSet<i32>>::try_into(Value::Int32(1))
+        .expect_err("a scalar must not convert to HashSet");
+
+    assert!(
+        err.to_string().contains("to HashSet"),
+        "unexpected error: {err}"
+    );
+}
+
+/// An empty `Set<Text>` must not quietly become an empty `HashSet<i32>`.
+#[test]
+fn hashset_conversion_rejects_a_mismatched_element_type() -> YdbResult<()> {
+    use std::collections::HashSet;
+
+    let text_set = Value::set_from(Value::Text(String::new()), Vec::new())?;
+
+    let err = TryInto::<HashSet<i32>>::try_into(text_set)
+        .expect_err("Set<Text> must not convert to HashSet<i32>");
+
+    assert!(
+        err.to_string().contains("hashset item type"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
 /// Value equality that treats NaN as equal to NaN (PartialEq says they aren't).
 fn value_roundtrip_eq(expected: &Value, actual: &Value) -> bool {
     match (expected, actual) {
@@ -878,5 +985,64 @@ async fn test_type_serialization() -> YdbResult<()> {
     for case in type_cases() {
         check_type_roundtrip(&client, &case).await?;
     }
+    Ok(())
+}
+
+/// The unit tests only prove the SDK round-trips its own encoding. This one
+/// proves the server accepts `Dict<T, Void>` as `Set<T>` and treats it as a
+/// set rather than an opaque value.
+#[tokio::test]
+#[ignore = "needs YDB access"]
+async fn set_roundtrips_through_the_server() -> YdbResult<()> {
+    let client = test_client_builder().build().await?;
+    let mut query_client = client.query_client();
+
+    let members = vec![Value::Int32(1), Value::Int32(2), Value::Int32(3)];
+    let set = Value::set_from(Value::Int32(0), members)?;
+
+    let mut row = query_client
+        .query_row("SELECT $val AS db_result")
+        .params(ydb_params!("$val" => set.clone()))
+        .await?;
+    let restored = unwrap_optional(
+        row.remove_field_by_name("db_result")?,
+        "Set<Int32>",
+        "{1, 2, 3}",
+    )?;
+
+    match (&set, &restored) {
+        (Value::Set(sent), Value::Set(got)) => {
+            assert_eq!(sent.t, got.t, "element type changed on the way back");
+            assert_eq!(
+                sent.values.len(),
+                got.values.len(),
+                "member count changed: sent {:?}, got {:?}",
+                sent.values,
+                got.values
+            );
+            for member in &sent.values {
+                assert!(
+                    got.values.contains(member),
+                    "member {member:?} missing from {:?}",
+                    got.values
+                );
+            }
+        }
+        other => panic!("expected a set on both sides, got {other:?}"),
+    }
+
+    // DictContains only type-checks if the server really sees a dict/set.
+    let mut row = query_client
+        .query_row("SELECT DictContains($val, 2) AS has_member")
+        .params(ydb_params!("$val" => set))
+        .await?;
+    let has_member: bool = unwrap_optional(
+        row.remove_field_by_name("has_member")?,
+        "Bool",
+        "DictContains",
+    )?
+    .try_into()?;
+    assert!(has_member, "the server did not see 2 as a set member");
+
     Ok(())
 }

--- a/ydb/src/types_test.rs
+++ b/ydb/src/types_test.rs
@@ -1044,5 +1044,65 @@ async fn set_roundtrips_through_the_server() -> YdbResult<()> {
     .try_into()?;
     assert!(has_member, "the server did not see 2 as a set member");
 
+    // An empty set arrives as an empty `Value` message - no pairs at all -
+    // which the decoder must read as an empty set rather than a malformed value.
+    let empty = Value::set_from(Value::Int32(0), Vec::new())?;
+    let mut row = query_client
+        .query_row("SELECT $val AS db_result")
+        .params(ydb_params!("$val" => empty.clone()))
+        .await?;
+    let restored_empty = unwrap_optional(
+        row.remove_field_by_name("db_result")?,
+        "Set<Int32>",
+        "empty set",
+    )?;
+    assert_eq!(restored_empty, empty);
+
+    // Non-numeric members go through the same path.
+    let text_set = Value::set_from(
+        Value::Text(String::new()),
+        vec![Value::Text("a".into()), Value::Text("b".into())],
+    )?;
+    let mut row = query_client
+        .query_row("SELECT $val AS db_result")
+        .params(ydb_params!("$val" => text_set.clone()))
+        .await?;
+    let restored_text = unwrap_optional(
+        row.remove_field_by_name("db_result")?,
+        "Set<Utf8>",
+        "{a, b}",
+    )?;
+    match (&text_set, &restored_text) {
+        (Value::Set(sent), Value::Set(got)) => {
+            assert_eq!(sent.t, got.t);
+            assert_eq!(sent.values.len(), got.values.len());
+        }
+        other => panic!("expected a set on both sides, got {other:?}"),
+    }
+
+    Ok(())
+}
+
+/// Empty containers arrive as an empty `Value` message too, so the same decode
+/// path has to serve `List`. This failed before `Set` was added.
+#[tokio::test]
+#[ignore = "needs YDB access"]
+async fn empty_list_roundtrips_through_the_server() -> YdbResult<()> {
+    let client = test_client_builder().build().await?;
+
+    let empty = Value::list_from(Value::Int32(0), Vec::new())?;
+    let mut row = client
+        .query_client()
+        .query_row("SELECT $val AS db_result")
+        .params(ydb_params!("$val" => empty.clone()))
+        .await?;
+    let restored = unwrap_optional(
+        row.remove_field_by_name("db_result")?,
+        "List<Int32>",
+        "empty list",
+    )?;
+
+    assert_eq!(restored, empty);
+
     Ok(())
 }


### PR DESCRIPTION
Closes #234.

## Encoding

YDB has no dedicated wire type for sets. Per the [container types documentation](https://ydb.tech/docs/en/yql/reference/types/containers), `Set<T>` is "a special case of a dictionary with the `Void` value type", and ydb-go-sdk implements it that way — `Set.ToYDB` emits a `DictType` with a void payload, and `setValue.toYDB` emits pairs whose payload is the void value. This mirrors that encoding.

The raw layer already had `RawType::Dict` and `RawValue::Pairs`, so only the public mapping was missing.

## What's added

- **`Value::Set(Box<ValueSet>)`** with `Value::set_from(example, members)`, validating members against the example exactly like `list_from`.
- **`HashSet<T>` ↔ `Set<T>`** in both directions — the set analogue of `Vec<T>` ↔ `List<T>`. `FromIterator for Value` already claims iterators for `List`, so sets convert through `From` on the concrete `HashSet`.
- A `Set` section in `examples/container-types.rs`.

Two deliberate differences from the Go SDK:

- **Empty sets keep their element type.** Go falls back to `EmptySet`/`EmptyDict` because it has no type information when the item list is empty; `set_from` always has the example, so it emits `Dict<T, Void>` with zero pairs, which round-trips.
- **A dict with a non-void payload is rejected on decode** rather than read as a set with the payloads dropped. `Value` has no `Dict` variant yet (#309), so this fails loudly.

Members are sent in the order given and are not de-duplicated, matching Go. YDB requires unique dict keys, so duplicates are the caller's responsibility — stated in the doc comment. Happy to add validation if you would prefer it over the O(n²) cost.

## Two decoding bugs this surfaced

The unit tests passed, but running against a real server did not. `TryFrom<ProtoValue> for RawValue` rejected any `Value` message carrying no oneof, no items and no pairs — which is exactly how the wire spells two legitimate things:

1. **`Void`.** It has no representation of its own, so it arrives as the payload of every pair in a `Dict<T, Void>`. Fixed in the pair conversion, where the payload is known to be void.
2. **An empty container.** An empty list or dict carries neither items nor pairs, so it decoded as `"empty value item"`. The generic decoder now yields `NullFlag` and lets the type-directed layer build the right empty value — which is what the existing `(RawType::List(_), RawValue::NullFlag)` arm was already written to expect.

**The second is not new with `Set`:** reading back an empty `List<T>` fails the same way on master today. `empty_list_roundtrips_through_the_server` covers it. Both new integration tests fail if the fix is reverted.

## Verification

Run against `ydbplatform/local-ydb:nightly` — the image CI uses:

```
cargo test --workspace -- --include-ignored     # 314 passed, 0 failed
cargo fmt --check
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
cargo check -p ydb --features force-exhaustive-all --all-targets
```

Master on the same image is 302 passed / 0 failed, so nothing regressed.

Server-side coverage: `Set<Int32>` round-trip, `DictContains` (which only type-checks if the server really sees a dict/set), an empty set, and a `Set<Utf8>`. Unit coverage: the wire shape (dict type, void payload, null-flag pairs), rejection of a dict with a real payload, the `set_from` validation paths, and the `HashSet` conversions including a mismatched element type. Adding the variant also extends the `Value::COUNT` fixture, so `Set` now flows through the existing value/proto round-trip test.

## Note for reviewers

Adding a variant is source-compatible under the default `non_exhaustive`, but **breaking under the `force-exhaustive-all` feature** — which is what that feature exists to surface. It compiles clean either way.

Unrelated but worth a separate issue: `docker-compose.yaml` pins `ydbplatform/local-ydb:latest`, while CI uses `:nightly`. On `:latest`, 11 of the existing integration tests fail with `Unknown name: $val` — every query-service parameter test. Local contributors following the README hit that before touching any code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
