### PR TITLE
fix: tracing subscriber env filter

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -57,6 +57,11 @@ jobs:
           cargo fmt --all
           git diff --exit-code
 
+      - name: Library check
+        run: |
+          cargo check -p ydb --lib --locked
+          cargo check -p ydb --lib --locked --all-features
+
       - name: Clippy check
         run: |
           cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings

--- a/ydb/Cargo.toml
+++ b/ydb/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1.22", features = ["full"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-util = "0.7.8"
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tonic = { workspace = true }
 tower = "0.4"
 url = "2.2"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
#583 moved tracing-test to dev-deps. Where was a implicit tracing-subsriber feature "env-filter", which were enabled by tracing-test and were used in tracing extenstion for crate. After that PR it is not possible to compile a library.
Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add env-filter feature in tracing-subscriber 
- Add CI test on successful library compilation with/without features

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
