### PR TITLE
feat: Graceful session pool shutdown

### DIFF
--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -110,6 +110,17 @@ impl Client {
         self.session_pool.stats()
     }
 
+    /// Stop the shared session pool and wait for all accepted DeleteSession attempts to finish.
+    ///
+    /// This consumes the driver and stops new session acquisition. Existing session leases may
+    /// finish; shutdown waits for them before deleting idle sessions. Do not use clients,
+    /// sessions, transactions, or streams derived from this driver after shutdown begins.
+    /// Shutdown must run while the Tokio runtime that created the driver is still alive.
+    #[instrument(name = "ydb.Driver.Shutdown", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
+    pub async fn shutdown(self) -> YdbResult<()> {
+        self.session_pool.shutdown().await
+    }
+
     pub fn database(&self) -> String {
         self.credentials.database.clone()
     }

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -146,8 +146,19 @@ async fn delete_session(
 
 #[cfg(test)]
 pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
+    start_test_session_cleanup_worker(|_| async {})
+}
+
+#[cfg(test)]
+pub(super) fn start_test_session_cleanup_worker<Delete, DeleteFuture>(
+    delete: Delete,
+) -> SessionCleanup
+where
+    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
+    DeleteFuture: Future<Output = ()> + Send + 'static,
+{
     let (sender, receiver) = mpsc::unbounded_channel();
-    tokio::spawn(run_cleanup_worker(receiver, |_| async {}));
+    tokio::spawn(run_cleanup_worker(receiver, delete));
     SessionCleanup { sender }
 }
 

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -2,10 +2,11 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
-use tracing::{error, warn};
+use tracing::{error, trace, warn};
 
+use crate::errors::{YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 
@@ -13,6 +14,7 @@ use super::session::SessionIdentity;
 
 enum CleanupCommand {
     DeleteSession(Arc<SessionIdentity>),
+    Shutdown { completed: oneshot::Sender<()> },
 }
 
 /// Submits server-side session resources to the cleanup worker.
@@ -35,6 +37,23 @@ impl SessionCleanup {
             );
         }
     }
+
+    /// Stop accepting cleanup requests and wait for every accepted deletion to finish.
+    pub(super) async fn shutdown(&self) -> YdbResult<()> {
+        let (completed, completion) = oneshot::channel();
+        self.sender
+            .send(CleanupCommand::Shutdown { completed })
+            .map_err(|_| {
+                YdbError::InternalError(
+                    "session cleanup worker stopped before shutdown was submitted".to_string(),
+                )
+            })?;
+        completion.await.map_err(|_| {
+            YdbError::InternalError(
+                "session cleanup worker stopped before shutdown completed".to_string(),
+            )
+        })
+    }
 }
 
 pub(super) fn start_session_cleanup_worker(
@@ -54,28 +73,35 @@ async fn run_cleanup_worker<Delete, DeleteFuture>(
     mut receiver: mpsc::UnboundedReceiver<CleanupCommand>,
     delete: Delete,
 ) where
-    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture,
+    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
     DeleteFuture: Future<Output = ()> + Send + 'static,
 {
     let mut tasks = JoinSet::new();
 
-    loop {
+    let shutdown_completion = loop {
         tokio::select! {
             command = receiver.recv() => match command {
                 Some(CleanupCommand::DeleteSession(identity)) => {
                     tasks.spawn(delete(identity));
                 }
+                Some(CleanupCommand::Shutdown { completed }) => {
+                    break Some(completed);
+                }
                 None => {
-                    drain_delete_tasks(&mut tasks).await;
-                    return;
+                    break None;
                 }
             },
-            result = tasks.join_next(), if !tasks.is_empty() => {
-                if let Some(result) = result {
-                    report_delete_task_result(result);
-                }
+            Some(result) = tasks.join_next(), if !tasks.is_empty() => {
+                report_delete_task_result(result);
             }
         }
+    };
+
+    drain_delete_tasks(&mut tasks).await;
+    if let Some(completed) = shutdown_completion
+        && completed.send(()).is_err()
+    {
+        trace!("session cleanup shutdown caller was dropped");
     }
 }
 
@@ -123,4 +149,119 @@ pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
     let (sender, receiver) = mpsc::unbounded_channel();
     tokio::spawn(run_cleanup_worker(receiver, |_| async {}));
     SessionCleanup { sender }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use http::Uri;
+    use tokio::sync::{Semaphore, mpsc};
+
+    use super::*;
+
+    fn identity(session_id: &str) -> Arc<SessionIdentity> {
+        Arc::new(SessionIdentity {
+            session_id: session_id.to_string(),
+            node_uri: Uri::from_static("http://127.0.0.1/test"),
+        })
+    }
+
+    fn start_test_worker<Delete, DeleteFuture>(
+        delete: Delete,
+    ) -> (SessionCleanup, tokio::task::JoinHandle<()>)
+    where
+        Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
+        DeleteFuture: Future<Output = ()> + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let worker = tokio::spawn(run_cleanup_worker(receiver, delete));
+        (SessionCleanup { sender }, worker)
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_all_concurrent_deletes_and_stops_worker() {
+        let (started_sender, mut started_receiver) = mpsc::unbounded_channel();
+        let release = Arc::new(Semaphore::new(0));
+        let (cleanup, worker) = start_test_worker({
+            let release = release.clone();
+            move |identity| {
+                let started_sender = started_sender.clone();
+                let release = release.clone();
+                async move {
+                    let _ = started_sender.send(identity.session_id.clone());
+                    if let Ok(permit) = release.acquire().await {
+                        permit.forget();
+                    }
+                }
+            }
+        });
+
+        for session_id in ["one", "two", "three"] {
+            cleanup.submit_delete(identity(session_id));
+        }
+
+        let shutdown_cleanup = cleanup.clone();
+        let shutdown = tokio::spawn(async move { shutdown_cleanup.shutdown().await });
+
+        let mut started = Vec::new();
+        for _ in 0..3 {
+            started.push(
+                tokio::time::timeout(Duration::from_secs(1), started_receiver.recv())
+                    .await
+                    .expect("all deletes must start concurrently")
+                    .expect("delete observer must remain open"),
+            );
+        }
+        started.sort();
+        assert_eq!(started, ["one", "three", "two"]);
+        assert!(!shutdown.is_finished());
+
+        release.add_permits(3);
+        shutdown
+            .await
+            .expect("shutdown task must finish")
+            .expect("cleanup shutdown must succeed");
+        worker.await.expect("cleanup worker must stop");
+        assert!(cleanup.sender.is_closed());
+        assert!(
+            cleanup
+                .sender
+                .send(CleanupCommand::DeleteSession(identity("late")))
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn closing_channel_drains_queued_deletes() {
+        let completed = Arc::new(Mutex::new(Vec::new()));
+        let (cleanup, worker) = start_test_worker({
+            let completed = completed.clone();
+            move |identity| {
+                let completed = completed.clone();
+                async move {
+                    completed
+                        .lock()
+                        .expect("completed lock must not be poisoned")
+                        .push(identity.session_id.clone());
+                }
+            }
+        });
+
+        cleanup.submit_delete(identity("one"));
+        cleanup.submit_delete(identity("two"));
+        drop(cleanup);
+
+        tokio::time::timeout(Duration::from_secs(1), worker)
+            .await
+            .expect("cleanup worker must drain and stop")
+            .expect("cleanup worker task must succeed");
+        let mut completed = completed
+            .lock()
+            .expect("completed lock must not be poisoned")
+            .clone();
+        completed.sort();
+        assert_eq!(completed, ["one", "two"]);
+    }
 }

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -1,0 +1,126 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tracing::{error, warn};
+
+use crate::grpc_connection_manager::GrpcConnectionManager;
+use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
+
+use super::session::SessionIdentity;
+
+enum CleanupCommand {
+    DeleteSession(Arc<SessionIdentity>),
+}
+
+/// Submits server-side session resources to the cleanup worker.
+#[derive(Clone)]
+pub(super) struct SessionCleanup {
+    sender: mpsc::UnboundedSender<CleanupCommand>,
+}
+
+impl SessionCleanup {
+    pub(super) fn submit_delete(&self, identity: Arc<SessionIdentity>) {
+        if self
+            .sender
+            .send(CleanupCommand::DeleteSession(identity.clone()))
+            .is_err()
+        {
+            error!(
+                session_id = %identity.session_id,
+                node_uri = %identity.node_uri,
+                "session cleanup worker is stopped; DeleteSession was not submitted"
+            );
+        }
+    }
+}
+
+pub(super) fn start_session_cleanup_worker(
+    connection_manager: GrpcConnectionManager,
+    delete_timeout: Duration,
+) -> SessionCleanup {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    let delete = move |identity| {
+        let connection_manager = connection_manager.clone();
+        async move { delete_session(connection_manager, delete_timeout, identity).await }
+    };
+    tokio::spawn(run_cleanup_worker(receiver, delete));
+    SessionCleanup { sender }
+}
+
+async fn run_cleanup_worker<Delete, DeleteFuture>(
+    mut receiver: mpsc::UnboundedReceiver<CleanupCommand>,
+    delete: Delete,
+) where
+    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture,
+    DeleteFuture: Future<Output = ()> + Send + 'static,
+{
+    let mut tasks = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            command = receiver.recv() => match command {
+                Some(CleanupCommand::DeleteSession(identity)) => {
+                    tasks.spawn(delete(identity));
+                }
+                None => {
+                    drain_delete_tasks(&mut tasks).await;
+                    return;
+                }
+            },
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                if let Some(result) = result {
+                    report_delete_task_result(result);
+                }
+            }
+        }
+    }
+}
+
+async fn drain_delete_tasks(tasks: &mut JoinSet<()>) {
+    while let Some(result) = tasks.join_next().await {
+        report_delete_task_result(result);
+    }
+}
+
+fn report_delete_task_result(result: Result<(), tokio::task::JoinError>) {
+    if let Err(err) = result {
+        error!(error = %err, "session cleanup task failed");
+    }
+}
+
+async fn delete_session(
+    connection_manager: GrpcConnectionManager,
+    delete_timeout: Duration,
+    identity: Arc<SessionIdentity>,
+) {
+    let mut client = match connection_manager
+        .get_auth_service_to_node(RawQueryClient::new, &identity.node_uri)
+        .await
+    {
+        Ok(client) => client,
+        Err(err) => {
+            warn!(session_id = %identity.session_id, error = %err, "failed to connect for DeleteSession");
+            return;
+        }
+    };
+
+    match tokio::time::timeout(delete_timeout, client.delete_session(&identity.session_id)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            warn!(session_id = %identity.session_id, error = %err, "DeleteSession failed")
+        }
+        Err(_) => {
+            warn!(session_id = %identity.session_id, ?delete_timeout, "DeleteSession timed out")
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    tokio::spawn(run_cleanup_worker(receiver, |_| async {}));
+    SessionCleanup { sender }
+}

--- a/ydb/src/session_pool/mod.rs
+++ b/ydb/src/session_pool/mod.rs
@@ -1,3 +1,4 @@
+mod cleanup_worker;
 mod pool;
 mod session;
 mod table_pool;

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -12,7 +12,8 @@ use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_services::Service;
 
-use super::session::{AttachedSession, CreatedSession, SessionCleanup};
+use super::cleanup_worker::{SessionCleanup, start_session_cleanup_worker};
+use super::session::{AttachedSession, CreatedSession};
 
 /// Default pool size for [`SessionPoolSettings::default()`] and the driver built-in pool.
 ///
@@ -303,7 +304,7 @@ impl SessionPool {
                 connection_manager: connection_manager.clone(),
                 semaphore: Arc::new(Semaphore::new(limit)),
                 explicit_idle: Mutex::new(Vec::new()),
-                cleanup: SessionCleanup::new(
+                cleanup: start_session_cleanup_worker(
                     connection_manager.clone(),
                     settings.session_delete_timeout,
                 ),
@@ -637,6 +638,7 @@ impl SessionPool {
         use crate::grpc_connection_manager::GrpcConnectionManager;
         use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
         use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
+        use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
 
         let settings = normalize_pool_settings(settings);
         let warm_up = settings.warm_up;
@@ -654,13 +656,14 @@ impl SessionPool {
             StaticDiscovery::new_from_str("grpc://127.0.0.1:2136")
                 .expect("static bench discovery must be valid"),
         );
+        let cleanup = start_noop_session_cleanup_worker();
         let inner = Arc::new_cyclic(|weak| SessionPoolInner {
             settings: settings.clone(),
             acquire_timeout_ms: AtomicU64::new(0),
             connection_manager: connection_manager.clone(),
             semaphore: Arc::new(Semaphore::new(limit)),
             explicit_idle: Mutex::new(Vec::new()),
-            cleanup: SessionCleanup::new(connection_manager.clone(), Duration::ZERO),
+            cleanup: cleanup.clone(),
             observer: SessionPoolObserver {
                 discovery: discovery.clone(),
                 pool: weak.clone(),

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -658,12 +658,20 @@ fn session_should_close(
 impl SessionPool {
     /// Explicit pool backed by in-memory stub sessions (no CreateSession / Attach / Delete RPC).
     pub(crate) fn new_explicit_bench(settings: SessionPoolSettings) -> Self {
+        use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
+
+        Self::new_explicit_bench_with_cleanup(settings, start_noop_session_cleanup_worker())
+    }
+
+    fn new_explicit_bench_with_cleanup(
+        settings: SessionPoolSettings,
+        cleanup: SessionCleanup,
+    ) -> Self {
         use crate::GrpcOptions;
         use crate::discovery::StaticDiscovery;
         use crate::grpc_connection_manager::GrpcConnectionManager;
         use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
         use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
-        use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
 
         let settings = normalize_pool_settings(settings);
         let warm_up = settings.warm_up;
@@ -681,7 +689,6 @@ impl SessionPool {
             StaticDiscovery::new_from_str("grpc://127.0.0.1:2136")
                 .expect("static bench discovery must be valid"),
         );
-        let cleanup = start_noop_session_cleanup_worker();
         let inner = Arc::new_cyclic(|weak| SessionPoolInner {
             settings: settings.clone(),
             acquire_timeout_ms: AtomicU64::new(0),
@@ -744,6 +751,9 @@ mod unit_tests {
     use std::task::Poll;
 
     use futures_util::poll;
+    use tokio::sync::mpsc;
+
+    use crate::session_pool::cleanup_worker::start_test_session_cleanup_worker;
 
     use super::*;
 
@@ -814,6 +824,49 @@ mod unit_tests {
 
         assert_eq!(observer.stats().idle, 0);
         assert!(observer.acquire_explicit().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_idle_and_dropped_lease_cleanup() {
+        let (deleted_sender, mut deleted_receiver) = mpsc::unbounded_channel();
+        let cleanup = start_test_session_cleanup_worker(move |identity| {
+            let deleted_sender = deleted_sender.clone();
+            async move {
+                deleted_sender
+                    .send(identity.session_id.clone())
+                    .expect("delete observer must remain open");
+            }
+        });
+        let pool = SessionPool::new_explicit_bench_with_cleanup(
+            SessionPoolSettings::new().with_limit(2).with_warm_up(2),
+            cleanup,
+        );
+        let lease = pool
+            .acquire_explicit()
+            .await
+            .expect("bench lease must be available");
+        let leased_session_id = lease.session_id().to_string();
+        assert_eq!(pool.stats().idle, 1);
+
+        let mut shutdown = Box::pin(pool.shutdown());
+        assert!(matches!(poll!(shutdown.as_mut()), Poll::Pending));
+
+        drop(lease);
+        shutdown.await.expect("pool shutdown must succeed");
+
+        let mut deleted = Vec::with_capacity(2);
+        for _ in 0..2 {
+            deleted.push(
+                deleted_receiver
+                    .try_recv()
+                    .expect("shutdown must finish both session deletions"),
+            );
+        }
+        assert!(deleted_receiver.try_recv().is_err());
+        assert!(deleted.contains(&leased_session_id));
+        deleted.sort();
+        deleted.dedup();
+        assert_eq!(deleted.len(), 2, "each session must be deleted once");
     }
 
     #[tokio::test]

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -741,6 +741,10 @@ impl SessionPool {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::task::Poll;
+
+    use futures_util::poll;
+
     use super::*;
 
     #[test]
@@ -826,22 +830,20 @@ mod unit_tests {
             .await
             .expect("second bench lease must be available");
         let observer = pool.clone();
-        let shutdown = tokio::spawn(pool.shutdown());
+        let mut shutdown = Box::pin(pool.shutdown());
 
-        tokio::task::yield_now().await;
-        assert!(!shutdown.is_finished());
+        // Queue the all-permits shutdown barrier before the late single-permit acquisition.
+        assert!(matches!(poll!(shutdown.as_mut()), Poll::Pending));
 
-        let late_acquire = tokio::spawn(async move { observer.acquire_explicit().await.is_ok() });
-        tokio::task::yield_now().await;
+        let mut late_acquire = Box::pin(observer.acquire_explicit());
+        assert!(matches!(poll!(late_acquire.as_mut()), Poll::Pending));
+
         first_lease.return_to_pool();
-        tokio::task::yield_now().await;
         second_lease.return_to_pool();
-        shutdown
-            .await
-            .expect("shutdown task must finish")
-            .expect("pool shutdown must succeed");
+
+        shutdown.await.expect("pool shutdown must succeed");
         assert!(
-            !late_acquire.await.expect("late acquire task must finish"),
+            late_acquire.await.is_err(),
             "session acquisition must not pass a pending shutdown barrier"
         );
     }

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -171,9 +171,11 @@ impl SessionPoolSettings {
 /// Call [`Self::return_to_pool`] to make a healthy session reusable. Dropping a lease without
 /// returning it schedules session cleanup.
 pub(crate) struct SessionPoolLease {
+    /// Drop the session before releasing the permit so shutdown cannot pass its lease barrier
+    /// before this lease has submitted cleanup.
+    record: SessionRecord,
     /// One permit represents this lease's exclusive use of one pool-capacity slot.
     permit: OwnedSemaphorePermit,
-    record: SessionRecord,
     pool: Arc<SessionPoolInner>,
 }
 
@@ -184,8 +186,8 @@ impl SessionPoolLease {
         pool: Arc<SessionPoolInner>,
     ) -> Self {
         Self {
-            permit,
             record: session.record,
+            permit,
             pool,
         }
     }
@@ -268,7 +270,7 @@ impl SessionPoolObserver {
         let Some(pool) = self.pool.upgrade() else {
             return;
         };
-        let _ = pool.drain_idle_for_node(node_uri);
+        pool.discard_idle_for_node(node_uri);
     }
 }
 
@@ -345,6 +347,17 @@ impl SessionPool {
         self.inner.stats()
     }
 
+    pub(crate) async fn shutdown(self) -> YdbResult<()> {
+        let _permits = self.inner.acquire_all_permits().await?;
+        self.inner.semaphore.close();
+        self.inner
+            .explicit_idle
+            .lock()
+            .expect("explicit idle lock")
+            .clear();
+        self.inner.cleanup.shutdown().await
+    }
+
     #[instrument(name = "ydb.SessionPool.AcquireSession", skip_all, fields(db.system.name = "ydb"), err)]
     pub async fn acquire_explicit(&self) -> YdbResult<SessionPoolLease> {
         let permit = self.inner.acquire_permit().await?;
@@ -371,6 +384,24 @@ impl SessionPool {
 }
 
 impl SessionPoolInner {
+    async fn acquire_all_permits(&self) -> YdbResult<OwnedSemaphorePermit> {
+        let permit_count = u32::try_from(self.settings.limit).map_err(|_| {
+            YdbError::InternalError(format!(
+                "session pool limit {} exceeds shutdown barrier capacity",
+                self.settings.limit
+            ))
+        })?;
+        self.semaphore
+            .clone()
+            .acquire_many_owned(permit_count)
+            .await
+            .map_err(|_| {
+                YdbError::InternalError(
+                    "session pool closed before shutdown acquired every lease".to_string(),
+                )
+            })
+    }
+
     fn acquire_timeout(&self) -> Duration {
         Duration::from_millis(self.acquire_timeout_ms.load(Ordering::Relaxed))
     }
@@ -473,18 +504,11 @@ impl SessionPoolInner {
         Ok(())
     }
 
-    fn drain_idle_for_node(&self, node_uri: &Uri) -> Vec<IdleSession> {
+    fn discard_idle_for_node(&self, node_uri: &Uri) {
         let mut idle = self.explicit_idle.lock().expect("explicit idle lock");
-        let mut drained = Vec::new();
-        let mut i = 0;
-        while i < idle.len() {
-            if idle[i].record.session.node_uri() == node_uri {
-                drained.push(idle.swap_remove(i));
-            } else {
-                i += 1;
-            }
-        }
-        drained
+        // Removed sessions must submit cleanup before releasing this lock. Shutdown uses the same
+        // mutex to drain the remaining idle sessions before terminating the cleanup worker.
+        idle.retain(|item| item.record.session.node_uri() != node_uri);
     }
 
     async fn create_explicit_session(&self) -> YdbResult<IdleSession> {
@@ -587,7 +611,6 @@ impl SessionPoolInner {
         item.last_used = Instant::now();
 
         if self.should_close_explicit(&item) {
-            drop(permit);
             drop(item);
         } else {
             let overflow = {
@@ -599,11 +622,13 @@ impl SessionPoolInner {
                     Some(item)
                 }
             };
-            drop(permit);
             if let Some(item) = overflow {
                 drop(item);
             }
         }
+        // Releasing the permit is the final ownership step. Shutdown uses all permits as a
+        // barrier, so every discarded session must submit cleanup before this point.
+        drop(permit);
     }
 }
 
@@ -772,5 +797,52 @@ mod unit_tests {
         assert!(session_should_close(
             &settings, 0, created, last_used, false,
         ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_discards_idle_sessions_and_closes_pool() {
+        let pool = SessionPool::new_explicit_bench(
+            SessionPoolSettings::new().with_limit(2).with_warm_up(2),
+        );
+        let observer = pool.clone();
+
+        pool.shutdown().await.expect("pool shutdown must succeed");
+
+        assert_eq!(observer.stats().idle, 0);
+        assert!(observer.acquire_explicit().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_blocks_new_leases_and_waits_for_outstanding_leases() {
+        let pool = SessionPool::new_explicit_bench(
+            SessionPoolSettings::new().with_limit(2).with_warm_up(2),
+        );
+        let first_lease = pool
+            .acquire_explicit()
+            .await
+            .expect("bench lease must be available");
+        let second_lease = pool
+            .acquire_explicit()
+            .await
+            .expect("second bench lease must be available");
+        let observer = pool.clone();
+        let shutdown = tokio::spawn(pool.shutdown());
+
+        tokio::task::yield_now().await;
+        assert!(!shutdown.is_finished());
+
+        let late_acquire = tokio::spawn(async move { observer.acquire_explicit().await.is_ok() });
+        tokio::task::yield_now().await;
+        first_lease.return_to_pool();
+        tokio::task::yield_now().await;
+        second_lease.return_to_pool();
+        shutdown
+            .await
+            .expect("shutdown task must finish")
+            .expect("pool shutdown must succeed");
+        assert!(
+            !late_acquire.await.expect("late acquire task must finish"),
+            "session acquisition must not pass a pending shutdown barrier"
+        );
     }
 }

--- a/ydb/src/session_pool/session.rs
+++ b/ydb/src/session_pool/session.rs
@@ -6,7 +6,6 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use futures_util::StreamExt;
 use http::Uri;
@@ -14,14 +13,19 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::errors::{YdbError, YdbResult, YdbStatusError};
-use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::attach_session::RawAttachSessionEvent;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use ydb_grpc::ydb_proto::query::SessionState;
 use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
+use super::cleanup_worker::SessionCleanup;
 use super::pool::SessionPoolObserver;
-use super::spawn_pool_release;
+
+/// Immutable identity shared by the session owner, AttachSession listener, and cleanup worker.
+pub(super) struct SessionIdentity {
+    pub(super) session_id: String,
+    pub(super) node_uri: Uri,
+}
 
 /// A server session returned by CreateSession but not attached yet.
 pub(super) struct CreatedSession {
@@ -158,12 +162,6 @@ impl Drop for SessionResource {
     }
 }
 
-/// Immutable identity shared by the AttachSession listener and cleanup path.
-struct SessionIdentity {
-    session_id: String,
-    node_uri: Uri,
-}
-
 /// One-way health signal shared with the AttachSession listener.
 ///
 /// No other data is published through this flag, so relaxed ordering is sufficient.
@@ -195,57 +193,6 @@ impl Drop for AttachSessionListener {
             #[cfg(test)]
             Self::Stub => {}
         }
-    }
-}
-
-/// Submits best-effort deletion for a server-side session resource.
-#[derive(Clone)]
-pub(super) struct SessionCleanup {
-    connection_manager: GrpcConnectionManager,
-    delete_timeout: Duration,
-}
-
-impl SessionCleanup {
-    pub(super) fn new(connection_manager: GrpcConnectionManager, delete_timeout: Duration) -> Self {
-        Self {
-            connection_manager,
-            delete_timeout,
-        }
-    }
-
-    fn submit_delete(&self, identity: Arc<SessionIdentity>) {
-        if cfg!(test) {
-            // Cleanup submission remains suppressed in test binaries until it is routed through
-            // the cleanup worker's testable command channel.
-            return;
-        }
-
-        let connection_manager = self.connection_manager.clone();
-        let delete_timeout = self.delete_timeout;
-        spawn_pool_release(async move {
-            let mut client = match connection_manager
-                .get_auth_service_to_node(RawQueryClient::new, &identity.node_uri)
-                .await
-            {
-                Ok(client) => client,
-                Err(err) => {
-                    warn!(session_id = %identity.session_id, error = %err, "failed to connect for DeleteSession");
-                    return;
-                }
-            };
-
-            match tokio::time::timeout(delete_timeout, client.delete_session(&identity.session_id))
-                .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => {
-                    warn!(session_id = %identity.session_id, error = %err, "DeleteSession failed")
-                }
-                Err(_) => {
-                    warn!(session_id = %identity.session_id, ?delete_timeout, "DeleteSession timed out")
-                }
-            }
-        });
     }
 }
 
@@ -306,20 +253,8 @@ async fn listen_attach_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::GrpcOptions;
-    use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
-    use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
-
-    fn connection_manager() -> GrpcConnectionManager {
-        GrpcConnectionManager::new(
-            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
-                Uri::from_static("http://127.0.0.1/bench"),
-            ))),
-            "bench".to_string(),
-            MultiInterceptor::new(),
-            GrpcOptions::default(),
-        )
-    }
+    use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn attached_session_drop_aborts_its_listener() {
@@ -333,7 +268,7 @@ mod tests {
             }
         }
 
-        let cleanup = SessionCleanup::new(connection_manager(), Duration::ZERO);
+        let cleanup = start_noop_session_cleanup_worker();
         let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
         let (dropped_sender, dropped_receiver) = tokio::sync::oneshot::channel();
         let listener = tokio::spawn(async move {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Sessions shutdown is best-effort with spawning non-awaitable tasks.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #555, related #560

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Introduce CleanupWorker for session. Session resources on drop sends a DeleteSession request for this worker. On Client graceful shutdown all session leases are awaited to be returned to the pool and that worker did all DeleteSession tasks. Session deletion inside worker is not guaranteed. 

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
