### PR TITLE
refactor: query stream session ownership

### DIFF
--- a/ydb/src/client_query/builders.rs
+++ b/ydb/src/client_query/builders.rs
@@ -9,7 +9,10 @@ use crate::result::{ResultSet, Row};
 use crate::types::Value;
 
 use super::FromYdbRow;
-use super::exec::{CallOptions, ClientExecContext, TransactionExecContext, resolve_commit_tx};
+use super::exec::{
+    CallOptions, ClientExecContext, TransactionExecContext, client_begin_stream, resolve_commit_tx,
+    transaction_begin_stream,
+};
 use super::internal::ExecCoreRef;
 use super::stream_facade::{QueryStream, materialize_query};
 
@@ -276,19 +279,27 @@ impl<'a, S> IntoFuture for CallBuilder<'a, Streamed, S> {
     type Output = YdbResult<QueryStream<'a>>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
-    fn into_future(mut self) -> Self::IntoFuture {
+    fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
-            let commit_tx = resolve_commit_tx(&self.core, &self.opts);
-            let opened = self
-                .core
-                .begin_stream(self.text, self.params, self.opts, false)
-                .await?;
-            Ok(QueryStream {
-                core: self.core,
-                stream: opened.stream,
-                owned_lease: opened.owned_lease,
-                commit_tx,
-            })
+            let commit_at_end = resolve_commit_tx(&self.core, &self.opts);
+            match self.core {
+                ExecCoreRef::Client(context) => {
+                    let opened =
+                        client_begin_stream(context, self.text, self.params, self.opts, false)
+                            .await?;
+                    Ok(QueryStream::from_client(opened))
+                }
+                ExecCoreRef::Transaction(context) => {
+                    let stream =
+                        transaction_begin_stream(context, self.text, self.params, self.opts, false)
+                            .await?;
+                    Ok(QueryStream::from_transaction(
+                        stream,
+                        context,
+                        commit_at_end,
+                    ))
+                }
+            }
         })
     }
 }

--- a/ydb/src/client_query/builders.rs
+++ b/ydb/src/client_query/builders.rs
@@ -10,10 +10,9 @@ use crate::types::Value;
 
 use super::FromYdbRow;
 use super::exec::{
-    CallOptions, ClientExecContext, TransactionExecContext, client_begin_stream, resolve_commit_tx,
-    transaction_begin_stream,
+    CallOptions, ClientExecContext, ExecTarget, TxExecContext, client_begin_stream,
+    resolve_commit_tx, tx_begin_stream,
 };
-use super::internal::ExecCoreRef;
 use super::stream_facade::{QueryStream, materialize_query};
 
 use futures_util::future::BoxFuture;
@@ -36,7 +35,7 @@ pub type ResultSetBuilder<'a, S = ClientOneShot> = CallBuilder<'a, OneResultSet,
 pub type QueryStreamBuilder<'a, S = ClientOneShot> = CallBuilder<'a, Streamed, S>;
 
 pub struct CallBuilder<'a, K, S = ClientOneShot> {
-    core: ExecCoreRef<'a>,
+    core: ExecTarget<'a>,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
@@ -47,7 +46,7 @@ pub struct CallBuilder<'a, K, S = ClientOneShot> {
 impl<'a, K> CallBuilder<'a, K, ClientOneShot> {
     pub(crate) fn new_client(ctx: &'a mut ClientExecContext, text: String) -> Self {
         Self {
-            core: ExecCoreRef::Client(ctx),
+            core: ExecTarget::Client(ctx),
             text,
             params: HashMap::new(),
             opts: CallOptions::default(),
@@ -65,9 +64,9 @@ impl<'a, K> CallBuilder<'a, K, ClientOneShot> {
 }
 
 impl<'a, K> CallBuilder<'a, K, Interactive> {
-    pub(crate) fn new_transaction(ctx: &'a mut TransactionExecContext, text: String) -> Self {
+    pub(crate) fn new_tx(ctx: &'a mut TxExecContext, text: String) -> Self {
         Self {
-            core: ExecCoreRef::Transaction(ctx),
+            core: ExecTarget::Tx(ctx),
             text,
             params: HashMap::new(),
             opts: CallOptions::default(),
@@ -221,11 +220,11 @@ impl<'a, T: FromYdbRow + 'a, S> IntoFuture for CallBuilder<'a, OneRow<T>, S> {
             let row = take_single_row(set)?.ok_or(YdbError::NoRows)?;
             let delta = start.elapsed();
             match &self.core {
-                ExecCoreRef::Client(core) => core
+                ExecTarget::Client(core) => core
                     .metrics_names
                     .client_row_query_time_histogram
                     .record(delta.as_secs_f64()),
-                ExecCoreRef::Transaction(core) => core
+                ExecTarget::Tx(core) => core
                     .metrics_names
                     .client_transaction_row_query_time_histogram
                     .record(delta.as_secs_f64()),
@@ -248,11 +247,11 @@ impl<'a, T: FromYdbRow + 'a, S> IntoFuture for CallBuilder<'a, OptionalRow<T>, S
             let row = take_single_row(set)?.map(T::from_row).transpose();
             let delta = start.elapsed();
             match &self.core {
-                ExecCoreRef::Client(core) => core
+                ExecTarget::Client(core) => core
                     .metrics_names
                     .client_row_query_time_histogram
                     .record(delta.as_secs_f64()),
-                ExecCoreRef::Transaction(core) => core
+                ExecTarget::Tx(core) => core
                     .metrics_names
                     .client_transaction_row_query_time_histogram
                     .record(delta.as_secs_f64()),
@@ -283,21 +282,16 @@ impl<'a, S> IntoFuture for CallBuilder<'a, Streamed, S> {
         Box::pin(async move {
             let commit_at_end = resolve_commit_tx(&self.core, &self.opts);
             match self.core {
-                ExecCoreRef::Client(context) => {
+                ExecTarget::Client(context) => {
                     let opened =
                         client_begin_stream(context, self.text, self.params, self.opts, false)
                             .await?;
                     Ok(QueryStream::from_client(opened))
                 }
-                ExecCoreRef::Transaction(context) => {
+                ExecTarget::Tx(context) => {
                     let stream =
-                        transaction_begin_stream(context, self.text, self.params, self.opts, false)
-                            .await?;
-                    Ok(QueryStream::from_transaction(
-                        stream,
-                        context,
-                        commit_at_end,
-                    ))
+                        tx_begin_stream(context, self.text, self.params, self.opts, false).await?;
+                    Ok(QueryStream::from_tx(stream, context, commit_at_end))
                 }
             }
         })
@@ -347,31 +341,31 @@ macro_rules! impl_client_query_methods {
     };
 }
 
-macro_rules! impl_transaction_query_methods {
+macro_rules! impl_tx_query_methods {
     () => {
         pub fn exec(&mut self, text: impl Into<String>) -> ExecBuilder<'_, Interactive> {
-            CallBuilder::new_transaction(&mut self.ctx, text.into())
+            CallBuilder::new_tx(&mut self.ctx, text.into())
         }
 
         pub fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_, Interactive> {
-            CallBuilder::new_transaction(&mut self.ctx, text.into())
+            CallBuilder::new_tx(&mut self.ctx, text.into())
         }
 
         pub fn query_result_set(
             &mut self,
             text: impl Into<String>,
         ) -> ResultSetBuilder<'_, Interactive> {
-            CallBuilder::new_transaction(&mut self.ctx, text.into())
+            CallBuilder::new_tx(&mut self.ctx, text.into())
         }
 
         pub fn query_row(
             &mut self,
             text: impl Into<String>,
         ) -> QueryRowBuilder<'_, Row, Interactive> {
-            CallBuilder::new_transaction(&mut self.ctx, text.into())
+            CallBuilder::new_tx(&mut self.ctx, text.into())
         }
     };
 }
 
 pub(crate) use impl_client_query_methods;
-pub(crate) use impl_transaction_query_methods;
+pub(crate) use impl_tx_query_methods;

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use tokio::time::timeout;
 
-use crate::errors::{Idempotency, TxErrorOutcome, YdbError, YdbResult};
+use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
@@ -77,9 +77,9 @@ pub(crate) enum TxState {
     Committed,
     /// Rollback path was chosen and the SDK must not report a commit.
     RolledBack,
-    /// A definitive operation failure ended the local transaction attempt.
+    /// A transaction operation failed; retry policy decides whether to start a new attempt.
     AttemptFailed(YdbError),
-    /// A commit or rollback RPC returned an error, so the local end attempt was not confirmed.
+    /// A commit or rollback RPC failed after dispatch, so its outcome was not confirmed.
     Undetermined(YdbError),
 }
 
@@ -164,18 +164,15 @@ impl TxExecContext {
         }
     }
 
-    fn finish_dispatched_error(&mut self, error: &YdbError) -> YdbResult<()> {
-        let outcome = error.tx_error_outcome();
-        let replacement = match outcome {
-            TxErrorOutcome::Ended | TxErrorOutcome::MayRemainActive => {
-                TxState::AttemptFailed(error.clone())
-            }
-            TxErrorOutcome::Undetermined => TxState::Undetermined(error.clone()),
-        };
-        let active = self.replace_active(replacement)?;
-        if outcome == TxErrorOutcome::Ended && !error.requires_session_discard() {
-            active.lease.return_to_pool();
+    fn fail_attempt(&mut self, error: &YdbError) -> YdbResult<()> {
+        let active = self.replace_active(TxState::AttemptFailed(error.clone()))?;
+
+        if error.requires_session_discard() {
+            // Dropping a lease without returning it schedules session cleanup.
+            return Ok(());
         }
+
+        release_unfinished_tx(self.connection_manager.clone(), active);
         Ok(())
     }
 }
@@ -529,7 +526,7 @@ pub(crate) async fn tx_ensure_begin(tx: &mut TxExecContext) -> YdbResult<()> {
             Ok(())
         }
         Err(err) => {
-            tx.finish_dispatched_error(&err)?;
+            tx.fail_attempt(&err)?;
             Err(err)
         }
     }
@@ -569,10 +566,10 @@ async fn tx_before_commit(tx: &mut TxExecContext) -> YdbResult<()> {
     Ok(())
 }
 
-/// Apply a query error to the retained session and transaction state.
+/// Finish a failed query attempt and release its transaction resources.
 pub(crate) fn tx_handle_query_error(tx: &mut TxExecContext, err: &YdbError) {
     if tx.state.is_active()
-        && let Err(error) = tx.finish_dispatched_error(err)
+        && let Err(error) = tx.fail_attempt(err)
     {
         tracing::error!(%error, "failed to finish transaction after query error");
     }
@@ -597,6 +594,7 @@ pub(crate) async fn tx_begin_stream(
         "implicit_session is only available on QueryClient one-shot builders"
     );
     tx.active()?;
+    let commit_at_end = opts.commit_tx.unwrap_or(false);
     let effective_timeout = resolve_effective_timeout(tx.retry_deadline, opts.timeout);
     let mut query_dispatched = false;
     let result: YdbResult<ExecuteQueryStream> =
@@ -606,7 +604,7 @@ pub(crate) async fn tx_begin_stream(
             if tx.begin {
                 tx_ensure_begin(tx).await?;
             }
-            if opts.commit_tx.unwrap_or(false) {
+            if commit_at_end {
                 tx_before_commit(tx).await?;
             }
             let (mut client, req) =
@@ -777,8 +775,8 @@ pub(crate) async fn tx_rollback(tx: &mut TxExecContext) -> YdbResult<()> {
     active.lease.finish(result)
 }
 
-/// Best-effort rollback when [`super::Transaction`] is dropped without `commit`/`rollback`.
-pub(crate) fn finish_query_tx_on_drop(connection_manager: GrpcConnectionManager, active: ActiveTx) {
+/// Release an unfinished transaction, rolling it back first when its id is known.
+pub(super) fn release_unfinished_tx(connection_manager: GrpcConnectionManager, active: ActiveTx) {
     let ActiveTx {
         lease,
         server_progress,
@@ -940,7 +938,7 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn definitive_dispatched_error_ends_attempt_and_returns_healthy_session() {
+    async fn begin_in_flight_error_discards_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
@@ -960,16 +958,16 @@ mod unit_tests {
             issues: vec![],
         });
 
-        ctx.finish_dispatched_error(&error)
+        ctx.fail_attempt(&error)
             .expect("rejected operation must finish the transaction");
 
         assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
-        let reused = pool
+        let replacement = pool
             .acquire_explicit()
             .await
-            .expect("healthy session must return to the pool");
-        assert_eq!(reused.session_id(), session_id);
-        reused.return_to_pool();
+            .expect("session with an unconfirmed begin must be replaced");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
     }
 
     #[tokio::test]
@@ -994,7 +992,7 @@ mod unit_tests {
                 issues: vec![],
             });
 
-            ctx.finish_dispatched_error(&error)
+            ctx.fail_attempt(&error)
                 .expect("temporary failure must finish the local transaction attempt");
 
             assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
@@ -1008,7 +1006,7 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn undetermined_dispatched_error_discards_session() {
+    async fn undetermined_query_error_fails_attempt_and_discards_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
@@ -1028,10 +1026,10 @@ mod unit_tests {
             issues: vec![],
         });
 
-        ctx.finish_dispatched_error(&error)
+        ctx.fail_attempt(&error)
             .expect("undetermined outcome must finish the transaction");
 
-        assert!(matches!(ctx.state, TxState::Undetermined(_)));
+        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
         let replacement = pool
             .acquire_explicit()
             .await
@@ -1060,7 +1058,7 @@ mod unit_tests {
             .replace_active(TxState::RolledBack)
             .expect("take active transaction");
 
-        finish_query_tx_on_drop(manager, active);
+        release_unfinished_tx(manager, active);
 
         let replacement = pool
             .acquire_explicit()

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -79,7 +79,7 @@ pub(crate) enum TxState {
     RolledBack,
     /// A transaction operation failed; retry policy decides whether to start a new attempt.
     AttemptFailed(YdbError),
-    /// A commit or rollback RPC failed after dispatch, so its outcome was not confirmed.
+    /// A dispatched operation did not confirm the transaction's final outcome.
     Undetermined(YdbError),
 }
 

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -792,21 +792,31 @@ pub(super) fn release_unfinished_tx(connection_manager: GrpcConnectionManager, a
         | TxServerProgress::RollbackInFlight(_) => return,
     };
 
+    let cleanup_timeout = lease.cleanup_timeout();
+    let node_uri = lease.node_uri().clone();
+    let session_id = lease.session_id().to_string();
+
     spawn_pool_release(async move {
-        let client_result = connection_manager
-            .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
-            .await;
-        let rollback_ok = match client_result {
-            Ok(mut client) => client
-                .rollback_transaction(lease.session_id(), tx_id.as_str())
+        let rollback = async move {
+            let mut client = connection_manager
+                .get_auth_service_to_node(RawQueryClient::new, &node_uri)
+                .await?;
+            client
+                .rollback_transaction(&session_id, tx_id.as_str())
                 .await
-                .is_ok(),
-            Err(_) => false,
+                .map_err(YdbError::from)
         };
-        if rollback_ok {
-            lease.return_to_pool();
-        }
+        finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
     });
+}
+
+async fn finish_rollback_cleanup<F>(lease: SessionPoolLease, cleanup_timeout: Duration, rollback: F)
+where
+    F: Future<Output = YdbResult<()>>,
+{
+    if matches!(timeout(cleanup_timeout, rollback).await, Ok(Ok(()))) {
+        lease.return_to_pool();
+    }
 }
 
 pub(crate) fn tx_exec_context(
@@ -1064,6 +1074,27 @@ mod unit_tests {
             .acquire_explicit()
             .await
             .expect("acquire replacement session");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn rollback_cleanup_timeout_discards_session_and_releases_pool_permit() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+
+        finish_rollback_cleanup(
+            lease,
+            Duration::ZERO,
+            std::future::pending::<YdbResult<()>>(),
+        )
+        .await;
+
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("timed-out rollback must release the pool permit");
         assert_ne!(replacement.session_id(), session_id);
         replacement.return_to_pool();
     }

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -76,7 +76,7 @@ pub(crate) enum TxState {
     Committed,
     /// Rollback path was chosen and the SDK must not report a commit.
     RolledBack,
-    /// The server ended the transaction after a definitive status on a query.
+    /// A definitive operation failure ended the local transaction attempt.
     Invalidated(YdbError),
     /// A commit or rollback RPC returned an error, so the local end attempt was not confirmed.
     Ambiguous(YdbError),
@@ -160,11 +160,15 @@ impl TransactionExecContext {
     fn finish_dispatched_error(&mut self, error: &YdbError) -> YdbResult<()> {
         let outcome = error.transaction_error_outcome();
         let replacement = match outcome {
-            TransactionErrorOutcome::AttemptFailed => TxState::Invalidated(error.clone()),
+            TransactionErrorOutcome::TransactionEnded
+            | TransactionErrorOutcome::TransactionMayRemainActive => {
+                TxState::Invalidated(error.clone())
+            }
             TransactionErrorOutcome::OutcomeUnknown => TxState::Ambiguous(error.clone()),
         };
         let active = self.take_active(replacement)?;
-        if outcome == TransactionErrorOutcome::AttemptFailed && !error.requires_session_discard() {
+        if outcome == TransactionErrorOutcome::TransactionEnded && !error.requires_session_discard()
+        {
             active.lease.return_to_pool();
         }
         Ok(())
@@ -959,6 +963,39 @@ mod unit_tests {
             .expect("healthy session must return to the pool");
         assert_eq!(reused.session_id(), session_id);
         reused.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn transient_dispatched_error_discards_session_with_possibly_active_transaction() {
+        for status in [StatusCode::Unavailable, StatusCode::Overloaded] {
+            let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+            let lease = pool.acquire_explicit().await.expect("acquire test session");
+            let session_id = lease.session_id().to_string();
+            let mut ctx = transaction_exec_context(
+                test_connection_manager(),
+                lease,
+                TransactionOptions::default(),
+                None,
+            );
+            ctx.active_mut().expect("active transaction").server =
+                ServerTransaction::Started("tx-1".to_string());
+            let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
+                message: "temporary query failure".into(),
+                operation_status: status as i32,
+                issues: vec![],
+            });
+
+            ctx.finish_dispatched_error(&error)
+                .expect("temporary failure must finish the local transaction attempt");
+
+            assert!(matches!(ctx.state, TxState::Invalidated(_)));
+            let replacement = pool
+                .acquire_explicit()
+                .await
+                .expect("session with an unconfirmed transaction must be replaced");
+            assert_ne!(replacement.session_id(), session_id);
+            replacement.return_to_pool();
+        }
     }
 
     #[tokio::test]

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use tokio::time::timeout;
 
-use crate::errors::{Idempotency, TransactionErrorOutcome, YdbError, YdbResult};
+use crate::errors::{Idempotency, TxErrorOutcome, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
@@ -62,24 +62,25 @@ pub(crate) enum ClientQuerySession {
 }
 
 impl ClientQuerySession {
-    pub(crate) fn complete(self) {
+    pub(crate) fn release(self) {
         if let Self::Pooled(lease) = self {
             lease.return_to_pool();
         }
     }
 }
 
+/// Complete local lifecycle state of a transaction attempt.
 pub(crate) enum TxState {
     /// An unfinished transaction always owns exactly one exclusive session lease.
-    Active(ActiveTransaction),
+    Active(ActiveTx),
     /// Real, confirmed commit: either `CommitTransaction` succeeded or `commit_tx` completed.
     Committed,
     /// Rollback path was chosen and the SDK must not report a commit.
     RolledBack,
     /// A definitive operation failure ended the local transaction attempt.
-    Invalidated(YdbError),
+    AttemptFailed(YdbError),
     /// A commit or rollback RPC returned an error, so the local end attempt was not confirmed.
-    Ambiguous(YdbError),
+    Undetermined(YdbError),
 }
 
 impl TxState {
@@ -88,16 +89,17 @@ impl TxState {
     }
 }
 
-pub(crate) struct ActiveTransaction {
+/// Resources owned while the local transaction attempt remains active.
+pub(crate) struct ActiveTx {
     lease: SessionPoolLease,
-    server: ServerTransaction,
+    server_progress: TxServerProgress,
 }
 
-/// Server-side progress within an active transaction.
+/// SDK-observed progress of the remote transaction.
 ///
 /// In-flight states retain the lease in the transaction so cancellation is conservative: dropping
 /// the transaction discards the session instead of issuing a second finalization RPC.
-enum ServerTransaction {
+enum TxServerProgress {
     NotStarted,
     BeginInFlight,
     Started(String),
@@ -105,7 +107,7 @@ enum ServerTransaction {
     RollbackInFlight(String),
 }
 
-pub(crate) struct TransactionExecContext {
+pub(crate) struct TxExecContext {
     pub connection_manager: GrpcConnectionManager,
     pub tx_mode: TxMode,
     /// When set, the first operation calls `BeginTransaction` RPC instead of lazy `BeginTx` in `ExecuteQuery`.
@@ -117,18 +119,23 @@ pub(crate) struct TransactionExecContext {
     pub metrics_names: MetricsNames,
 }
 
-impl TransactionExecContext {
-    fn active(&self) -> YdbResult<&ActiveTransaction> {
+pub(crate) enum ExecTarget<'a> {
+    Client(&'a mut ClientExecContext),
+    Tx(&'a mut TxExecContext),
+}
+
+impl TxExecContext {
+    fn active(&self) -> YdbResult<&ActiveTx> {
         match &self.state {
             TxState::Active(active) => Ok(active),
-            _ => Err(transaction_finished_error()),
+            _ => Err(tx_finished_error()),
         }
     }
 
-    fn active_mut(&mut self) -> YdbResult<&mut ActiveTransaction> {
+    fn active_mut(&mut self) -> YdbResult<&mut ActiveTx> {
         match &mut self.state {
             TxState::Active(active) => Ok(active),
-            _ => Err(transaction_finished_error()),
+            _ => Err(tx_finished_error()),
         }
     }
 
@@ -138,44 +145,42 @@ impl TransactionExecContext {
 
     pub(super) fn transaction_id(&self) -> Option<&str> {
         match &self.state {
-            TxState::Active(ActiveTransaction {
-                server: ServerTransaction::Started(id),
+            TxState::Active(ActiveTx {
+                server_progress: TxServerProgress::Started(id),
                 ..
             }) => Some(id),
             _ => None,
         }
     }
 
-    fn take_active(&mut self, replacement: TxState) -> YdbResult<ActiveTransaction> {
+    fn replace_active(&mut self, replacement: TxState) -> YdbResult<ActiveTx> {
         let previous = std::mem::replace(&mut self.state, replacement);
         match previous {
             TxState::Active(active) => Ok(active),
             state => {
                 self.state = state;
-                Err(transaction_finished_error())
+                Err(tx_finished_error())
             }
         }
     }
 
     fn finish_dispatched_error(&mut self, error: &YdbError) -> YdbResult<()> {
-        let outcome = error.transaction_error_outcome();
+        let outcome = error.tx_error_outcome();
         let replacement = match outcome {
-            TransactionErrorOutcome::TransactionEnded
-            | TransactionErrorOutcome::TransactionMayRemainActive => {
-                TxState::Invalidated(error.clone())
+            TxErrorOutcome::Ended | TxErrorOutcome::MayRemainActive => {
+                TxState::AttemptFailed(error.clone())
             }
-            TransactionErrorOutcome::OutcomeUnknown => TxState::Ambiguous(error.clone()),
+            TxErrorOutcome::Undetermined => TxState::Undetermined(error.clone()),
         };
-        let active = self.take_active(replacement)?;
-        if outcome == TransactionErrorOutcome::TransactionEnded && !error.requires_session_discard()
-        {
+        let active = self.replace_active(replacement)?;
+        if outcome == TxErrorOutcome::Ended && !error.requires_session_discard() {
             active.lease.return_to_pool();
         }
         Ok(())
     }
 }
 
-fn transaction_finished_error() -> YdbError {
+fn tx_finished_error() -> YdbError {
     YdbError::Custom("transaction already finished (committed or rolled back)".to_string())
 }
 
@@ -221,7 +226,7 @@ where
     }
 }
 
-async fn query_client_from_tx(tx: &TransactionExecContext) -> YdbResult<RawQueryClient> {
+async fn query_client_from_tx(tx: &TxExecContext) -> YdbResult<RawQueryClient> {
     Box::pin(
         tx.connection_manager
             .get_auth_service_to_node(RawQueryClient::new, tx.session_lease()?.node_uri()),
@@ -262,10 +267,7 @@ fn ensure_interactive_tx_mode(mode: TxMode) -> YdbResult<()> {
     Ok(())
 }
 
-fn reject_per_call_tx_mode_override(
-    tx: &TransactionExecContext,
-    opts: &CallOptions,
-) -> YdbResult<()> {
+fn reject_per_call_tx_mode_override(tx: &TxExecContext, opts: &CallOptions) -> YdbResult<()> {
     if let Some(override_mode) = opts.tx_mode
         && override_mode != tx.tx_mode
     {
@@ -277,7 +279,7 @@ fn reject_per_call_tx_mode_override(
     Ok(())
 }
 
-fn interactive_tx_mode(tx: &TransactionExecContext, opts: &CallOptions) -> YdbResult<TxMode> {
+fn interactive_tx_mode(tx: &TxExecContext, opts: &CallOptions) -> YdbResult<TxMode> {
     reject_per_call_tx_mode_override(tx, opts)?;
     ensure_interactive_tx_mode(opts.tx_mode.unwrap_or(tx.tx_mode))?;
     Ok(tx.tx_mode)
@@ -297,27 +299,27 @@ fn default_commit_tx_client(_mode: TxMode) -> bool {
 /// `BeginTx` with `commit_tx: false` — no upfront `BeginTransaction` RPC. The server
 /// returns `tx_id` in the response stream; later queries use `TxId`.
 ///
-/// **Explicit begin:** when [`TransactionExecContext::begin`] is set or
-/// [`transaction_ensure_begin`] was called, `tx_id` is already known and this
+/// **Explicit begin:** when [`TxExecContext::begin`] is set or
+/// [`tx_ensure_begin`] was called, `tx_id` is already known and this
 /// function always emits `TxId`.
 fn tx_control_for_transaction(
-    tx: &TransactionExecContext,
+    tx: &TxExecContext,
     opts: &CallOptions,
 ) -> YdbResult<Option<ydb_grpc::ydb_proto::query::TransactionControl>> {
     let commit_tx = opts.commit_tx.unwrap_or(false);
-    Ok(Some(match &tx.active()?.server {
-        ServerTransaction::Started(id) => {
+    Ok(Some(match &tx.active()?.server_progress {
+        TxServerProgress::Started(id) => {
             interactive_tx_mode(tx, opts)?;
             tx_id_control(id, commit_tx)
         }
-        ServerTransaction::NotStarted => {
+        TxServerProgress::NotStarted => {
             reject_per_call_tx_mode_override(tx, opts)?;
             ensure_interactive_tx_mode(tx.tx_mode)?;
             begin_tx_control(tx_mode_to_raw(tx.tx_mode)?, commit_tx)
         }
-        ServerTransaction::BeginInFlight
-        | ServerTransaction::CommitInFlight(_)
-        | ServerTransaction::RollbackInFlight(_) => {
+        TxServerProgress::BeginInFlight
+        | TxServerProgress::CommitInFlight(_)
+        | TxServerProgress::RollbackInFlight(_) => {
             return Err(YdbError::InternalError(
                 "query transaction operation is already in progress".to_string(),
             ));
@@ -325,13 +327,13 @@ fn tx_control_for_transaction(
     }))
 }
 
-pub(crate) fn resolve_commit_tx(core: &super::internal::ExecCoreRef, opts: &CallOptions) -> bool {
+pub(crate) fn resolve_commit_tx(target: &ExecTarget, opts: &CallOptions) -> bool {
     if let Some(commit_tx) = opts.commit_tx {
         return commit_tx;
     }
-    match core {
-        super::internal::ExecCoreRef::Client(_) => default_commit_tx_client(client_tx_mode(opts)),
-        super::internal::ExecCoreRef::Transaction(_) => false,
+    match target {
+        ExecTarget::Client(_) => default_commit_tx_client(client_tx_mode(opts)),
+        ExecTarget::Tx(_) => false,
     }
 }
 
@@ -458,10 +460,8 @@ pub(crate) async fn client_begin_stream(
 }
 
 /// Session and transaction ids for cross-service RPCs (e.g. topic `UpdateOffsetsInTransaction`).
-pub(crate) async fn transaction_identity(
-    tx: &mut TransactionExecContext,
-) -> YdbResult<(String, String)> {
-    transaction_ensure_begin(tx).await?;
+pub(crate) async fn tx_identity(tx: &mut TxExecContext) -> YdbResult<(String, String)> {
+    tx_ensure_begin(tx).await?;
     let session_id = tx.session_lease()?.session_id().to_string();
     let transaction_id = tx
         .transaction_id()
@@ -471,8 +471,8 @@ pub(crate) async fn transaction_identity(
 }
 
 #[instrument(name = "ydb.ExecuteQuery", skip_all, fields(db.system.name = "ydb", ydb.Query.text = %ensure_len_string(&yql_text), ydb.Query.params = ?parameters, ydb.Query.opts = ?opts))]
-async fn transaction_execute_request(
-    tx: &TransactionExecContext,
+async fn tx_execute_request(
+    tx: &TxExecContext,
     yql_text: String,
     parameters: HashMap<String, Value>,
     opts: &CallOptions,
@@ -492,13 +492,13 @@ async fn transaction_execute_request(
 
 /// Open the transaction via `BeginTransaction` RPC (explicit begin).
 #[instrument(name = "ydb.Query.TransactionEnsureBegin", skip_all, fields(db.system.name = "ydb", ydb.tx.mode = ?tx.tx_mode, ydb.session.id = tracing::field::Empty), err)]
-pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) -> YdbResult<()> {
-    match &tx.active()?.server {
-        ServerTransaction::Started(_) => return Ok(()),
-        ServerTransaction::NotStarted => {}
-        ServerTransaction::BeginInFlight
-        | ServerTransaction::CommitInFlight(_)
-        | ServerTransaction::RollbackInFlight(_) => {
+pub(crate) async fn tx_ensure_begin(tx: &mut TxExecContext) -> YdbResult<()> {
+    match &tx.active()?.server_progress {
+        TxServerProgress::Started(_) => return Ok(()),
+        TxServerProgress::NotStarted => {}
+        TxServerProgress::BeginInFlight
+        | TxServerProgress::CommitInFlight(_)
+        | TxServerProgress::RollbackInFlight(_) => {
             return Err(YdbError::InternalError(
                 "query transaction operation is already in progress".to_string(),
             ));
@@ -508,7 +508,7 @@ pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) ->
     tx.session_lease()?.ensure_healthy()?;
     let raw_tx_mode = tx_mode_to_raw(tx.tx_mode)?;
     let mut client = query_client_from_tx(tx).await?;
-    tx.active_mut()?.server = ServerTransaction::BeginInFlight;
+    tx.active_mut()?.server_progress = TxServerProgress::BeginInFlight;
 
     let result = {
         let active = tx.active()?;
@@ -525,7 +525,7 @@ pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) ->
 
     match result {
         Ok(tx_id) => {
-            tx.active_mut()?.server = ServerTransaction::Started(tx_id);
+            tx.active_mut()?.server_progress = TxServerProgress::Started(tx_id);
             Ok(())
         }
         Err(err) => {
@@ -536,34 +536,33 @@ pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) ->
 }
 
 /// Finish a successful transaction query after its response stream reaches EOF.
-pub(crate) fn transaction_finish_query(
-    tx: &mut TransactionExecContext,
-    commit_at_end: bool,
-) -> YdbResult<()> {
+pub(crate) fn tx_finish_query(tx: &mut TxExecContext, commit_at_end: bool) -> YdbResult<()> {
     if commit_at_end {
         tx.metrics_names
             .client_transaction_commit_counter
             .increment(1);
-        tx.take_active(TxState::Committed)?.lease.return_to_pool();
+        tx.replace_active(TxState::Committed)?
+            .lease
+            .return_to_pool();
         return Ok(());
     }
 
-    let message = match &tx.active()?.server {
-        ServerTransaction::Started(_) => return Ok(()),
-        ServerTransaction::BeginInFlight => "ExecuteQuery response missing transaction id",
-        ServerTransaction::NotStarted
-        | ServerTransaction::CommitInFlight(_)
-        | ServerTransaction::RollbackInFlight(_) => {
+    let message = match &tx.active()?.server_progress {
+        TxServerProgress::Started(_) => return Ok(()),
+        TxServerProgress::BeginInFlight => "ExecuteQuery response missing transaction id",
+        TxServerProgress::NotStarted
+        | TxServerProgress::CommitInFlight(_)
+        | TxServerProgress::RollbackInFlight(_) => {
             "query transaction reached an invalid state after ExecuteQuery"
         }
     };
     let error = YdbError::InternalError(message.to_string());
-    let mut active = tx.take_active(TxState::Ambiguous(error.clone()))?;
+    let mut active = tx.replace_active(TxState::Undetermined(error.clone()))?;
     active.lease.invalidate();
     Err(error)
 }
 
-async fn transaction_before_commit(tx: &mut TransactionExecContext) -> YdbResult<()> {
+async fn tx_before_commit(tx: &mut TxExecContext) -> YdbResult<()> {
     for hook in &mut tx.hooks {
         hook.before_commit().await?;
     }
@@ -571,7 +570,7 @@ async fn transaction_before_commit(tx: &mut TransactionExecContext) -> YdbResult
 }
 
 /// Apply a query error to the retained session and transaction state.
-pub(crate) fn transaction_handle_query_error(tx: &mut TransactionExecContext, err: &YdbError) {
+pub(crate) fn tx_handle_query_error(tx: &mut TxExecContext, err: &YdbError) {
     if tx.state.is_active()
         && let Err(error) = tx.finish_dispatched_error(err)
     {
@@ -579,15 +578,15 @@ pub(crate) fn transaction_handle_query_error(tx: &mut TransactionExecContext, er
     }
 }
 
-pub(crate) fn transaction_invalidate_session(tx: &mut TransactionExecContext) {
+pub(crate) fn tx_invalidate_session(tx: &mut TxExecContext) {
     if let TxState::Active(active) = &mut tx.state {
         active.lease.invalidate();
     }
 }
 
 #[instrument(name = "ydb.Query.TransactionBeginStream", skip_all, fields(db.system.name = "ydb", ydb.tx.mode = ?tx.tx_mode, ydb.session.id = tracing::field::Empty), err)]
-pub(crate) async fn transaction_begin_stream(
-    tx: &mut TransactionExecContext,
+pub(crate) async fn tx_begin_stream(
+    tx: &mut TxExecContext,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
@@ -605,17 +604,17 @@ pub(crate) async fn transaction_begin_stream(
             tx.session_lease()?.ensure_healthy()?;
             tracing::Span::current().record("ydb.session.id", tx.session_lease()?.session_id());
             if tx.begin {
-                transaction_ensure_begin(tx).await?;
+                tx_ensure_begin(tx).await?;
             }
             if opts.commit_tx.unwrap_or(false) {
-                transaction_before_commit(tx).await?;
+                tx_before_commit(tx).await?;
             }
             let (mut client, req) =
-                transaction_execute_request(tx, text, params, &opts, concurrent_result_sets)
-                    .await?;
-            let starts_transaction = matches!(tx.active()?.server, ServerTransaction::NotStarted);
+                tx_execute_request(tx, text, params, &opts, concurrent_result_sets).await?;
+            let starts_transaction =
+                matches!(tx.active()?.server_progress, TxServerProgress::NotStarted);
             if starts_transaction {
-                tx.active_mut()?.server = ServerTransaction::BeginInFlight;
+                tx.active_mut()?.server_progress = TxServerProgress::BeginInFlight;
             }
             query_dispatched = true;
             let stream = client.execute_query(req).await.map_err(YdbError::from)?;
@@ -625,7 +624,7 @@ pub(crate) async fn transaction_begin_stream(
                 let error = YdbError::InternalError(
                     "ExecuteQuery response stream closed before the first part".to_string(),
                 );
-                let mut active = tx.take_active(TxState::Ambiguous(error.clone()))?;
+                let mut active = tx.replace_active(TxState::Undetermined(error.clone()))?;
                 active.lease.invalidate();
                 return Err(error);
             }
@@ -636,7 +635,7 @@ pub(crate) async fn transaction_begin_stream(
         .await;
     if let Err(err) = &result {
         if query_dispatched {
-            transaction_handle_query_error(tx, err);
+            tx_handle_query_error(tx, err);
         } else if let TxState::Active(active) = &mut tx.state
             && err.requires_session_discard()
         {
@@ -647,20 +646,20 @@ pub(crate) async fn transaction_begin_stream(
 }
 
 #[instrument(name = "ydb.Commit", skip_all, fields(db.system.name = "ydb", ydb.tx.id = tracing::field::Empty, ydb.session.id = tracing::field::Empty), err)]
-pub(crate) async fn transaction_commit(tx: &mut TransactionExecContext) -> YdbResult<()> {
+pub(crate) async fn tx_commit(tx: &mut TxExecContext) -> YdbResult<()> {
     if !tx.state.is_active() {
         return Ok(());
     }
-    if let Err(err) = transaction_before_commit(tx).await {
-        let _ = transaction_rollback(tx).await;
+    if let Err(err) = tx_before_commit(tx).await {
+        let _ = tx_rollback(tx).await;
         return Err(err);
     }
-    let transaction_id = match &tx.active()?.server {
-        ServerTransaction::Started(id) => Some(id.clone()),
-        ServerTransaction::NotStarted => None,
-        ServerTransaction::BeginInFlight
-        | ServerTransaction::CommitInFlight(_)
-        | ServerTransaction::RollbackInFlight(_) => {
+    let transaction_id = match &tx.active()?.server_progress {
+        TxServerProgress::Started(id) => Some(id.clone()),
+        TxServerProgress::NotStarted => None,
+        TxServerProgress::BeginInFlight
+        | TxServerProgress::CommitInFlight(_)
+        | TxServerProgress::RollbackInFlight(_) => {
             return Err(YdbError::InternalError(
                 "query transaction operation is already in progress".to_string(),
             ));
@@ -668,11 +667,13 @@ pub(crate) async fn transaction_commit(tx: &mut TransactionExecContext) -> YdbRe
     };
     match transaction_id {
         None => {
-            tx.take_active(TxState::Committed)?.lease.return_to_pool();
+            tx.replace_active(TxState::Committed)?
+                .lease
+                .return_to_pool();
             return Ok(());
         }
         Some(id) => {
-            tx.active_mut()?.server = ServerTransaction::CommitInFlight(id);
+            tx.active_mut()?.server_progress = TxServerProgress::CommitInFlight(id);
         }
     }
     tx.metrics_names
@@ -680,7 +681,7 @@ pub(crate) async fn transaction_commit(tx: &mut TransactionExecContext) -> YdbRe
         .increment(1);
     let result = async {
         let active = tx.active()?;
-        let ServerTransaction::CommitInFlight(tx_id) = &active.server else {
+        let TxServerProgress::CommitInFlight(tx_id) = &active.server_progress else {
             return Err(YdbError::InternalError(
                 "query transaction is not committing".to_string(),
             ));
@@ -705,27 +706,27 @@ pub(crate) async fn transaction_commit(tx: &mut TransactionExecContext) -> YdbRe
 
     let terminal = match &result {
         Ok(()) => TxState::Committed,
-        Err(err) => TxState::Ambiguous(err.clone()),
+        Err(err) => TxState::Undetermined(err.clone()),
     };
-    let active = tx.take_active(terminal)?;
+    let active = tx.replace_active(terminal)?;
     // Do not retry commit: a transport timeout may mean the commit succeeded server-side.
     active.lease.finish(result)
 }
 
 #[instrument(name = "ydb.Rollback", skip_all, fields(db.system.name = "ydb", ydb.tx.id = tracing::field::Empty, ydb.session.id = tracing::field::Empty), err)]
-pub(crate) async fn transaction_rollback(tx: &mut TransactionExecContext) -> YdbResult<()> {
+pub(crate) async fn tx_rollback(tx: &mut TxExecContext) -> YdbResult<()> {
     if !tx.state.is_active() {
         return Ok(());
     }
     tx.metrics_names
         .client_transaction_rollback_counter
         .increment(1);
-    let transaction_id = match &tx.active()?.server {
-        ServerTransaction::Started(id) => Some(id.clone()),
-        ServerTransaction::NotStarted => None,
-        ServerTransaction::BeginInFlight
-        | ServerTransaction::CommitInFlight(_)
-        | ServerTransaction::RollbackInFlight(_) => {
+    let transaction_id = match &tx.active()?.server_progress {
+        TxServerProgress::Started(id) => Some(id.clone()),
+        TxServerProgress::NotStarted => None,
+        TxServerProgress::BeginInFlight
+        | TxServerProgress::CommitInFlight(_)
+        | TxServerProgress::RollbackInFlight(_) => {
             return Err(YdbError::InternalError(
                 "query transaction operation is already in progress".to_string(),
             ));
@@ -733,17 +734,19 @@ pub(crate) async fn transaction_rollback(tx: &mut TransactionExecContext) -> Ydb
     };
     match transaction_id {
         None => {
-            tx.take_active(TxState::RolledBack)?.lease.return_to_pool();
+            tx.replace_active(TxState::RolledBack)?
+                .lease
+                .return_to_pool();
             return Ok(());
         }
         Some(id) => {
-            tx.active_mut()?.server = ServerTransaction::RollbackInFlight(id);
+            tx.active_mut()?.server_progress = TxServerProgress::RollbackInFlight(id);
         }
     }
 
     let result = async {
         let active = tx.active()?;
-        let ServerTransaction::RollbackInFlight(tx_id) = &active.server else {
+        let TxServerProgress::RollbackInFlight(tx_id) = &active.server_progress else {
             return Err(YdbError::InternalError(
                 "query transaction is not rolling back".to_string(),
             ));
@@ -768,27 +771,27 @@ pub(crate) async fn transaction_rollback(tx: &mut TransactionExecContext) -> Ydb
 
     let terminal = match &result {
         Ok(()) => TxState::RolledBack,
-        Err(err) => TxState::Ambiguous(err.clone()),
+        Err(err) => TxState::Undetermined(err.clone()),
     };
-    let active = tx.take_active(terminal)?;
+    let active = tx.replace_active(terminal)?;
     active.lease.finish(result)
 }
 
 /// Best-effort rollback when [`super::Transaction`] is dropped without `commit`/`rollback`.
-pub(crate) fn finish_query_tx_on_drop(
-    connection_manager: GrpcConnectionManager,
-    active: ActiveTransaction,
-) {
-    let ActiveTransaction { lease, server } = active;
-    let tx_id = match server {
-        ServerTransaction::NotStarted => {
+pub(crate) fn finish_query_tx_on_drop(connection_manager: GrpcConnectionManager, active: ActiveTx) {
+    let ActiveTx {
+        lease,
+        server_progress,
+    } = active;
+    let tx_id = match server_progress {
+        TxServerProgress::NotStarted => {
             lease.return_to_pool();
             return;
         }
-        ServerTransaction::Started(tx_id) => tx_id,
-        ServerTransaction::BeginInFlight
-        | ServerTransaction::CommitInFlight(_)
-        | ServerTransaction::RollbackInFlight(_) => return,
+        TxServerProgress::Started(tx_id) => tx_id,
+        TxServerProgress::BeginInFlight
+        | TxServerProgress::CommitInFlight(_)
+        | TxServerProgress::RollbackInFlight(_) => return,
     };
 
     spawn_pool_release(async move {
@@ -808,20 +811,20 @@ pub(crate) fn finish_query_tx_on_drop(
     });
 }
 
-pub(crate) fn transaction_exec_context(
+pub(crate) fn tx_exec_context(
     connection_manager: GrpcConnectionManager,
     lease: SessionPoolLease,
     options: TransactionOptions,
     retry_deadline: Option<Instant>,
     metrics_names: MetricsNames,
-) -> TransactionExecContext {
-    TransactionExecContext {
+) -> TxExecContext {
+    TxExecContext {
         connection_manager,
         tx_mode: options.mode(),
         begin: options.begin(),
-        state: TxState::Active(ActiveTransaction {
+        state: TxState::Active(ActiveTx {
             lease,
-            server: ServerTransaction::NotStarted,
+            server_progress: TxServerProgress::NotStarted,
         }),
         hooks: Vec::new(),
         retry_deadline,
@@ -829,7 +832,7 @@ pub(crate) fn transaction_exec_context(
     }
 }
 
-pub(crate) fn apply_stream_tx_id(tx: &mut TransactionExecContext, tx_id: Option<String>) {
+pub(crate) fn apply_stream_tx_id(tx: &mut TxExecContext, tx_id: Option<String>) {
     let Some(id) = tx_id else {
         return;
     };
@@ -837,11 +840,11 @@ pub(crate) fn apply_stream_tx_id(tx: &mut TransactionExecContext, tx_id: Option<
         tracing::warn!("query transaction received tx_id after it finished");
         return;
     };
-    match &active.server {
-        ServerTransaction::NotStarted | ServerTransaction::BeginInFlight => {
-            active.server = ServerTransaction::Started(id);
+    match &active.server_progress {
+        TxServerProgress::NotStarted | TxServerProgress::BeginInFlight => {
+            active.server_progress = TxServerProgress::Started(id);
         }
-        ServerTransaction::Started(existing) => {
+        TxServerProgress::Started(existing) => {
             if existing != &id {
                 tracing::warn!(
                     existing = existing.as_str(),
@@ -850,7 +853,7 @@ pub(crate) fn apply_stream_tx_id(tx: &mut TransactionExecContext, tx_id: Option<
                 );
             }
         }
-        ServerTransaction::CommitInFlight(_) | ServerTransaction::RollbackInFlight(_) => {
+        TxServerProgress::CommitInFlight(_) | TxServerProgress::RollbackInFlight(_) => {
             tracing::warn!(
                 incoming = id.as_str(),
                 "query transaction received tx_id while finalization was in progress"
@@ -913,16 +916,17 @@ mod unit_tests {
     async fn transaction_rollback_is_nop_when_finished() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let mut ctx = transaction_exec_context(
+        let mut ctx = tx_exec_context(
             test_connection_manager(),
             lease,
             TransactionOptions::default(),
             None,
             MetricsNames::new(None),
         );
-        ctx.active_mut().expect("active transaction").server =
-            ServerTransaction::Started("tx-1".to_string());
-        transaction_handle_query_error(
+        ctx.active_mut()
+            .expect("active transaction")
+            .server_progress = TxServerProgress::Started("tx-1".to_string());
+        tx_handle_query_error(
             &mut ctx,
             &YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
                 "bad",
@@ -932,21 +936,24 @@ mod unit_tests {
         );
         assert!(!ctx.state.is_active());
         assert!(ctx.transaction_id().is_none());
-        transaction_rollback(&mut ctx).await.expect("rollback nop");
+        tx_rollback(&mut ctx).await.expect("rollback nop");
     }
 
     #[tokio::test]
-    async fn definitive_dispatched_error_invalidates_and_returns_healthy_session() {
+    async fn definitive_dispatched_error_ends_attempt_and_returns_healthy_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
-        let mut ctx = transaction_exec_context(
+        let mut ctx = tx_exec_context(
             test_connection_manager(),
             lease,
             TransactionOptions::default(),
             None,
+            MetricsNames::new(None),
         );
-        ctx.active_mut().expect("active transaction").server = ServerTransaction::BeginInFlight;
+        ctx.active_mut()
+            .expect("active transaction")
+            .server_progress = TxServerProgress::BeginInFlight;
         let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
             message: "transaction rejected".into(),
             operation_status: StatusCode::Aborted as i32,
@@ -956,7 +963,7 @@ mod unit_tests {
         ctx.finish_dispatched_error(&error)
             .expect("rejected operation must finish the transaction");
 
-        assert!(matches!(ctx.state, TxState::Invalidated(_)));
+        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
         let reused = pool
             .acquire_explicit()
             .await
@@ -971,14 +978,16 @@ mod unit_tests {
             let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
             let lease = pool.acquire_explicit().await.expect("acquire test session");
             let session_id = lease.session_id().to_string();
-            let mut ctx = transaction_exec_context(
+            let mut ctx = tx_exec_context(
                 test_connection_manager(),
                 lease,
                 TransactionOptions::default(),
                 None,
+                MetricsNames::new(None),
             );
-            ctx.active_mut().expect("active transaction").server =
-                ServerTransaction::Started("tx-1".to_string());
+            ctx.active_mut()
+                .expect("active transaction")
+                .server_progress = TxServerProgress::Started("tx-1".to_string());
             let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
                 message: "temporary query failure".into(),
                 operation_status: status as i32,
@@ -988,7 +997,7 @@ mod unit_tests {
             ctx.finish_dispatched_error(&error)
                 .expect("temporary failure must finish the local transaction attempt");
 
-            assert!(matches!(ctx.state, TxState::Invalidated(_)));
+            assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
             let replacement = pool
                 .acquire_explicit()
                 .await
@@ -999,17 +1008,20 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn unknown_dispatched_error_is_ambiguous_and_discards_session() {
+    async fn undetermined_dispatched_error_discards_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
-        let mut ctx = transaction_exec_context(
+        let mut ctx = tx_exec_context(
             test_connection_manager(),
             lease,
             TransactionOptions::default(),
             None,
+            MetricsNames::new(None),
         );
-        ctx.active_mut().expect("active transaction").server = ServerTransaction::BeginInFlight;
+        ctx.active_mut()
+            .expect("active transaction")
+            .server_progress = TxServerProgress::BeginInFlight;
         let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
             message: "transaction outcome unknown".into(),
             operation_status: StatusCode::Undetermined as i32,
@@ -1017,9 +1029,9 @@ mod unit_tests {
         });
 
         ctx.finish_dispatched_error(&error)
-            .expect("unknown outcome must finish the transaction");
+            .expect("undetermined outcome must finish the transaction");
 
-        assert!(matches!(ctx.state, TxState::Ambiguous(_)));
+        assert!(matches!(ctx.state, TxState::Undetermined(_)));
         let replacement = pool
             .acquire_explicit()
             .await
@@ -1034,11 +1046,18 @@ mod unit_tests {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
-        let mut ctx =
-            transaction_exec_context(manager.clone(), lease, TransactionOptions::default(), None);
-        ctx.active_mut().expect("active transaction").server = ServerTransaction::BeginInFlight;
+        let mut ctx = tx_exec_context(
+            manager.clone(),
+            lease,
+            TransactionOptions::default(),
+            None,
+            MetricsNames::new(None),
+        );
+        ctx.active_mut()
+            .expect("active transaction")
+            .server_progress = TxServerProgress::BeginInFlight;
         let active = ctx
-            .take_active(TxState::RolledBack)
+            .replace_active(TxState::RolledBack)
             .expect("take active transaction");
 
         finish_query_tx_on_drop(manager, active);

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -30,8 +30,7 @@ pub(crate) struct CallOptions {
     pub collect_stats: bool,
     /// Override Query Service `commit_tx`. `None` uses context default.
     pub commit_tx: Option<bool>,
-    /// Per-call isolation override. `None` → [`TxMode::Implicit`] on client,
-    /// [`TransactionExecContext::tx_mode`] in interactive transactions.
+    /// Per-call isolation override. `None` uses the surrounding context default.
     pub tx_mode: Option<TxMode>,
     /// One-shot [`QueryClient`] only: send `ExecuteQuery` with an empty `session_id`.
     pub implicit_session: bool,
@@ -51,19 +50,28 @@ pub(crate) struct ClientExecContext {
     pub metrics_names: MetricsNames,
 }
 
-/// Query stream together with a pooled session lease when the stream itself owns that lease.
-pub(crate) struct OpenedQueryStream {
+/// Opened client stream and its explicit session ownership mode.
+pub(crate) struct OpenedClientQueryStream {
     pub(crate) stream: ExecuteQueryStream,
-    /// `Some` for a pooled `QueryClient` query: the stream must return or discard this lease.
-    /// `None` means the stream owns no lease: an implicit query has none, while a transaction
-    /// keeps its lease in [`TransactionExecContext`].
-    pub(crate) owned_lease: Option<SessionPoolLease>,
+    pub(crate) session: ClientQuerySession,
 }
 
-#[derive(Clone, Debug)]
+pub(crate) enum ClientQuerySession {
+    ServerImplicit,
+    Pooled(SessionPoolLease),
+}
+
+impl ClientQuerySession {
+    pub(crate) fn complete(self) {
+        if let Self::Pooled(lease) = self {
+            lease.return_to_pool();
+        }
+    }
+}
+
 pub(crate) enum TxState {
-    /// Still going: further queries are allowed, and a final commit is still pending.
-    Active,
+    /// An unfinished transaction always owns exactly one exclusive session lease.
+    Active(ActiveTransaction),
     /// Real, confirmed commit: either `CommitTransaction` succeeded or `commit_tx` completed.
     Committed,
     /// Rollback path was chosen and the SDK must not report a commit.
@@ -76,18 +84,32 @@ pub(crate) enum TxState {
 
 impl TxState {
     pub(crate) fn is_active(&self) -> bool {
-        matches!(self, Self::Active)
+        matches!(self, Self::Active(_))
     }
+}
+
+pub(crate) struct ActiveTransaction {
+    lease: SessionPoolLease,
+    server: ServerTransaction,
+}
+
+/// Server-side progress within an active transaction.
+///
+/// In-flight states retain the lease in the transaction so cancellation is conservative: dropping
+/// the transaction discards the session instead of issuing a second finalization RPC.
+enum ServerTransaction {
+    NotStarted,
+    BeginInFlight,
+    Started(String),
+    CommitInFlight(String),
+    RollbackInFlight(String),
 }
 
 pub(crate) struct TransactionExecContext {
     pub connection_manager: GrpcConnectionManager,
     pub tx_mode: TxMode,
-    pub session_pool: SessionPool,
     /// When set, the first operation calls `BeginTransaction` RPC instead of lazy `BeginTx` in `ExecuteQuery`.
     pub begin: bool,
-    pub pooled_lease: Option<SessionPoolLease>,
-    pub tx_id: Option<String>,
     pub state: TxState,
     pub hooks: Vec<Box<dyn QueryTxHook>>,
     /// Absolute deadline from [`QueryClient::retry_tx`] `.timeout()`, propagated to every RPC in the callback.
@@ -96,11 +118,48 @@ pub(crate) struct TransactionExecContext {
 }
 
 impl TransactionExecContext {
-    pub(super) fn session_lease(&self) -> YdbResult<&SessionPoolLease> {
-        self.pooled_lease.as_ref().ok_or_else(|| {
-            YdbError::InternalError("query transaction session is not initialized".to_string())
-        })
+    fn active(&self) -> YdbResult<&ActiveTransaction> {
+        match &self.state {
+            TxState::Active(active) => Ok(active),
+            _ => Err(transaction_finished_error()),
+        }
     }
+
+    fn active_mut(&mut self) -> YdbResult<&mut ActiveTransaction> {
+        match &mut self.state {
+            TxState::Active(active) => Ok(active),
+            _ => Err(transaction_finished_error()),
+        }
+    }
+
+    pub(super) fn session_lease(&self) -> YdbResult<&SessionPoolLease> {
+        Ok(&self.active()?.lease)
+    }
+
+    pub(super) fn transaction_id(&self) -> Option<&str> {
+        match &self.state {
+            TxState::Active(ActiveTransaction {
+                server: ServerTransaction::Started(id),
+                ..
+            }) => Some(id),
+            _ => None,
+        }
+    }
+
+    fn take_active(&mut self, replacement: TxState) -> YdbResult<ActiveTransaction> {
+        let previous = std::mem::replace(&mut self.state, replacement);
+        match previous {
+            TxState::Active(active) => Ok(active),
+            state => {
+                self.state = state;
+                Err(transaction_finished_error())
+            }
+        }
+    }
+}
+
+fn transaction_finished_error() -> YdbError {
+    YdbError::Custom("transaction already finished (committed or rolled back)".to_string())
 }
 
 /// Per-call timeout capped by the parent [`retry_tx`](crate::QueryClient::retry_tx) deadline when set.
@@ -201,18 +260,17 @@ fn reject_per_call_tx_mode_override(
     Ok(())
 }
 
-fn client_tx_mode(opts: &CallOptions) -> TxMode {
-    opts.tx_mode.unwrap_or(TxMode::Implicit)
-}
-
 fn interactive_tx_mode(tx: &TransactionExecContext, opts: &CallOptions) -> YdbResult<TxMode> {
     reject_per_call_tx_mode_override(tx, opts)?;
     ensure_interactive_tx_mode(opts.tx_mode.unwrap_or(tx.tx_mode))?;
     Ok(tx.tx_mode)
 }
 
+fn client_tx_mode(opts: &CallOptions) -> TxMode {
+    opts.tx_mode.unwrap_or(TxMode::Implicit)
+}
+
 fn default_commit_tx_client(_mode: TxMode) -> bool {
-    // All one-shot modes auto-commit today; revisit if a future mode should not.
     true
 }
 
@@ -229,28 +287,30 @@ fn tx_control_for_transaction(
     tx: &TransactionExecContext,
     opts: &CallOptions,
 ) -> YdbResult<Option<ydb_grpc::ydb_proto::query::TransactionControl>> {
-    if !tx.state.is_active() {
-        return Err(YdbError::Custom(
-            "transaction already finished (committed or rolled back)".to_string(),
-        ));
-    }
     let commit_tx = opts.commit_tx.unwrap_or(false);
-    Ok(Some(match &tx.tx_id {
-        Some(id) => {
+    Ok(Some(match &tx.active()?.server {
+        ServerTransaction::Started(id) => {
             interactive_tx_mode(tx, opts)?;
             tx_id_control(id, commit_tx)
         }
-        None => {
+        ServerTransaction::NotStarted => {
             reject_per_call_tx_mode_override(tx, opts)?;
             ensure_interactive_tx_mode(tx.tx_mode)?;
             begin_tx_control(tx_mode_to_raw(tx.tx_mode)?, commit_tx)
+        }
+        ServerTransaction::BeginInFlight
+        | ServerTransaction::CommitInFlight(_)
+        | ServerTransaction::RollbackInFlight(_) => {
+            return Err(YdbError::InternalError(
+                "query transaction operation is already in progress".to_string(),
+            ));
         }
     }))
 }
 
 pub(crate) fn resolve_commit_tx(core: &super::internal::ExecCoreRef, opts: &CallOptions) -> bool {
-    if let Some(v) = opts.commit_tx {
-        return v;
+    if let Some(commit_tx) = opts.commit_tx {
+        return commit_tx;
     }
     match core {
         super::internal::ExecCoreRef::Client(_) => default_commit_tx_client(client_tx_mode(opts)),
@@ -264,14 +324,14 @@ pub(crate) fn resolve_commit_tx(core: &super::internal::ExecCoreRef, opts: &Call
 fn tx_control_for_client(
     opts: &CallOptions,
 ) -> YdbResult<Option<ydb_grpc::ydb_proto::query::TransactionControl>> {
-    let mode = client_tx_mode(opts);
-    if mode == TxMode::Implicit {
+    let tx_mode = client_tx_mode(opts);
+    if tx_mode == TxMode::Implicit {
         return Ok(None);
     }
     let commit_tx = opts
         .commit_tx
-        .unwrap_or_else(|| default_commit_tx_client(mode));
-    Ok(Some(begin_tx_control(tx_mode_to_raw(mode)?, commit_tx)))
+        .unwrap_or_else(|| default_commit_tx_client(tx_mode));
+    Ok(Some(begin_tx_control(tx_mode_to_raw(tx_mode)?, commit_tx)))
 }
 
 async fn client_implicit_session_request(
@@ -303,15 +363,15 @@ pub(super) async fn client_begin_stream_once(
     params: &HashMap<String, Value>,
     opts: &CallOptions,
     concurrent_result_sets: bool,
-) -> YdbResult<OpenedQueryStream> {
+) -> YdbResult<OpenedClientQueryStream> {
     if opts.implicit_session {
         let (mut client, req) =
             client_implicit_session_request(ctx, text, params, opts, concurrent_result_sets)
                 .await?;
         let stream = client.execute_query(req).await.map_err(YdbError::from)?;
-        return Ok(OpenedQueryStream {
+        return Ok(OpenedClientQueryStream {
             stream: ExecuteQueryStream::new(stream),
-            owned_lease: None,
+            session: ClientQuerySession::ServerImplicit,
         });
     }
 
@@ -324,7 +384,7 @@ async fn open_pooled_query_stream(
     params: &HashMap<String, Value>,
     opts: &CallOptions,
     concurrent_result_sets: bool,
-) -> YdbResult<OpenedQueryStream> {
+) -> YdbResult<OpenedClientQueryStream> {
     let tx_control = tx_control_for_client(opts)?;
     let lease = Box::pin(ctx.session_pool.acquire_explicit()).await?;
     let result = async {
@@ -348,9 +408,9 @@ async fn open_pooled_query_stream(
     .await;
 
     match result {
-        Ok(stream) => Ok(OpenedQueryStream {
+        Ok(stream) => Ok(OpenedClientQueryStream {
             stream,
-            owned_lease: Some(lease),
+            session: ClientQuerySession::Pooled(lease),
         }),
         Err(err) => lease.finish(Err(err)),
     }
@@ -363,7 +423,7 @@ pub(crate) async fn client_begin_stream(
     params: HashMap<String, Value>,
     opts: CallOptions,
     concurrent_result_sets: bool,
-) -> YdbResult<OpenedQueryStream> {
+) -> YdbResult<OpenedClientQueryStream> {
     ctx.retry_settings
         .clone()
         .with_deadline(opts.timeout)
@@ -380,46 +440,17 @@ pub(crate) async fn client_begin_stream(
         .await
 }
 
-/// Interactive transactions need a stable attached session from the driver pool.
-#[instrument(name = "ydb.Query.EnsureTxSession", skip_all, fields(db.system.name = "ydb"), err)]
-async fn ensure_tx_session(tx: &mut TransactionExecContext) -> YdbResult<()> {
-    if let Some(lease) = &tx.pooled_lease {
-        lease.ensure_healthy()?;
-        return Ok(());
-    }
-    let lease = Box::pin(tx.session_pool.acquire_explicit()).await?;
-    tx.pooled_lease = Some(lease);
-    Ok(())
-}
-
 /// Session and transaction ids for cross-service RPCs (e.g. topic `UpdateOffsetsInTransaction`).
 pub(crate) async fn transaction_identity(
     tx: &mut TransactionExecContext,
 ) -> YdbResult<(String, String)> {
-    transaction_ensure_begin(tx, false).await?;
+    transaction_ensure_begin(tx).await?;
     let session_id = tx.session_lease()?.session_id().to_string();
     let transaction_id = tx
-        .tx_id
-        .as_deref()
-        .filter(|id| !id.is_empty())
+        .transaction_id()
         .ok_or_else(|| YdbError::Custom("query transaction id is not available".to_string()))?
         .to_string();
     Ok((session_id, transaction_id))
-}
-
-#[instrument(name = "ydb.Query.ReleaseTxSession", skip_all, fields(db.system.name = "ydb"))]
-pub(super) fn release_tx_session(tx: &mut TransactionExecContext) {
-    if let Some(lease) = tx.pooled_lease.take() {
-        lease.return_to_pool();
-    }
-}
-
-#[instrument(name = "ydb.Query.ReleaseTxSession", skip_all, fields(db.system.name = "ydb"))]
-fn finish_tx_session<T>(tx: &mut TransactionExecContext, result: YdbResult<T>) -> YdbResult<T> {
-    match tx.pooled_lease.take() {
-        Some(lease) => lease.finish(result),
-        None => result,
-    }
 }
 
 #[instrument(name = "ydb.ExecuteQuery", skip_all, fields(db.system.name = "ydb", ydb.Query.text = %ensure_len_string(&yql_text), ydb.Query.params = ?parameters, ydb.Query.opts = ?opts))]
@@ -430,10 +461,9 @@ async fn transaction_execute_request(
     opts: &CallOptions,
     concurrent_result_sets: bool,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
-    let session_id = tx.session_lease()?.session_id().to_string();
     let client = query_client_from_tx(tx).await?;
     let mut req = RawExecuteQueryRequest::new(
-        session_id,
+        tx.session_lease()?.session_id(),
         yql_text,
         parameters,
         tx_control_for_transaction(tx, opts)?,
@@ -445,45 +475,82 @@ async fn transaction_execute_request(
 
 /// Open the transaction via `BeginTransaction` RPC (explicit begin).
 #[instrument(name = "ydb.Query.TransactionEnsureBegin", skip_all, fields(db.system.name = "ydb", ydb.tx.mode = ?tx.tx_mode, ydb.session.id = tracing::field::Empty), err)]
-pub(crate) async fn transaction_ensure_begin(
-    tx: &mut TransactionExecContext,
-    session_ready: bool,
-) -> YdbResult<()> {
-    if !tx.state.is_active() {
-        return Err(YdbError::Custom(
-            "transaction already finished (committed or rolled back)".to_string(),
-        ));
-    }
-    if tx.tx_id.as_ref().is_some_and(|id| !id.is_empty()) {
-        return Ok(());
+pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) -> YdbResult<()> {
+    match &tx.active()?.server {
+        ServerTransaction::Started(_) => return Ok(()),
+        ServerTransaction::NotStarted => {}
+        ServerTransaction::BeginInFlight
+        | ServerTransaction::CommitInFlight(_)
+        | ServerTransaction::RollbackInFlight(_) => {
+            return Err(YdbError::InternalError(
+                "query transaction operation is already in progress".to_string(),
+            ));
+        }
     }
     ensure_interactive_tx_mode(tx.tx_mode)?;
-    if !session_ready {
-        ensure_tx_session(tx).await?;
-    }
-    let session_id = tx.session_lease()?.session_id().to_string();
-    tracing::Span::current().record("ydb.session.id", &session_id);
-    let mut client = query_client_from_tx(tx).await?;
-    let tx_id =
+    tx.session_lease()?.ensure_healthy()?;
+    tx.active_mut()?.server = ServerTransaction::BeginInFlight;
+
+    let result = async {
+        let active = tx.active()?;
+        let session_id = active.lease.session_id();
+        tracing::Span::current().record("ydb.session.id", session_id);
+        let mut client = tx
+            .connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, active.lease.node_uri())
+            .await?;
         maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
             client
-                .begin_transaction(&session_id, tx_mode_to_raw(tx.tx_mode)?)
+                .begin_transaction(session_id, tx_mode_to_raw(tx.tx_mode)?)
                 .await
                 .map_err(Into::into)
         })
-        .await?;
-    apply_stream_tx_id(tx, Some(tx_id));
-    Ok(())
+        .await
+    }
+    .await;
+
+    match result {
+        Ok(tx_id) => {
+            tx.active_mut()?.server = ServerTransaction::Started(tx_id);
+            Ok(())
+        }
+        Err(err) => {
+            let active = tx.active_mut()?;
+            active.server = ServerTransaction::NotStarted;
+            if err.requires_session_discard() {
+                active.lease.invalidate();
+            }
+            Err(err)
+        }
+    }
 }
 
-/// Mark the transaction committed by the server as part of the last `ExecuteQuery` (`commit_tx: true`).
-pub(crate) fn transaction_finish_committed_via_query(tx: &mut TransactionExecContext) {
-    tx.metrics_names
-        .client_transaction_commit_counter
-        .increment(1);
-    tx.state = TxState::Committed;
-    tx.tx_id = None;
-    release_tx_session(tx);
+/// Finish a successful transaction query after its response stream reaches EOF.
+pub(crate) fn transaction_finish_query(
+    tx: &mut TransactionExecContext,
+    commit_at_end: bool,
+) -> YdbResult<()> {
+    if commit_at_end {
+        tx.metrics_names
+            .client_transaction_commit_counter
+            .increment(1);
+        tx.take_active(TxState::Committed)?.lease.return_to_pool();
+        return Ok(());
+    }
+
+    let message = match &tx.active()?.server {
+        ServerTransaction::Started(_) => return Ok(()),
+        ServerTransaction::BeginInFlight => "ExecuteQuery response missing transaction id",
+        ServerTransaction::NotStarted
+        | ServerTransaction::CommitInFlight(_)
+        | ServerTransaction::RollbackInFlight(_) => {
+            "query transaction reached an invalid state after ExecuteQuery"
+        }
+    };
+    let error = YdbError::InternalError(message.to_string());
+    let mut active = tx.take_active(TxState::Ambiguous(error.clone()))?;
+    active.lease.invalidate();
+    Err(error)
 }
 
 async fn transaction_before_commit(tx: &mut TransactionExecContext) -> YdbResult<()> {
@@ -495,14 +562,26 @@ async fn transaction_before_commit(tx: &mut TransactionExecContext) -> YdbResult
 
 /// Apply a query error to the retained session and transaction state.
 pub(crate) fn transaction_handle_query_error(tx: &mut TransactionExecContext, err: &YdbError) {
-    if err.requires_session_discard()
-        && let Some(lease) = &mut tx.pooled_lease
+    if err.invalidates_server_transaction() && tx.state.is_active() {
+        let previous = std::mem::replace(&mut tx.state, TxState::Invalidated(err.clone()));
+        let TxState::Active(mut active) = previous else {
+            tx.state = previous;
+            return;
+        };
+        if err.requires_session_discard() {
+            active.lease.invalidate();
+        }
+        active.lease.return_to_pool();
+    } else if let TxState::Active(active) = &mut tx.state
+        && err.requires_session_discard()
     {
-        lease.invalidate();
+        active.lease.invalidate();
     }
-    if tx.state.is_active() && err.invalidates_server_transaction() {
-        tx.state = TxState::Invalidated(err.clone());
-        tx.tx_id = None;
+}
+
+pub(crate) fn transaction_invalidate_session(tx: &mut TransactionExecContext) {
+    if let TxState::Active(active) = &mut tx.state {
+        active.lease.invalidate();
     }
 }
 
@@ -513,23 +592,19 @@ pub(crate) async fn transaction_begin_stream(
     params: HashMap<String, Value>,
     opts: CallOptions,
     concurrent_result_sets: bool,
-) -> YdbResult<OpenedQueryStream> {
+) -> YdbResult<ExecuteQueryStream> {
     debug_assert!(
         !opts.implicit_session,
         "implicit_session is only available on QueryClient one-shot builders"
     );
-    if !tx.state.is_active() {
-        return Err(YdbError::Custom(
-            "transaction already finished (committed or rolled back)".to_string(),
-        ));
-    }
+    tx.active()?;
     let effective_timeout = resolve_effective_timeout(tx.retry_deadline, opts.timeout);
-    let result: YdbResult<OpenedQueryStream> =
+    let result: YdbResult<ExecuteQueryStream> =
         maybe_with_operation_timeout(effective_timeout, async {
-            ensure_tx_session(tx).await?;
+            tx.session_lease()?.ensure_healthy()?;
             tracing::Span::current().record("ydb.session.id", tx.session_lease()?.session_id());
             if tx.begin {
-                transaction_ensure_begin(tx, true).await?;
+                transaction_ensure_begin(tx).await?;
             }
             if opts.commit_tx.unwrap_or(false) {
                 transaction_before_commit(tx).await?;
@@ -537,20 +612,40 @@ pub(crate) async fn transaction_begin_stream(
             let (mut client, req) =
                 transaction_execute_request(tx, text, params, &opts, concurrent_result_sets)
                     .await?;
+            let starts_transaction = matches!(tx.active()?.server, ServerTransaction::NotStarted);
+            if starts_transaction {
+                tx.active_mut()?.server = ServerTransaction::BeginInFlight;
+            }
             let stream = client.execute_query(req).await.map_err(YdbError::from)?;
             let mut stream = ExecuteQueryStream::new(stream);
             stream.prime_first_part().await?;
-            if let Some(id) = stream.take_captured_tx_id() {
-                apply_stream_tx_id(tx, Some(id));
+            if !stream.in_progress() {
+                let error = YdbError::InternalError(
+                    "ExecuteQuery response stream closed before the first part".to_string(),
+                );
+                let mut active = tx.take_active(TxState::Ambiguous(error.clone()))?;
+                active.lease.invalidate();
+                return Err(error);
             }
-            Ok(OpenedQueryStream {
-                stream,
-                owned_lease: None,
-            })
+            let tx_id = stream.take_captured_tx_id();
+            apply_stream_tx_id(tx, tx_id);
+            Ok(stream)
         })
         .await;
     if let Err(err) = &result {
-        transaction_handle_query_error(tx, err);
+        if matches!(
+            tx.state,
+            TxState::Active(ActiveTransaction {
+                server: ServerTransaction::BeginInFlight,
+                ..
+            })
+        ) {
+            let mut active = tx.take_active(TxState::Ambiguous(err.clone()))?;
+            active.lease.invalidate();
+            active.lease.return_to_pool();
+        } else {
+            transaction_handle_query_error(tx, err);
+        }
     }
     result
 }
@@ -564,37 +659,61 @@ pub(crate) async fn transaction_commit(tx: &mut TransactionExecContext) -> YdbRe
         let _ = transaction_rollback(tx).await;
         return Err(err);
     }
-    if tx.tx_id.as_ref().is_none_or(String::is_empty) {
-        tx.state = TxState::Committed;
-        release_tx_session(tx);
-        return Ok(());
+    let transaction_id = match &tx.active()?.server {
+        ServerTransaction::Started(id) => Some(id.clone()),
+        ServerTransaction::NotStarted => None,
+        ServerTransaction::BeginInFlight
+        | ServerTransaction::CommitInFlight(_)
+        | ServerTransaction::RollbackInFlight(_) => {
+            return Err(YdbError::InternalError(
+                "query transaction operation is already in progress".to_string(),
+            ));
+        }
+    };
+    match transaction_id {
+        None => {
+            tx.take_active(TxState::Committed)?.lease.return_to_pool();
+            return Ok(());
+        }
+        Some(id) => {
+            tx.active_mut()?.server = ServerTransaction::CommitInFlight(id);
+        }
     }
     tx.metrics_names
         .client_transaction_commit_counter
         .increment(1);
-
-    ensure_tx_session(tx).await?;
-    let tx_id = tx.tx_id.take().expect("checked Some");
-    let session_id = tx.session_lease()?.session_id().to_string();
-    tracing::Span::current()
-        .record("ydb.session.id", &session_id)
-        .record("ydb.tx.id", &tx_id);
-    let mut client = query_client_from_tx(tx).await?;
-    let result =
+    let result = async {
+        let active = tx.active()?;
+        let ServerTransaction::CommitInFlight(tx_id) = &active.server else {
+            return Err(YdbError::InternalError(
+                "query transaction is not committing".to_string(),
+            ));
+        };
+        let session_id = active.lease.session_id();
+        tracing::Span::current()
+            .record("ydb.session.id", session_id)
+            .record("ydb.tx.id", tx_id.as_str());
+        let mut client = tx
+            .connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, active.lease.node_uri())
+            .await?;
         maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
             client
-                .commit_transaction(&session_id, &tx_id)
+                .commit_transaction(session_id, tx_id.as_str())
                 .await
                 .map_err(Into::into)
         })
-        .await;
-    let result = finish_tx_session(tx, result);
-    tx.state = match &result {
+        .await
+    }
+    .await;
+
+    let terminal = match &result {
         Ok(()) => TxState::Committed,
         Err(err) => TxState::Ambiguous(err.clone()),
     };
+    let active = tx.take_active(terminal)?;
     // Do not retry commit: a transport timeout may mean the commit succeeded server-side.
-    result
+    active.lease.finish(result)
 }
 
 #[instrument(name = "ydb.Rollback", skip_all, fields(db.system.name = "ydb", ydb.tx.id = tracing::field::Empty, ydb.session.id = tracing::field::Empty), err)]
@@ -605,50 +724,75 @@ pub(crate) async fn transaction_rollback(tx: &mut TransactionExecContext) -> Ydb
     tx.metrics_names
         .client_transaction_rollback_counter
         .increment(1);
-    let mut rollback_err: Option<YdbError> = None;
-    if tx.tx_id.as_ref().is_some_and(|id| !id.is_empty()) && tx.pooled_lease.is_some() {
-        let tx_id = tx.tx_id.take().expect("checked Some");
-        if let Ok(session_id) = tx.session_lease().map(|lease| lease.session_id())
-            && let Ok(mut client) = query_client_from_tx(tx).await
-        {
-            tracing::Span::current()
-                .record("ydb.session.id", session_id)
-                .record("ydb.tx.id", &tx_id);
-            let rollback_result = maybe_with_operation_timeout(
-                resolve_effective_timeout(tx.retry_deadline, None),
-                async {
-                    client
-                        .rollback_transaction(session_id, &tx_id)
-                        .await
-                        .map_err(Into::into)
-                },
-            )
-            .await;
-            if let Err(err) = rollback_result {
-                rollback_err = Some(err);
-            }
+    let transaction_id = match &tx.active()?.server {
+        ServerTransaction::Started(id) => Some(id.clone()),
+        ServerTransaction::NotStarted => None,
+        ServerTransaction::BeginInFlight
+        | ServerTransaction::CommitInFlight(_)
+        | ServerTransaction::RollbackInFlight(_) => {
+            return Err(YdbError::InternalError(
+                "query transaction operation is already in progress".to_string(),
+            ));
         }
-    } else {
-        tx.tx_id = None;
+    };
+    match transaction_id {
+        None => {
+            tx.take_active(TxState::RolledBack)?.lease.return_to_pool();
+            return Ok(());
+        }
+        Some(id) => {
+            tx.active_mut()?.server = ServerTransaction::RollbackInFlight(id);
+        }
     }
-    let result = finish_tx_session(tx, rollback_err.map_or(Ok(()), Err));
-    tx.state = match &result {
+
+    let result = async {
+        let active = tx.active()?;
+        let ServerTransaction::RollbackInFlight(tx_id) = &active.server else {
+            return Err(YdbError::InternalError(
+                "query transaction is not rolling back".to_string(),
+            ));
+        };
+        let session_id = active.lease.session_id();
+        tracing::Span::current()
+            .record("ydb.session.id", session_id)
+            .record("ydb.tx.id", tx_id.as_str());
+        let mut client = tx
+            .connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, active.lease.node_uri())
+            .await?;
+        maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
+            client
+                .rollback_transaction(session_id, tx_id.as_str())
+                .await
+                .map_err(Into::into)
+        })
+        .await
+    }
+    .await;
+
+    let terminal = match &result {
         Ok(()) => TxState::RolledBack,
         Err(err) => TxState::Ambiguous(err.clone()),
     };
-    result
+    let active = tx.take_active(terminal)?;
+    active.lease.finish(result)
 }
 
 /// Best-effort rollback when [`super::Transaction`] is dropped without `commit`/`rollback`.
-pub(crate) fn spawn_query_tx_rollback_on_drop(ctx: &mut TransactionExecContext) {
-    let tx_id = ctx.tx_id.take().filter(|id| !id.is_empty());
-    let Some(lease) = ctx.pooled_lease.take() else {
-        return;
-    };
-    let connection_manager = ctx.connection_manager.clone();
-
-    let Some(tx_id) = tx_id else {
-        return;
+pub(crate) fn finish_query_tx_on_drop(
+    connection_manager: GrpcConnectionManager,
+    active: ActiveTransaction,
+) {
+    let ActiveTransaction { lease, server } = active;
+    let tx_id = match server {
+        ServerTransaction::NotStarted => {
+            lease.return_to_pool();
+            return;
+        }
+        ServerTransaction::Started(tx_id) => tx_id,
+        ServerTransaction::BeginInFlight
+        | ServerTransaction::CommitInFlight(_)
+        | ServerTransaction::RollbackInFlight(_) => return,
     };
 
     spawn_pool_release(async move {
@@ -657,7 +801,7 @@ pub(crate) fn spawn_query_tx_rollback_on_drop(ctx: &mut TransactionExecContext) 
             .await;
         let rollback_ok = match client_result {
             Ok(mut client) => client
-                .rollback_transaction(lease.session_id(), &tx_id)
+                .rollback_transaction(lease.session_id(), tx_id.as_str())
                 .await
                 .is_ok(),
             Err(_) => false,
@@ -670,19 +814,19 @@ pub(crate) fn spawn_query_tx_rollback_on_drop(ctx: &mut TransactionExecContext) 
 
 pub(crate) fn transaction_exec_context(
     connection_manager: GrpcConnectionManager,
-    session_pool: SessionPool,
+    lease: SessionPoolLease,
     options: TransactionOptions,
     retry_deadline: Option<Instant>,
     metrics_names: MetricsNames,
 ) -> TransactionExecContext {
     TransactionExecContext {
         connection_manager,
-        session_pool,
         tx_mode: options.mode(),
         begin: options.begin(),
-        pooled_lease: None,
-        tx_id: None,
-        state: TxState::Active,
+        state: TxState::Active(ActiveTransaction {
+            lease,
+            server: ServerTransaction::NotStarted,
+        }),
         hooks: Vec::new(),
         retry_deadline,
         metrics_names,
@@ -690,20 +834,33 @@ pub(crate) fn transaction_exec_context(
 }
 
 pub(crate) fn apply_stream_tx_id(tx: &mut TransactionExecContext, tx_id: Option<String>) {
-    let Some(id) = tx_id.filter(|id| !id.is_empty()) else {
+    let Some(id) = tx_id else {
         return;
     };
-    if let Some(existing) = &tx.tx_id {
-        if *existing != id {
+    let Ok(active) = tx.active_mut() else {
+        tracing::warn!("query transaction received tx_id after it finished");
+        return;
+    };
+    match &active.server {
+        ServerTransaction::NotStarted | ServerTransaction::BeginInFlight => {
+            active.server = ServerTransaction::Started(id);
+        }
+        ServerTransaction::Started(existing) => {
+            if existing != &id {
+                tracing::warn!(
+                    existing = existing.as_str(),
+                    incoming = id.as_str(),
+                    "query transaction tx_id changed in stream; keeping first value"
+                );
+            }
+        }
+        ServerTransaction::CommitInFlight(_) | ServerTransaction::RollbackInFlight(_) => {
             tracing::warn!(
-                existing = existing.as_str(),
                 incoming = id.as_str(),
-                "query transaction tx_id changed in stream; keeping first value"
+                "query transaction received tx_id while finalization was in progress"
             );
         }
-        return;
     }
-    tx.tx_id = Some(id);
 }
 
 #[cfg(test)]
@@ -747,6 +904,8 @@ mod unit_tests {
         use http::Uri;
         use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
         let mut ctx = transaction_exec_context(
             GrpcConnectionManager::new(
                 SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
@@ -756,12 +915,13 @@ mod unit_tests {
                 MultiInterceptor::new(),
                 GrpcOptions::default(),
             ),
-            SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1)),
+            lease,
             TransactionOptions::default(),
             None,
             MetricsNames::new(None),
         );
-        ctx.tx_id = Some("tx-1".into());
+        ctx.active_mut().expect("active transaction").server =
+            ServerTransaction::Started("tx-1".to_string());
         transaction_handle_query_error(
             &mut ctx,
             &YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
@@ -771,7 +931,44 @@ mod unit_tests {
             )),
         );
         assert!(!ctx.state.is_active());
-        assert!(ctx.tx_id.is_none());
+        assert!(ctx.transaction_id().is_none());
         transaction_rollback(&mut ctx).await.expect("rollback nop");
+    }
+
+    #[tokio::test]
+    async fn in_flight_transaction_cleanup_discards_its_session() {
+        use crate::client_query::TransactionOptions;
+        use crate::grpc_connection_manager::GrpcConnectionManager;
+        use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
+        use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
+        use crate::session_pool::{SessionPool, SessionPoolSettings};
+        use http::Uri;
+
+        let manager = GrpcConnectionManager::new(
+            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
+                Uri::from_static("http://127.0.0.1/bench"),
+            ))),
+            "bench".to_string(),
+            MultiInterceptor::new(),
+            GrpcOptions::default(),
+        );
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut ctx =
+            transaction_exec_context(manager.clone(), lease, TransactionOptions::default(), None);
+        ctx.active_mut().expect("active transaction").server = ServerTransaction::BeginInFlight;
+        let active = ctx
+            .take_active(TxState::RolledBack)
+            .expect("take active transaction");
+
+        finish_query_tx_on_drop(manager, active);
+
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("acquire replacement session");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
     }
 }

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -575,9 +575,18 @@ pub(crate) fn tx_handle_query_error(tx: &mut TxExecContext, err: &YdbError) {
     }
 }
 
-pub(crate) fn tx_invalidate_session(tx: &mut TxExecContext) {
-    if let TxState::Active(active) = &mut tx.state {
-        active.lease.invalidate();
+/// Cancel a transaction query whose response stream was not successfully closed.
+pub(crate) fn tx_cancel_query(tx: &mut TxExecContext) {
+    if !tx.state.is_active() {
+        return;
+    }
+
+    let error = YdbError::InternalError(
+        "query response stream was dropped before successful close".to_string(),
+    );
+    match tx.replace_active(TxState::Undetermined(error)) {
+        Ok(mut active) => active.lease.invalidate(),
+        Err(error) => tracing::error!(%error, "failed to cancel transaction query"),
     }
 }
 

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -971,11 +971,11 @@ mod unit_tests {
         ctx.active_mut()
             .expect("active transaction")
             .server_progress = TxServerProgress::BeginInFlight;
-        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
-            message: "transaction rejected".into(),
-            operation_status: StatusCode::Aborted as i32,
-            issues: vec![],
-        });
+        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
+            "transaction rejected",
+            StatusCode::Aborted as i32,
+            vec![],
+        ));
 
         ctx.fail_attempt(&error)
             .expect("rejected operation must finish the transaction");
@@ -1005,11 +1005,11 @@ mod unit_tests {
             ctx.active_mut()
                 .expect("active transaction")
                 .server_progress = TxServerProgress::Started("tx-1".to_string());
-            let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
-                message: "temporary query failure".into(),
-                operation_status: status as i32,
-                issues: vec![],
-            });
+            let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
+                "temporary query failure",
+                status as i32,
+                vec![],
+            ));
 
             ctx.fail_attempt(&error)
                 .expect("temporary failure must finish the local transaction attempt");
@@ -1039,11 +1039,11 @@ mod unit_tests {
         ctx.active_mut()
             .expect("active transaction")
             .server_progress = TxServerProgress::BeginInFlight;
-        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
-            message: "transaction outcome unknown".into(),
-            operation_status: StatusCode::Undetermined as i32,
-            issues: vec![],
-        });
+        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
+            "transaction outcome unknown",
+            StatusCode::Undetermined as i32,
+            vec![],
+        ));
 
         ctx.fail_attempt(&error)
             .expect("undetermined outcome must finish the transaction");

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use tokio::time::timeout;
 
-use crate::errors::{Idempotency, YdbError, YdbResult};
+use crate::errors::{Idempotency, TransactionErrorOutcome, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
@@ -155,6 +155,19 @@ impl TransactionExecContext {
                 Err(transaction_finished_error())
             }
         }
+    }
+
+    fn finish_dispatched_error(&mut self, error: &YdbError) -> YdbResult<()> {
+        let outcome = error.transaction_error_outcome();
+        let replacement = match outcome {
+            TransactionErrorOutcome::AttemptFailed => TxState::Invalidated(error.clone()),
+            TransactionErrorOutcome::OutcomeUnknown => TxState::Ambiguous(error.clone()),
+        };
+        let active = self.take_active(replacement)?;
+        if outcome == TransactionErrorOutcome::AttemptFailed && !error.requires_session_discard() {
+            active.lease.return_to_pool();
+        }
+        Ok(())
     }
 }
 
@@ -489,25 +502,22 @@ pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) ->
     }
     ensure_interactive_tx_mode(tx.tx_mode)?;
     tx.session_lease()?.ensure_healthy()?;
+    let raw_tx_mode = tx_mode_to_raw(tx.tx_mode)?;
+    let mut client = query_client_from_tx(tx).await?;
     tx.active_mut()?.server = ServerTransaction::BeginInFlight;
 
-    let result = async {
+    let result = {
         let active = tx.active()?;
         let session_id = active.lease.session_id();
         tracing::Span::current().record("ydb.session.id", session_id);
-        let mut client = tx
-            .connection_manager
-            .get_auth_service_to_node(RawQueryClient::new, active.lease.node_uri())
-            .await?;
         maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
             client
-                .begin_transaction(session_id, tx_mode_to_raw(tx.tx_mode)?)
+                .begin_transaction(session_id, raw_tx_mode)
                 .await
                 .map_err(Into::into)
         })
         .await
-    }
-    .await;
+    };
 
     match result {
         Ok(tx_id) => {
@@ -515,11 +525,7 @@ pub(crate) async fn transaction_ensure_begin(tx: &mut TransactionExecContext) ->
             Ok(())
         }
         Err(err) => {
-            let active = tx.active_mut()?;
-            active.server = ServerTransaction::NotStarted;
-            if err.requires_session_discard() {
-                active.lease.invalidate();
-            }
+            tx.finish_dispatched_error(&err)?;
             Err(err)
         }
     }
@@ -562,20 +568,10 @@ async fn transaction_before_commit(tx: &mut TransactionExecContext) -> YdbResult
 
 /// Apply a query error to the retained session and transaction state.
 pub(crate) fn transaction_handle_query_error(tx: &mut TransactionExecContext, err: &YdbError) {
-    if err.invalidates_server_transaction() && tx.state.is_active() {
-        let previous = std::mem::replace(&mut tx.state, TxState::Invalidated(err.clone()));
-        let TxState::Active(mut active) = previous else {
-            tx.state = previous;
-            return;
-        };
-        if err.requires_session_discard() {
-            active.lease.invalidate();
-        }
-        active.lease.return_to_pool();
-    } else if let TxState::Active(active) = &mut tx.state
-        && err.requires_session_discard()
+    if tx.state.is_active()
+        && let Err(error) = tx.finish_dispatched_error(err)
     {
-        active.lease.invalidate();
+        tracing::error!(%error, "failed to finish transaction after query error");
     }
 }
 
@@ -599,6 +595,7 @@ pub(crate) async fn transaction_begin_stream(
     );
     tx.active()?;
     let effective_timeout = resolve_effective_timeout(tx.retry_deadline, opts.timeout);
+    let mut query_dispatched = false;
     let result: YdbResult<ExecuteQueryStream> =
         maybe_with_operation_timeout(effective_timeout, async {
             tx.session_lease()?.ensure_healthy()?;
@@ -616,6 +613,7 @@ pub(crate) async fn transaction_begin_stream(
             if starts_transaction {
                 tx.active_mut()?.server = ServerTransaction::BeginInFlight;
             }
+            query_dispatched = true;
             let stream = client.execute_query(req).await.map_err(YdbError::from)?;
             let mut stream = ExecuteQueryStream::new(stream);
             stream.prime_first_part().await?;
@@ -633,18 +631,12 @@ pub(crate) async fn transaction_begin_stream(
         })
         .await;
     if let Err(err) = &result {
-        if matches!(
-            tx.state,
-            TxState::Active(ActiveTransaction {
-                server: ServerTransaction::BeginInFlight,
-                ..
-            })
-        ) {
-            let mut active = tx.take_active(TxState::Ambiguous(err.clone()))?;
-            active.lease.invalidate();
-            active.lease.return_to_pool();
-        } else {
+        if query_dispatched {
             transaction_handle_query_error(tx, err);
+        } else if let TxState::Active(active) = &mut tx.state
+            && err.requires_session_discard()
+        {
+            active.lease.invalidate();
         }
     }
     result
@@ -882,8 +874,27 @@ pub(super) fn build_client_execute_request_for_test(
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+    use http::Uri;
+    use ydb_grpc::ydb_proto::status_ids::StatusCode;
+
     use crate::GrpcOptions;
+    use crate::client_query::TransactionOptions;
     use crate::errors::{Idempotency, YdbError, YdbOrCustomerError};
+    use crate::grpc_connection_manager::GrpcConnectionManager;
+    use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
+    use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
+    use crate::session_pool::{SessionPool, SessionPoolSettings};
+
+    fn test_connection_manager() -> GrpcConnectionManager {
+        GrpcConnectionManager::new(
+            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
+                Uri::from_static("http://127.0.0.1/bench"),
+            ))),
+            "bench".to_string(),
+            MultiInterceptor::new(),
+            GrpcOptions::default(),
+        )
+    }
 
     #[test]
     fn retry_helpers_and_wait() {
@@ -896,25 +907,10 @@ mod unit_tests {
 
     #[tokio::test]
     async fn transaction_rollback_is_nop_when_finished() {
-        use crate::client_query::TransactionOptions;
-        use crate::grpc_connection_manager::GrpcConnectionManager;
-        use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
-        use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
-        use crate::session_pool::{SessionPool, SessionPoolSettings};
-        use http::Uri;
-        use ydb_grpc::ydb_proto::status_ids::StatusCode;
-
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let mut ctx = transaction_exec_context(
-            GrpcConnectionManager::new(
-                SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
-                    Uri::from_static("http://127.0.0.1/bench"),
-                ))),
-                "bench".to_string(),
-                MultiInterceptor::new(),
-                GrpcOptions::default(),
-            ),
+            test_connection_manager(),
             lease,
             TransactionOptions::default(),
             None,
@@ -936,22 +932,68 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn in_flight_transaction_cleanup_discards_its_session() {
-        use crate::client_query::TransactionOptions;
-        use crate::grpc_connection_manager::GrpcConnectionManager;
-        use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
-        use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
-        use crate::session_pool::{SessionPool, SessionPoolSettings};
-        use http::Uri;
-
-        let manager = GrpcConnectionManager::new(
-            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
-                Uri::from_static("http://127.0.0.1/bench"),
-            ))),
-            "bench".to_string(),
-            MultiInterceptor::new(),
-            GrpcOptions::default(),
+    async fn definitive_dispatched_error_invalidates_and_returns_healthy_session() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut ctx = transaction_exec_context(
+            test_connection_manager(),
+            lease,
+            TransactionOptions::default(),
+            None,
         );
+        ctx.active_mut().expect("active transaction").server = ServerTransaction::BeginInFlight;
+        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
+            message: "transaction rejected".into(),
+            operation_status: StatusCode::Aborted as i32,
+            issues: vec![],
+        });
+
+        ctx.finish_dispatched_error(&error)
+            .expect("rejected operation must finish the transaction");
+
+        assert!(matches!(ctx.state, TxState::Invalidated(_)));
+        let reused = pool
+            .acquire_explicit()
+            .await
+            .expect("healthy session must return to the pool");
+        assert_eq!(reused.session_id(), session_id);
+        reused.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn unknown_dispatched_error_is_ambiguous_and_discards_session() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut ctx = transaction_exec_context(
+            test_connection_manager(),
+            lease,
+            TransactionOptions::default(),
+            None,
+        );
+        ctx.active_mut().expect("active transaction").server = ServerTransaction::BeginInFlight;
+        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError {
+            message: "transaction outcome unknown".into(),
+            operation_status: StatusCode::Undetermined as i32,
+            issues: vec![],
+        });
+
+        ctx.finish_dispatched_error(&error)
+            .expect("unknown outcome must finish the transaction");
+
+        assert!(matches!(ctx.state, TxState::Ambiguous(_)));
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("discarded session must be replaced");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn in_flight_transaction_cleanup_discards_its_session() {
+        let manager = test_connection_manager();
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();

--- a/ydb/src/client_query/internal.rs
+++ b/ydb/src/client_query/internal.rs
@@ -1,6 +1,0 @@
-use super::exec::{ClientExecContext, TransactionExecContext};
-
-pub(crate) enum ExecCoreRef<'a> {
-    Client(&'a mut ClientExecContext),
-    Transaction(&'a mut TransactionExecContext),
-}

--- a/ydb/src/client_query/internal.rs
+++ b/ydb/src/client_query/internal.rs
@@ -1,37 +1,6 @@
-use std::collections::HashMap;
-
-use futures_util::future::BoxFuture;
-
-use crate::errors::YdbResult;
-use crate::types::Value;
-
-use super::exec::{
-    CallOptions, ClientExecContext, OpenedQueryStream, TransactionExecContext, client_begin_stream,
-    transaction_begin_stream,
-};
+use super::exec::{ClientExecContext, TransactionExecContext};
 
 pub(crate) enum ExecCoreRef<'a> {
     Client(&'a mut ClientExecContext),
     Transaction(&'a mut TransactionExecContext),
-}
-
-impl ExecCoreRef<'_> {
-    pub(crate) fn begin_stream(
-        &mut self,
-        text: String,
-        params: HashMap<String, Value>,
-        opts: CallOptions,
-        concurrent_result_sets: bool,
-    ) -> BoxFuture<'_, YdbResult<OpenedQueryStream>> {
-        Box::pin(async move {
-            match self {
-                ExecCoreRef::Client(ctx) => {
-                    client_begin_stream(ctx, text, params, opts, concurrent_result_sets).await
-                }
-                ExecCoreRef::Transaction(ctx) => {
-                    transaction_begin_stream(ctx, text, params, opts, concurrent_result_sets).await
-                }
-            }
-        })
-    }
 }

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -47,9 +47,8 @@ use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session_pool::SessionPool;
 use builders::{impl_client_query_methods, impl_transaction_query_methods};
 use exec::{
-    ClientExecContext, TransactionExecContext, release_tx_session, spawn_query_tx_rollback_on_drop,
-    transaction_commit, transaction_ensure_begin, transaction_exec_context, transaction_identity,
-    transaction_rollback,
+    ClientExecContext, TransactionExecContext, finish_query_tx_on_drop, transaction_commit,
+    transaction_ensure_begin, transaction_exec_context, transaction_identity, transaction_rollback,
 };
 use hooks::{QueryTxCommitStatus, QueryTxHook};
 
@@ -289,9 +288,15 @@ impl QueryClient {
             .retry(closure!(
                 [&client = self, callback, &options],
                 async |retry: &RetryState| {
+                    let lease = match client.ctx.session_pool.acquire_explicit().await {
+                        Ok(lease) => lease,
+                        Err(err) => {
+                            return YdbOrCustomerError::from(err).retry_flow(idempotency);
+                        }
+                    };
                     let tx = Transaction::new(
                         client.ctx.connection_manager.clone(),
-                        client.ctx.session_pool.clone(),
+                        lease,
                         options.clone(),
                         wall_timeout.map(|d| retry.start_time + d),
                         client.ctx.metrics_names.clone(),
@@ -365,9 +370,9 @@ fn resolve_post_callback_action(state: &TxState) -> PostCallbackAction {
     match state {
         TxState::RolledBack => PostCallbackAction::Return(QueryTxCommitStatus::Aborted),
         TxState::Committed => PostCallbackAction::Return(QueryTxCommitStatus::Committed),
-        TxState::Invalidated(err) => PostCallbackAction::Retry(err.clone()),
+        TxState::Invalidated(error) => PostCallbackAction::Retry(error.clone()),
         TxState::Ambiguous(err) => PostCallbackAction::Fail(err.clone()),
-        TxState::Active => PostCallbackAction::Commit,
+        TxState::Active(_) => PostCallbackAction::Commit,
     }
 }
 
@@ -401,7 +406,7 @@ impl Transaction {
 
     fn new(
         connection_manager: GrpcConnectionManager,
-        session_pool: SessionPool,
+        lease: crate::session_pool::SessionPoolLease,
         options: TransactionOptions,
         retry_deadline: Option<Instant>,
         metrics_names: MetricsNames,
@@ -409,7 +414,7 @@ impl Transaction {
         Self {
             ctx: transaction_exec_context(
                 connection_manager,
-                session_pool,
+                lease,
                 options,
                 retry_deadline,
                 metrics_names,
@@ -434,7 +439,7 @@ impl Transaction {
         if !self.ctx.state.is_active() {
             return Err(YdbError::Custom("transaction already finished".to_string()));
         }
-        transaction_ensure_begin(&mut self.ctx, false).await
+        transaction_ensure_begin(&mut self.ctx).await
     }
 
     /// Session and transaction ids for topic offset updates inside a transaction.
@@ -477,13 +482,13 @@ impl Transaction {
     }
 
     pub(crate) async fn uri(&mut self) -> YdbResult<&Uri> {
-        transaction_ensure_begin(&mut self.ctx, false).await?;
+        transaction_ensure_begin(&mut self.ctx).await?;
         Ok(self.ctx.session_lease()?.node_uri())
     }
 
     #[cfg(test)]
     pub(crate) fn tx_id_for_test(&self) -> Option<&str> {
-        self.ctx.tx_id.as_deref()
+        self.ctx.transaction_id()
     }
 }
 
@@ -494,16 +499,19 @@ pub(crate) struct QueryTxIdentity {
 
 impl Drop for Transaction {
     fn drop(&mut self) {
-        if matches!(self.ctx.state, TxState::Invalidated(_)) {
-            release_tx_session(&mut self.ctx);
-            return;
+        if self.ctx.state.is_active() {
+            self.notify_hooks(QueryTxCommitStatus::Aborted);
         }
-        if !self.ctx.state.is_active() {
-            return;
+        let state = std::mem::replace(&mut self.ctx.state, TxState::RolledBack);
+        match state {
+            TxState::Active(active) => {
+                finish_query_tx_on_drop(self.ctx.connection_manager.clone(), active);
+            }
+            TxState::Committed
+            | TxState::RolledBack
+            | TxState::Invalidated(_)
+            | TxState::Ambiguous(_) => {}
         }
-        self.ctx.state = TxState::RolledBack;
-        self.notify_hooks(QueryTxCommitStatus::Aborted);
-        spawn_query_tx_rollback_on_drop(&mut self.ctx);
     }
 }
 
@@ -550,6 +558,9 @@ pub use stream_facade::{QueryStats, QueryStream};
 #[cfg(test)]
 mod unit_tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use crate::GrpcOptions;
     use crate::errors::YdbStatusError;
     use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
@@ -598,12 +609,11 @@ mod unit_tests {
         let session_id = lease.session_id().to_string();
         let mut tx = Transaction::new(
             test_connection_manager(),
-            pool.clone(),
+            lease,
             TransactionOptions::default(),
             None,
             MetricsNames::new(None),
         );
-        tx.ctx.pooled_lease = Some(lease);
         exec::transaction_handle_query_error(
             &mut tx.ctx,
             &YdbError::YdbStatusError(YdbStatusError::new(
@@ -660,20 +670,69 @@ mod unit_tests {
         ));
     }
 
-    #[test]
-    fn active_state_needs_a_real_commit() {
+    #[tokio::test]
+    async fn active_state_needs_a_real_commit() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let state = transaction_exec_context(
+            test_connection_manager(),
+            lease,
+            TransactionOptions::default(),
+            None,
+        )
+        .state;
         assert!(matches!(
-            resolve_post_callback_action(&TxState::Active),
+            resolve_post_callback_action(&state),
             PostCallbackAction::Commit
         ));
     }
 
     #[tokio::test]
-    async fn invalidated_transaction_returns_healthy_session_on_drop() {
+    async fn retry_transaction_owns_a_session_before_the_callback() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let (tx, session_id) = invalidated_transaction(&pool, StatusCode::Aborted).await;
+        let client = QueryClient::new(
+            test_connection_manager(),
+            pool.clone(),
+            RetrySettings::dont_retry(),
+        );
+        let observed_pool = pool.clone();
 
-        drop(tx);
+        let result: YdbResultWithCustomerErr<()> = client
+            .retry_tx(closure!([&observed_pool], async |_tx| {
+                assert_eq!(observed_pool.stats().in_use, 1);
+                Ok(())
+            }))
+            .await;
+
+        result.expect("transaction without queries must commit locally");
+        assert_eq!(pool.stats().in_use, 0);
+    }
+
+    #[tokio::test]
+    async fn retry_transaction_does_not_call_user_code_without_a_session() {
+        let pool = SessionPool::new_explicit_bench_with_create_failures(
+            SessionPoolSettings::new().with_limit(1),
+            1,
+        );
+        let client = QueryClient::new(test_connection_manager(), pool, RetrySettings::dont_retry());
+        let callback_called = Arc::new(AtomicBool::new(false));
+        let observed_called = callback_called.clone();
+
+        let result: YdbResultWithCustomerErr<()> = client
+            .retry_tx(closure!([observed_called], async |_tx| {
+                observed_called.store(true, Ordering::Relaxed);
+                Ok(())
+            }))
+            .await;
+
+        assert!(result.is_err());
+        assert!(!callback_called.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn invalidated_transaction_immediately_returns_healthy_session() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let (_tx, session_id) = invalidated_transaction(&pool, StatusCode::Aborted).await;
 
         let lease = pool
             .acquire_explicit()
@@ -684,11 +743,9 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn invalidated_transaction_discards_broken_session_on_drop() {
+    async fn invalidated_transaction_immediately_discards_broken_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let (tx, session_id) = invalidated_transaction(&pool, StatusCode::BadSession).await;
-
-        drop(tx);
+        let (_tx, session_id) = invalidated_transaction(&pool, StatusCode::BadSession).await;
 
         let lease = pool
             .acquire_explicit()

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -6,7 +6,6 @@ mod builders;
 mod exec;
 mod explain_query;
 pub(crate) mod hooks;
-mod internal;
 mod retry_tx;
 mod script;
 mod stream_facade;
@@ -45,10 +44,10 @@ use crate::result::Row;
 
 use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session_pool::SessionPool;
-use builders::{impl_client_query_methods, impl_transaction_query_methods};
+use builders::{impl_client_query_methods, impl_tx_query_methods};
 use exec::{
-    ClientExecContext, TransactionExecContext, finish_query_tx_on_drop, transaction_commit,
-    transaction_ensure_begin, transaction_exec_context, transaction_identity, transaction_rollback,
+    ClientExecContext, TxExecContext, finish_query_tx_on_drop, tx_commit, tx_ensure_begin,
+    tx_exec_context, tx_identity, tx_rollback,
 };
 use hooks::{QueryTxCommitStatus, QueryTxHook};
 
@@ -243,7 +242,7 @@ impl QueryClient {
                             tx.notify_hooks(QueryTxCommitStatus::Committed);
                             Ok(value)
                         }
-                        // Commit outcome is ambiguous on transport errors; never retry.
+                        // Commit outcome is undetermined on transport errors; never retry.
                         Err(e) => {
                             tx.notify_hooks(QueryTxCommitStatus::Aborted);
                             Err(e.into())
@@ -370,8 +369,8 @@ fn resolve_post_callback_action(state: &TxState) -> PostCallbackAction {
     match state {
         TxState::RolledBack => PostCallbackAction::Return(QueryTxCommitStatus::Aborted),
         TxState::Committed => PostCallbackAction::Return(QueryTxCommitStatus::Committed),
-        TxState::Invalidated(error) => PostCallbackAction::Retry(error.clone()),
-        TxState::Ambiguous(err) => PostCallbackAction::Fail(err.clone()),
+        TxState::AttemptFailed(error) => PostCallbackAction::Retry(error.clone()),
+        TxState::Undetermined(err) => PostCallbackAction::Fail(err.clone()),
         TxState::Active(_) => PostCallbackAction::Commit,
     }
 }
@@ -398,11 +397,11 @@ impl QueryExecutor for QueryClient {
 }
 
 pub struct Transaction {
-    ctx: TransactionExecContext,
+    ctx: TxExecContext,
 }
 
 impl Transaction {
-    impl_transaction_query_methods!();
+    impl_tx_query_methods!();
 
     fn new(
         connection_manager: GrpcConnectionManager,
@@ -412,7 +411,7 @@ impl Transaction {
         metrics_names: MetricsNames,
     ) -> Self {
         Self {
-            ctx: transaction_exec_context(
+            ctx: tx_exec_context(
                 connection_manager,
                 lease,
                 options,
@@ -439,7 +438,7 @@ impl Transaction {
         if !self.ctx.state.is_active() {
             return Err(YdbError::Custom("transaction already finished".to_string()));
         }
-        transaction_ensure_begin(&mut self.ctx).await
+        tx_ensure_begin(&mut self.ctx).await
     }
 
     /// Session and transaction ids for topic offset updates inside a transaction.
@@ -447,23 +446,23 @@ impl Transaction {
         if !self.ctx.state.is_active() {
             return Err(YdbError::Custom("transaction already finished".to_string()));
         }
-        transaction_identity(&mut self.ctx).await
+        tx_identity(&mut self.ctx).await
     }
 
     pub async fn rollback(&mut self) -> YdbResult<()> {
         if !self.ctx.state.is_active() {
             return Ok(());
         }
-        transaction_rollback(&mut self.ctx).await
+        tx_rollback(&mut self.ctx).await
     }
 
     async fn commit(&mut self) -> YdbResult<()> {
-        transaction_commit(&mut self.ctx).await
+        tx_commit(&mut self.ctx).await
     }
 
     async fn rollback_quiet(&mut self) {
         if self.ctx.state.is_active() {
-            let _ = transaction_rollback(&mut self.ctx).await;
+            let _ = tx_rollback(&mut self.ctx).await;
         }
     }
 
@@ -474,7 +473,7 @@ impl Transaction {
     }
 
     pub(crate) async fn tx_identity(&mut self) -> YdbResult<QueryTxIdentity> {
-        let (session_id, transaction_id) = transaction_identity(&mut self.ctx).await?;
+        let (session_id, transaction_id) = tx_identity(&mut self.ctx).await?;
         Ok(QueryTxIdentity {
             transaction_id,
             session_id,
@@ -482,7 +481,7 @@ impl Transaction {
     }
 
     pub(crate) async fn uri(&mut self) -> YdbResult<&Uri> {
-        transaction_ensure_begin(&mut self.ctx).await?;
+        tx_ensure_begin(&mut self.ctx).await?;
         Ok(self.ctx.session_lease()?.node_uri())
     }
 
@@ -509,8 +508,8 @@ impl Drop for Transaction {
             }
             TxState::Committed
             | TxState::RolledBack
-            | TxState::Invalidated(_)
-            | TxState::Ambiguous(_) => {}
+            | TxState::AttemptFailed(_)
+            | TxState::Undetermined(_) => {}
         }
     }
 }
@@ -601,10 +600,7 @@ mod unit_tests {
         )
     }
 
-    async fn invalidated_transaction(
-        pool: &SessionPool,
-        status: StatusCode,
-    ) -> (Transaction, String) {
+    async fn failed_transaction(pool: &SessionPool, status: StatusCode) -> (Transaction, String) {
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
         let mut tx = Transaction::new(
@@ -614,7 +610,7 @@ mod unit_tests {
             None,
             MetricsNames::new(None),
         );
-        exec::transaction_handle_query_error(
+        exec::tx_handle_query_error(
             &mut tx.ctx,
             &YdbError::YdbStatusError(YdbStatusError::new(
                 "transaction failed",
@@ -622,7 +618,7 @@ mod unit_tests {
                 Vec::new(),
             )),
         );
-        assert!(matches!(tx.ctx.state, TxState::Invalidated(_)));
+        assert!(matches!(tx.ctx.state, TxState::AttemptFailed(_)));
         (tx, session_id)
     }
 
@@ -641,8 +637,8 @@ mod unit_tests {
     }
 
     #[test]
-    fn invalidated_state_fails_instead_of_committing() {
-        let state = TxState::Invalidated(YdbError::Custom("server aborted".into()));
+    fn failed_attempt_state_retries_instead_of_committing() {
+        let state = TxState::AttemptFailed(YdbError::Custom("server aborted".into()));
         assert!(matches!(
             resolve_post_callback_action(&state),
             PostCallbackAction::Retry(_)
@@ -650,8 +646,8 @@ mod unit_tests {
     }
 
     #[test]
-    fn ambiguous_state_fails_instead_of_committing() {
-        let state = TxState::Ambiguous(YdbError::Custom("rollback rpc failed".into()));
+    fn undetermined_state_fails_instead_of_committing() {
+        let state = TxState::Undetermined(YdbError::Custom("rollback rpc failed".into()));
         assert!(matches!(
             resolve_post_callback_action(&state),
             PostCallbackAction::Fail(_)
@@ -674,11 +670,12 @@ mod unit_tests {
     async fn active_state_needs_a_real_commit() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let state = transaction_exec_context(
+        let state = tx_exec_context(
             test_connection_manager(),
             lease,
             TransactionOptions::default(),
             None,
+            MetricsNames::new(None),
         )
         .state;
         assert!(matches!(
@@ -694,6 +691,7 @@ mod unit_tests {
             test_connection_manager(),
             pool.clone(),
             RetrySettings::dont_retry(),
+            MetricsNames::new(None),
         );
         let observed_pool = pool.clone();
 
@@ -714,7 +712,12 @@ mod unit_tests {
             SessionPoolSettings::new().with_limit(1),
             1,
         );
-        let client = QueryClient::new(test_connection_manager(), pool, RetrySettings::dont_retry());
+        let client = QueryClient::new(
+            test_connection_manager(),
+            pool,
+            RetrySettings::dont_retry(),
+            MetricsNames::new(None),
+        );
         let callback_called = Arc::new(AtomicBool::new(false));
         let observed_called = callback_called.clone();
 
@@ -730,9 +733,9 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn invalidated_transaction_immediately_returns_healthy_session() {
+    async fn failed_transaction_immediately_returns_healthy_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let (_tx, session_id) = invalidated_transaction(&pool, StatusCode::Aborted).await;
+        let (_tx, session_id) = failed_transaction(&pool, StatusCode::Aborted).await;
 
         let lease = pool
             .acquire_explicit()
@@ -743,9 +746,9 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn invalidated_transaction_immediately_discards_broken_session() {
+    async fn failed_transaction_immediately_discards_broken_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let (_tx, session_id) = invalidated_transaction(&pool, StatusCode::BadSession).await;
+        let (_tx, session_id) = failed_transaction(&pool, StatusCode::BadSession).await;
 
         let lease = pool
             .acquire_explicit()

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -46,7 +46,7 @@ use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session_pool::SessionPool;
 use builders::{impl_client_query_methods, impl_tx_query_methods};
 use exec::{
-    ClientExecContext, TxExecContext, finish_query_tx_on_drop, tx_commit, tx_ensure_begin,
+    ClientExecContext, TxExecContext, release_unfinished_tx, tx_commit, tx_ensure_begin,
     tx_exec_context, tx_identity, tx_rollback,
 };
 use hooks::{QueryTxCommitStatus, QueryTxHook};
@@ -504,7 +504,7 @@ impl Drop for Transaction {
         let state = std::mem::replace(&mut self.ctx.state, TxState::RolledBack);
         match state {
             TxState::Active(active) => {
-                finish_query_tx_on_drop(self.ctx.connection_manager.clone(), active);
+                release_unfinished_tx(self.ctx.connection_manager.clone(), active);
             }
             TxState::Committed
             | TxState::RolledBack

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -4,13 +4,15 @@ use std::time::Duration;
 use crate::closure;
 use crate::errors::{YdbError, YdbResult};
 use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
+use crate::grpc_wrapper::raw_table_service::value::RawResultSet;
 use crate::result::ResultSet;
-use crate::session_pool::SessionPoolLease;
 use crate::types::Value;
 
 use super::exec::{
-    CallOptions, ClientExecContext, apply_stream_tx_id, client_begin_stream_once,
-    resolve_commit_tx, transaction_finish_committed_via_query, transaction_handle_query_error,
+    CallOptions, ClientExecContext, ClientQuerySession, OpenedClientQueryStream,
+    TransactionExecContext, apply_stream_tx_id, client_begin_stream_once, resolve_commit_tx,
+    transaction_begin_stream, transaction_finish_query, transaction_handle_query_error,
+    transaction_invalidate_session,
 };
 use super::internal::ExecCoreRef;
 
@@ -19,52 +21,130 @@ use super::internal::ExecCoreRef;
 /// Inside a transaction, [`CallBuilder::with_commit(true)`] commits only on successful close.
 #[must_use = "QueryStream must be fully consumed and closed"]
 pub struct QueryStream<'a> {
-    pub(crate) core: ExecCoreRef<'a>,
-    pub(crate) stream: ExecuteQueryStream,
-    /// Lease owned by this stream for a pooled `QueryClient` query.
-    pub(crate) owned_lease: Option<SessionPoolLease>,
-    pub(crate) commit_tx: bool,
+    stream: ExecuteQueryStream,
+    lifecycle: QueryStreamLifecycle<'a>,
+}
+
+enum QueryStreamLifecycle<'a> {
+    Active(QueryStreamOwner<'a>),
+    Finished,
+}
+
+enum QueryStreamOwner<'a> {
+    Client(ClientQuerySession),
+    Transaction {
+        context: &'a mut TransactionExecContext,
+        commit_at_end: bool,
+    },
 }
 
 impl Drop for QueryStream<'_> {
     fn drop(&mut self) {
-        if let Some(tx_id) = self.stream.take_captured_tx_id()
-            && let ExecCoreRef::Transaction(ctx) = &mut self.core
-        {
-            apply_stream_tx_id(ctx, Some(tx_id));
-        }
-        // Do not mark the transaction finished here: with_commit(true) requires
-        // draining the stream and calling close() so the server can commit.
-        let dropped_mid_stream = self.stream.in_progress();
-        self.stream.cancel();
-        if let ExecCoreRef::Transaction(ctx) = &mut self.core
-            && let Some(lease) = &mut ctx.pooled_lease
-            && dropped_mid_stream
-        {
-            lease.invalidate();
-        }
+        self.cancel_active();
     }
 }
 
 impl QueryStream<'_> {
+    fn cancel_active(&mut self) {
+        self.apply_captured_transaction_id();
+        let dropped_mid_stream = self.stream.in_progress();
+        self.stream.cancel();
+        let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Transaction { context, .. }) =
+            lifecycle
+            && dropped_mid_stream
+        {
+            transaction_invalidate_session(context);
+        }
+    }
+}
+
+impl<'a> QueryStream<'a> {
+    pub(crate) fn from_client(opened: OpenedClientQueryStream) -> Self {
+        Self {
+            stream: opened.stream,
+            lifecycle: QueryStreamLifecycle::Active(QueryStreamOwner::Client(opened.session)),
+        }
+    }
+
+    pub(crate) fn from_transaction(
+        stream: ExecuteQueryStream,
+        context: &'a mut TransactionExecContext,
+        commit_at_end: bool,
+    ) -> Self {
+        Self {
+            stream,
+            lifecycle: QueryStreamLifecycle::Active(QueryStreamOwner::Transaction {
+                context,
+                commit_at_end,
+            }),
+        }
+    }
+
+    fn apply_transaction_id(&mut self, transaction_id: Option<String>) {
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Transaction { context, .. }) =
+            &mut self.lifecycle
+        {
+            apply_stream_tx_id(context, transaction_id);
+        }
+    }
+
+    fn apply_captured_transaction_id(&mut self) {
+        let transaction_id = self.stream.take_captured_tx_id();
+        self.apply_transaction_id(transaction_id);
+    }
+
+    fn handle_error(&mut self, error: &YdbError) {
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Transaction { context, .. }) =
+            &mut self.lifecycle
+        {
+            transaction_handle_query_error(context, error);
+        }
+    }
+
+    fn finish(&mut self) -> YdbResult<()> {
+        let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
+        match lifecycle {
+            QueryStreamLifecycle::Active(QueryStreamOwner::Client(session)) => {
+                session.complete();
+                Ok(())
+            }
+            QueryStreamLifecycle::Active(QueryStreamOwner::Transaction {
+                context,
+                commit_at_end,
+            }) => transaction_finish_query(context, commit_at_end),
+            QueryStreamLifecycle::Finished => Ok(()),
+        }
+    }
+
     pub async fn next_result_set(&mut self) -> YdbResult<Option<ResultSet>> {
         let next = match self.stream.next_result_set().await {
             Ok(v) => v,
             Err(err) => {
                 let ydb_err = YdbError::from(err);
-                if let ExecCoreRef::Transaction(ctx) = &mut self.core {
-                    transaction_handle_query_error(ctx, &ydb_err);
+                self.handle_error(&ydb_err);
+                if matches!(
+                    &self.lifecycle,
+                    QueryStreamLifecycle::Active(QueryStreamOwner::Client(_))
+                ) && !ydb_err.requires_session_discard()
+                {
+                    self.stream.cancel();
+                    return Err(ydb_err);
                 }
+                self.cancel_active();
                 return Err(ydb_err);
             }
         };
-        let Some((raw, tx_id)) = next else {
-            return Ok(None);
-        };
-        if let ExecCoreRef::Transaction(ctx) = &mut self.core {
-            apply_stream_tx_id(ctx, tx_id);
+        match next {
+            Some((raw, transaction_id)) => {
+                self.apply_transaction_id(transaction_id);
+                ResultSet::try_from(raw).map(Some)
+            }
+            None => {
+                self.apply_captured_transaction_id();
+                Ok(None)
+            }
         }
-        Ok(Some(ResultSet::try_from(raw)?))
     }
 
     pub fn stats(&self) -> Option<QueryStats> {
@@ -76,22 +156,12 @@ impl QueryStream<'_> {
     pub async fn close(mut self) -> YdbResult<()> {
         match self.stream.close().await {
             Ok(meta) => {
-                if let Some(lease) = self.owned_lease.take() {
-                    lease.return_to_pool();
-                }
-                if let ExecCoreRef::Transaction(ctx) = &mut self.core {
-                    apply_stream_tx_id(ctx, meta.tx_id);
-                    if self.commit_tx {
-                        transaction_finish_committed_via_query(ctx);
-                    }
-                }
-                Ok(())
+                self.apply_transaction_id(meta.tx_id);
+                self.finish()
             }
             Err(err) => {
                 let ydb_err = YdbError::from(err);
-                if let ExecCoreRef::Transaction(ctx) = &mut self.core {
-                    transaction_handle_query_error(ctx, &ydb_err);
-                }
+                self.handle_error(&ydb_err);
                 Err(ydb_err)
             }
         }
@@ -111,6 +181,7 @@ pub(crate) async fn materialize_query(
     params: HashMap<String, Value>,
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
+    let commit_at_end = resolve_commit_tx(core, &opts);
     match core {
         ExecCoreRef::Client(ctx) => {
             ctx.retry_settings
@@ -124,7 +195,9 @@ pub(crate) async fn materialize_query(
                 )
                 .await
         }
-        ExecCoreRef::Transaction(_) => materialize_transaction_once(core, text, params, opts).await,
+        ExecCoreRef::Transaction(context) => {
+            materialize_transaction_once(context, text, params, opts, commit_at_end).await
+        }
     }
 }
 
@@ -135,64 +208,58 @@ async fn materialize_client_once(
     opts: &CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
     let mut opened = client_begin_stream_once(ctx, text, params, opts, true).await?;
-    let sets = collect_result_sets(&mut opened.stream).await?;
-    opened.stream.close().await?;
-    if let Some(lease) = opened.owned_lease.take() {
-        lease.return_to_pool();
+    let result: YdbResult<Vec<RawResultSet>> = async {
+        let raw_sets = drain_result_sets(&mut opened.stream).await?;
+        opened.stream.close().await?;
+        Ok(raw_sets)
     }
-    Ok(sets)
+    .await;
+    match result {
+        Ok(raw_sets) => {
+            opened.session.complete();
+            convert_result_sets(raw_sets)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 async fn materialize_transaction_once(
-    core: &mut ExecCoreRef<'_>,
+    context: &mut TransactionExecContext,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
+    commit_at_end: bool,
 ) -> YdbResult<Vec<ResultSet>> {
-    let commit_tx = resolve_commit_tx(core, &opts);
-    let result: YdbResult<Vec<ResultSet>> = async {
-        let mut opened = core.begin_stream(text, params, opts, true).await?;
-        let sets = match collect_result_sets(&mut opened.stream).await {
-            Ok(sets) => sets,
-            Err(ydb_err) => {
-                if let ExecCoreRef::Transaction(ctx) = core {
-                    transaction_handle_query_error(ctx, &ydb_err);
-                }
-                return Err(ydb_err);
-            }
-        };
-        match opened.stream.close().await {
-            Ok(meta) => {
-                if let Some(lease) = opened.owned_lease.take() {
-                    lease.return_to_pool();
-                }
-                if let ExecCoreRef::Transaction(ctx) = core {
-                    apply_stream_tx_id(ctx, meta.tx_id);
-                    if commit_tx {
-                        transaction_finish_committed_via_query(ctx);
-                    }
-                }
-            }
-            Err(err) => {
-                let ydb_err = YdbError::from(err);
-                if let ExecCoreRef::Transaction(ctx) = core {
-                    transaction_handle_query_error(ctx, &ydb_err);
-                }
-                return Err(ydb_err);
-            }
+    let mut stream = transaction_begin_stream(context, text, params, opts, true).await?;
+    let raw_sets = match drain_result_sets(&mut stream).await {
+        Ok(raw_sets) => raw_sets,
+        Err(ydb_err) => {
+            transaction_handle_query_error(context, &ydb_err);
+            return Err(ydb_err);
         }
-        Ok(sets)
+    };
+    match stream.close().await {
+        Ok(meta) => {
+            apply_stream_tx_id(context, meta.tx_id);
+            transaction_finish_query(context, commit_at_end)?;
+        }
+        Err(err) => {
+            let ydb_err = YdbError::from(err);
+            transaction_handle_query_error(context, &ydb_err);
+            return Err(ydb_err);
+        }
     }
-    .await;
-
-    result
+    convert_result_sets(raw_sets)
 }
 
-async fn collect_result_sets(stream: &mut ExecuteQueryStream) -> YdbResult<Vec<ResultSet>> {
-    let raw_sets = stream
+async fn drain_result_sets(stream: &mut ExecuteQueryStream) -> YdbResult<Vec<RawResultSet>> {
+    stream
         .materialize_all_result_sets()
         .await
-        .map_err(YdbError::from)?;
+        .map_err(YdbError::from)
+}
+
+fn convert_result_sets(raw_sets: Vec<RawResultSet>) -> YdbResult<Vec<ResultSet>> {
     let mut sets = Vec::with_capacity(raw_sets.len());
     for raw in raw_sets {
         sets.push(ResultSet::try_from(raw)?);

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -9,12 +9,10 @@ use crate::result::ResultSet;
 use crate::types::Value;
 
 use super::exec::{
-    CallOptions, ClientExecContext, ClientQuerySession, OpenedClientQueryStream,
-    TransactionExecContext, apply_stream_tx_id, client_begin_stream_once, resolve_commit_tx,
-    transaction_begin_stream, transaction_finish_query, transaction_handle_query_error,
-    transaction_invalidate_session,
+    CallOptions, ClientExecContext, ClientQuerySession, ExecTarget, OpenedClientQueryStream,
+    TxExecContext, apply_stream_tx_id, client_begin_stream_once, resolve_commit_tx,
+    tx_begin_stream, tx_finish_query, tx_handle_query_error, tx_invalidate_session,
 };
-use super::internal::ExecCoreRef;
 
 /// Streaming query result. Drain all result sets and call [`Self::close`] to return an owned
 /// pooled session for reuse. Dropping the stream cancels it and discards that session.
@@ -32,29 +30,28 @@ enum QueryStreamLifecycle<'a> {
 
 enum QueryStreamOwner<'a> {
     Client(ClientQuerySession),
-    Transaction {
-        context: &'a mut TransactionExecContext,
+    Tx {
+        context: &'a mut TxExecContext,
         commit_at_end: bool,
     },
 }
 
 impl Drop for QueryStream<'_> {
     fn drop(&mut self) {
-        self.cancel_active();
+        self.abort();
     }
 }
 
 impl QueryStream<'_> {
-    fn cancel_active(&mut self) {
+    fn abort(&mut self) {
         self.apply_captured_transaction_id();
         let dropped_mid_stream = self.stream.in_progress();
         self.stream.cancel();
         let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
-        if let QueryStreamLifecycle::Active(QueryStreamOwner::Transaction { context, .. }) =
-            lifecycle
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) = lifecycle
             && dropped_mid_stream
         {
-            transaction_invalidate_session(context);
+            tx_invalidate_session(context);
         }
     }
 }
@@ -67,14 +64,14 @@ impl<'a> QueryStream<'a> {
         }
     }
 
-    pub(crate) fn from_transaction(
+    pub(crate) fn from_tx(
         stream: ExecuteQueryStream,
-        context: &'a mut TransactionExecContext,
+        context: &'a mut TxExecContext,
         commit_at_end: bool,
     ) -> Self {
         Self {
             stream,
-            lifecycle: QueryStreamLifecycle::Active(QueryStreamOwner::Transaction {
+            lifecycle: QueryStreamLifecycle::Active(QueryStreamOwner::Tx {
                 context,
                 commit_at_end,
             }),
@@ -82,7 +79,7 @@ impl<'a> QueryStream<'a> {
     }
 
     fn apply_transaction_id(&mut self, transaction_id: Option<String>) {
-        if let QueryStreamLifecycle::Active(QueryStreamOwner::Transaction { context, .. }) =
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) =
             &mut self.lifecycle
         {
             apply_stream_tx_id(context, transaction_id);
@@ -95,10 +92,10 @@ impl<'a> QueryStream<'a> {
     }
 
     fn handle_error(&mut self, error: &YdbError) {
-        if let QueryStreamLifecycle::Active(QueryStreamOwner::Transaction { context, .. }) =
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) =
             &mut self.lifecycle
         {
-            transaction_handle_query_error(context, error);
+            tx_handle_query_error(context, error);
         }
     }
 
@@ -106,13 +103,13 @@ impl<'a> QueryStream<'a> {
         let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
         match lifecycle {
             QueryStreamLifecycle::Active(QueryStreamOwner::Client(session)) => {
-                session.complete();
+                session.release();
                 Ok(())
             }
-            QueryStreamLifecycle::Active(QueryStreamOwner::Transaction {
+            QueryStreamLifecycle::Active(QueryStreamOwner::Tx {
                 context,
                 commit_at_end,
-            }) => transaction_finish_query(context, commit_at_end),
+            }) => tx_finish_query(context, commit_at_end),
             QueryStreamLifecycle::Finished => Ok(()),
         }
     }
@@ -131,7 +128,7 @@ impl<'a> QueryStream<'a> {
                     self.stream.cancel();
                     return Err(ydb_err);
                 }
-                self.cancel_active();
+                self.abort();
                 return Err(ydb_err);
             }
         };
@@ -176,14 +173,14 @@ impl<'a> QueryStream<'a> {
 /// On [`QueryClient`], the full open+drain+close cycle is retried on retryable errors.
 /// Interactive transactions are materialized once since tx retries are owned by [`QueryClient::retry_tx`] loop.
 pub(crate) async fn materialize_query(
-    core: &mut ExecCoreRef<'_>,
+    target: &mut ExecTarget<'_>,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
-    let commit_at_end = resolve_commit_tx(core, &opts);
-    match core {
-        ExecCoreRef::Client(ctx) => {
+    let commit_at_end = resolve_commit_tx(target, &opts);
+    match target {
+        ExecTarget::Client(ctx) => {
             ctx.retry_settings
                 .clone()
                 .with_deadline(opts.timeout)
@@ -195,8 +192,8 @@ pub(crate) async fn materialize_query(
                 )
                 .await
         }
-        ExecCoreRef::Transaction(context) => {
-            materialize_transaction_once(context, text, params, opts, commit_at_end).await
+        ExecTarget::Tx(context) => {
+            materialize_tx_once(context, text, params, opts, commit_at_end).await
         }
     }
 }
@@ -216,36 +213,36 @@ async fn materialize_client_once(
     .await;
     match result {
         Ok(raw_sets) => {
-            opened.session.complete();
+            opened.session.release();
             convert_result_sets(raw_sets)
         }
         Err(error) => Err(error),
     }
 }
 
-async fn materialize_transaction_once(
-    context: &mut TransactionExecContext,
+async fn materialize_tx_once(
+    context: &mut TxExecContext,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
     commit_at_end: bool,
 ) -> YdbResult<Vec<ResultSet>> {
-    let mut stream = transaction_begin_stream(context, text, params, opts, true).await?;
+    let mut stream = tx_begin_stream(context, text, params, opts, true).await?;
     let raw_sets = match drain_result_sets(&mut stream).await {
         Ok(raw_sets) => raw_sets,
         Err(ydb_err) => {
-            transaction_handle_query_error(context, &ydb_err);
+            tx_handle_query_error(context, &ydb_err);
             return Err(ydb_err);
         }
     };
     match stream.close().await {
         Ok(meta) => {
             apply_stream_tx_id(context, meta.tx_id);
-            transaction_finish_query(context, commit_at_end)?;
+            tx_finish_query(context, commit_at_end)?;
         }
         Err(err) => {
             let ydb_err = YdbError::from(err);
-            transaction_handle_query_error(context, &ydb_err);
+            tx_handle_query_error(context, &ydb_err);
             return Err(ydb_err);
         }
     }

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -235,6 +235,13 @@ async fn materialize_tx_once(
             return Err(ydb_err);
         }
     };
+    let sets = match convert_result_sets(raw_sets) {
+        Ok(sets) => sets,
+        Err(ydb_err) => {
+            tx_handle_query_error(context, &ydb_err);
+            return Err(ydb_err);
+        }
+    };
     match stream.close().await {
         Ok(meta) => {
             apply_stream_tx_id(context, meta.tx_id);
@@ -246,7 +253,7 @@ async fn materialize_tx_once(
             return Err(ydb_err);
         }
     }
-    convert_result_sets(raw_sets)
+    Ok(sets)
 }
 
 async fn drain_result_sets(stream: &mut ExecuteQueryStream) -> YdbResult<Vec<RawResultSet>> {

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -11,7 +11,7 @@ use crate::types::Value;
 use super::exec::{
     CallOptions, ClientExecContext, ClientQuerySession, ExecTarget, OpenedClientQueryStream,
     TxExecContext, apply_stream_tx_id, client_begin_stream_once, resolve_commit_tx,
-    tx_begin_stream, tx_finish_query, tx_handle_query_error, tx_invalidate_session,
+    tx_begin_stream, tx_cancel_query, tx_finish_query, tx_handle_query_error,
 };
 
 /// Streaming query result. Drain all result sets and call [`Self::close`] to return an owned
@@ -45,13 +45,10 @@ impl Drop for QueryStream<'_> {
 impl QueryStream<'_> {
     fn abort(&mut self) {
         self.apply_captured_transaction_id();
-        let dropped_mid_stream = self.stream.in_progress();
         self.stream.cancel();
         let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
-        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) = lifecycle
-            && dropped_mid_stream
-        {
-            tx_invalidate_session(context);
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) = lifecycle {
+            tx_cancel_query(context);
         }
     }
 }

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -94,6 +94,14 @@ pub(crate) enum NeedRetry {
     False,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TransactionErrorOutcome {
+    /// The server returned a concrete failure for the dispatched operation.
+    AttemptFailed,
+    /// The SDK cannot determine the outcome of the dispatched operation.
+    OutcomeUnknown,
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Idempotency {
     Idempotent,
@@ -323,37 +331,44 @@ impl YdbError {
         YdbError::Custom(s.into())
     }
 
-    /// Definitive YDB operation status on a transactional statement: the server has
-    /// ended the transaction (explicit commit/rollback would return NOT_FOUND).
-    ///
-    /// Transport and ambiguous statuses (`UNDETERMINED`, `UNAVAILABLE`, `OVERLOADED`,
-    /// `SUCCESS`, `UNSPECIFIED`) are excluded — the transaction may still be active.
-    pub(crate) fn invalidates_server_transaction(&self) -> bool {
-        let Self::YdbStatusError(status) = self else {
-            return false;
-        };
-        let Ok(code) = status.operation_status() else {
-            return false;
-        };
-        matches!(
-            code,
-            StatusCode::BadRequest
-                | StatusCode::Unauthorized
-                | StatusCode::InternalError
-                | StatusCode::Aborted
-                | StatusCode::SchemeError
-                | StatusCode::GenericError
-                | StatusCode::Timeout
-                | StatusCode::BadSession
-                | StatusCode::PreconditionFailed
-                | StatusCode::AlreadyExists
-                | StatusCode::NotFound
-                | StatusCode::SessionExpired
-                | StatusCode::Cancelled
-                | StatusCode::Unsupported
-                | StatusCode::SessionBusy
-                | StatusCode::ExternalError
-        )
+    /// Classify the outcome of a dispatched transaction operation independently from retry and
+    /// session-health policy.
+    pub(crate) fn transaction_error_outcome(&self) -> TransactionErrorOutcome {
+        match self {
+            Self::YdbStatusError(status) => match status.operation_status() {
+                Ok(StatusCode::Undetermined | StatusCode::Unspecified | StatusCode::Success)
+                | Err(_) => TransactionErrorOutcome::OutcomeUnknown,
+                Ok(
+                    StatusCode::BadRequest
+                    | StatusCode::Unauthorized
+                    | StatusCode::InternalError
+                    | StatusCode::Aborted
+                    | StatusCode::Unavailable
+                    | StatusCode::Overloaded
+                    | StatusCode::SchemeError
+                    | StatusCode::GenericError
+                    | StatusCode::Timeout
+                    | StatusCode::BadSession
+                    | StatusCode::PreconditionFailed
+                    | StatusCode::AlreadyExists
+                    | StatusCode::NotFound
+                    | StatusCode::SessionExpired
+                    | StatusCode::Cancelled
+                    | StatusCode::Unsupported
+                    | StatusCode::SessionBusy
+                    | StatusCode::ExternalError,
+                ) => TransactionErrorOutcome::AttemptFailed,
+            },
+            Self::Custom(_)
+            | Self::Convert(_)
+            | Self::NoRows
+            | Self::EndpointHasNoHost(_)
+            | Self::InternalError(_)
+            | Self::TransportDial(_)
+            | Self::Transport(_)
+            | Self::TransportGRPCStatus(_)
+            | Self::DeadlineExceeded => TransactionErrorOutcome::OutcomeUnknown,
+        }
     }
 
     /// Whether an operation error makes a pooled session unsafe to reuse.
@@ -568,30 +583,50 @@ mod error_classification_tests {
     }
 
     #[test]
-    fn success_does_not_invalidate_server_transaction() {
-        assert!(!ydb_status(StatusCode::Success).invalidates_server_transaction());
+    fn malformed_success_status_has_unknown_transaction_outcome() {
+        assert_eq!(
+            ydb_status(StatusCode::Success).transaction_error_outcome(),
+            TransactionErrorOutcome::OutcomeUnknown
+        );
     }
 
     #[test]
-    fn operational_errors_invalidate_server_transaction() {
-        assert!(ydb_status(StatusCode::PreconditionFailed).invalidates_server_transaction());
-        assert!(ydb_status(StatusCode::Aborted).invalidates_server_transaction());
-        assert!(ydb_status(StatusCode::BadSession).invalidates_server_transaction());
+    fn concrete_ydb_failures_end_the_transaction_attempt() {
+        for status in [
+            StatusCode::PreconditionFailed,
+            StatusCode::Aborted,
+            StatusCode::Unavailable,
+            StatusCode::Overloaded,
+            StatusCode::BadSession,
+        ] {
+            assert_eq!(
+                ydb_status(status).transaction_error_outcome(),
+                TransactionErrorOutcome::AttemptFailed
+            );
+        }
     }
 
     #[test]
-    fn ambiguous_and_transport_errors_do_not_invalidate() {
-        assert!(!ydb_status(StatusCode::Undetermined).invalidates_server_transaction());
-        assert!(!ydb_status(StatusCode::Unavailable).invalidates_server_transaction());
-        assert!(!ydb_status(StatusCode::Overloaded).invalidates_server_transaction());
-        assert!(!YdbError::Transport("timeout".into()).invalidates_server_transaction());
-        assert!(!YdbError::Custom("x".into()).invalidates_server_transaction());
+    fn ambiguous_and_transport_errors_have_unknown_transaction_outcome() {
+        for error in [
+            ydb_status(StatusCode::Undetermined),
+            YdbError::Transport("timeout".into()),
+            YdbError::Custom("malformed response".into()),
+        ] {
+            assert_eq!(
+                error.transaction_error_outcome(),
+                TransactionErrorOutcome::OutcomeUnknown
+            );
+        }
     }
 
     #[test]
-    fn unknown_status_code_does_not_invalidate() {
+    fn unknown_status_code_has_unknown_transaction_outcome() {
         let err = YdbError::YdbStatusError(YdbStatusError::new("unknown", -1, vec![]));
-        assert!(!err.invalidates_server_transaction());
+        assert_eq!(
+            err.transaction_error_outcome(),
+            TransactionErrorOutcome::OutcomeUnknown
+        );
     }
 
     #[test]

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -96,8 +96,11 @@ pub(crate) enum NeedRetry {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum TransactionErrorOutcome {
-    /// The server returned a concrete failure for the dispatched operation.
-    AttemptFailed,
+    /// The failed operation also ended the server transaction.
+    TransactionEnded,
+    /// The operation failed, but an existing server transaction may remain active; its session
+    /// cannot be reused without cleanup.
+    TransactionMayRemainActive,
     /// The SDK cannot determine the outcome of the dispatched operation.
     OutcomeUnknown,
 }
@@ -338,13 +341,14 @@ impl YdbError {
             Self::YdbStatusError(status) => match status.operation_status() {
                 Ok(StatusCode::Undetermined | StatusCode::Unspecified | StatusCode::Success)
                 | Err(_) => TransactionErrorOutcome::OutcomeUnknown,
+                Ok(StatusCode::Unavailable | StatusCode::Overloaded) => {
+                    TransactionErrorOutcome::TransactionMayRemainActive
+                }
                 Ok(
                     StatusCode::BadRequest
                     | StatusCode::Unauthorized
                     | StatusCode::InternalError
                     | StatusCode::Aborted
-                    | StatusCode::Unavailable
-                    | StatusCode::Overloaded
                     | StatusCode::SchemeError
                     | StatusCode::GenericError
                     | StatusCode::Timeout
@@ -357,7 +361,7 @@ impl YdbError {
                     | StatusCode::Unsupported
                     | StatusCode::SessionBusy
                     | StatusCode::ExternalError,
-                ) => TransactionErrorOutcome::AttemptFailed,
+                ) => TransactionErrorOutcome::TransactionEnded,
             },
             Self::Custom(_)
             | Self::Convert(_)
@@ -591,17 +595,25 @@ mod error_classification_tests {
     }
 
     #[test]
-    fn concrete_ydb_failures_end_the_transaction_attempt() {
+    fn definitive_ydb_failures_end_the_server_transaction() {
         for status in [
             StatusCode::PreconditionFailed,
             StatusCode::Aborted,
-            StatusCode::Unavailable,
-            StatusCode::Overloaded,
             StatusCode::BadSession,
         ] {
             assert_eq!(
                 ydb_status(status).transaction_error_outcome(),
-                TransactionErrorOutcome::AttemptFailed
+                TransactionErrorOutcome::TransactionEnded
+            );
+        }
+    }
+
+    #[test]
+    fn transient_query_failures_may_leave_the_server_transaction_active() {
+        for status in [StatusCode::Unavailable, StatusCode::Overloaded] {
+            assert_eq!(
+                ydb_status(status).transaction_error_outcome(),
+                TransactionErrorOutcome::TransactionMayRemainActive
             );
         }
     }

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -94,17 +94,6 @@ pub(crate) enum NeedRetry {
     False,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum TxErrorOutcome {
-    /// The failed operation also ended the server transaction.
-    Ended,
-    /// The operation failed, but an existing server transaction may remain active; its session
-    /// cannot be reused without cleanup.
-    MayRemainActive,
-    /// The SDK cannot determine the outcome of the dispatched operation.
-    Undetermined,
-}
-
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Idempotency {
     Idempotent,
@@ -334,50 +323,6 @@ impl YdbError {
         YdbError::Custom(s.into())
     }
 
-    /// Classify the outcome of a dispatched transaction operation independently from retry and
-    /// session-health policy.
-    pub(crate) fn tx_error_outcome(&self) -> TxErrorOutcome {
-        match self {
-            Self::YdbStatusError(status) => match status.operation_status() {
-                // Successful responses are not represented as YdbStatusError.
-                Ok(StatusCode::Success) => TxErrorOutcome::Undetermined,
-                Ok(StatusCode::Undetermined | StatusCode::Unspecified) | Err(_) => {
-                    TxErrorOutcome::Undetermined
-                }
-                Ok(StatusCode::Unavailable | StatusCode::Overloaded) => {
-                    TxErrorOutcome::MayRemainActive
-                }
-                Ok(
-                    StatusCode::BadRequest
-                    | StatusCode::Unauthorized
-                    | StatusCode::InternalError
-                    | StatusCode::Aborted
-                    | StatusCode::SchemeError
-                    | StatusCode::GenericError
-                    | StatusCode::Timeout
-                    | StatusCode::BadSession
-                    | StatusCode::PreconditionFailed
-                    | StatusCode::AlreadyExists
-                    | StatusCode::NotFound
-                    | StatusCode::SessionExpired
-                    | StatusCode::Cancelled
-                    | StatusCode::Unsupported
-                    | StatusCode::SessionBusy
-                    | StatusCode::ExternalError,
-                ) => TxErrorOutcome::Ended,
-            },
-            Self::Custom(_)
-            | Self::Convert(_)
-            | Self::NoRows
-            | Self::EndpointHasNoHost(_)
-            | Self::InternalError(_)
-            | Self::TransportDial(_)
-            | Self::Transport(_)
-            | Self::TransportGRPCStatus(_)
-            | Self::DeadlineExceeded => TxErrorOutcome::Undetermined,
-        }
-    }
-
     /// Whether an operation error makes a pooled session unsafe to reuse.
     ///
     /// This is deliberately separate from retry classification: retryability describes
@@ -587,52 +532,6 @@ mod error_classification_tests {
 
     fn ydb_status(status: StatusCode) -> YdbError {
         YdbError::YdbStatusError(YdbStatusError::new("test", status as i32, vec![]))
-    }
-
-    #[test]
-    fn malformed_success_status_is_conservatively_undetermined() {
-        assert_eq!(
-            ydb_status(StatusCode::Success).tx_error_outcome(),
-            TxErrorOutcome::Undetermined
-        );
-    }
-
-    #[test]
-    fn definitive_ydb_failures_end_the_server_transaction() {
-        for status in [
-            StatusCode::PreconditionFailed,
-            StatusCode::Aborted,
-            StatusCode::BadSession,
-        ] {
-            assert_eq!(ydb_status(status).tx_error_outcome(), TxErrorOutcome::Ended);
-        }
-    }
-
-    #[test]
-    fn transient_query_failures_may_leave_the_server_transaction_active() {
-        for status in [StatusCode::Unavailable, StatusCode::Overloaded] {
-            assert_eq!(
-                ydb_status(status).tx_error_outcome(),
-                TxErrorOutcome::MayRemainActive
-            );
-        }
-    }
-
-    #[test]
-    fn undetermined_and_transport_errors_have_undetermined_tx_outcome() {
-        for error in [
-            ydb_status(StatusCode::Undetermined),
-            YdbError::Transport("timeout".into()),
-            YdbError::Custom("malformed response".into()),
-        ] {
-            assert_eq!(error.tx_error_outcome(), TxErrorOutcome::Undetermined);
-        }
-    }
-
-    #[test]
-    fn unknown_status_code_has_undetermined_tx_outcome() {
-        let err = YdbError::YdbStatusError(YdbStatusError::new("unknown", -1, vec![]));
-        assert_eq!(err.tx_error_outcome(), TxErrorOutcome::Undetermined);
     }
 
     #[test]

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -95,14 +95,14 @@ pub(crate) enum NeedRetry {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum TransactionErrorOutcome {
+pub(crate) enum TxErrorOutcome {
     /// The failed operation also ended the server transaction.
-    TransactionEnded,
+    Ended,
     /// The operation failed, but an existing server transaction may remain active; its session
     /// cannot be reused without cleanup.
-    TransactionMayRemainActive,
+    MayRemainActive,
     /// The SDK cannot determine the outcome of the dispatched operation.
-    OutcomeUnknown,
+    Undetermined,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -336,13 +336,16 @@ impl YdbError {
 
     /// Classify the outcome of a dispatched transaction operation independently from retry and
     /// session-health policy.
-    pub(crate) fn transaction_error_outcome(&self) -> TransactionErrorOutcome {
+    pub(crate) fn tx_error_outcome(&self) -> TxErrorOutcome {
         match self {
             Self::YdbStatusError(status) => match status.operation_status() {
-                Ok(StatusCode::Undetermined | StatusCode::Unspecified | StatusCode::Success)
-                | Err(_) => TransactionErrorOutcome::OutcomeUnknown,
+                // Successful responses are not represented as YdbStatusError.
+                Ok(StatusCode::Success) => TxErrorOutcome::Undetermined,
+                Ok(StatusCode::Undetermined | StatusCode::Unspecified) | Err(_) => {
+                    TxErrorOutcome::Undetermined
+                }
                 Ok(StatusCode::Unavailable | StatusCode::Overloaded) => {
-                    TransactionErrorOutcome::TransactionMayRemainActive
+                    TxErrorOutcome::MayRemainActive
                 }
                 Ok(
                     StatusCode::BadRequest
@@ -361,7 +364,7 @@ impl YdbError {
                     | StatusCode::Unsupported
                     | StatusCode::SessionBusy
                     | StatusCode::ExternalError,
-                ) => TransactionErrorOutcome::TransactionEnded,
+                ) => TxErrorOutcome::Ended,
             },
             Self::Custom(_)
             | Self::Convert(_)
@@ -371,7 +374,7 @@ impl YdbError {
             | Self::TransportDial(_)
             | Self::Transport(_)
             | Self::TransportGRPCStatus(_)
-            | Self::DeadlineExceeded => TransactionErrorOutcome::OutcomeUnknown,
+            | Self::DeadlineExceeded => TxErrorOutcome::Undetermined,
         }
     }
 
@@ -587,10 +590,10 @@ mod error_classification_tests {
     }
 
     #[test]
-    fn malformed_success_status_has_unknown_transaction_outcome() {
+    fn malformed_success_status_is_conservatively_undetermined() {
         assert_eq!(
-            ydb_status(StatusCode::Success).transaction_error_outcome(),
-            TransactionErrorOutcome::OutcomeUnknown
+            ydb_status(StatusCode::Success).tx_error_outcome(),
+            TxErrorOutcome::Undetermined
         );
     }
 
@@ -601,10 +604,7 @@ mod error_classification_tests {
             StatusCode::Aborted,
             StatusCode::BadSession,
         ] {
-            assert_eq!(
-                ydb_status(status).transaction_error_outcome(),
-                TransactionErrorOutcome::TransactionEnded
-            );
+            assert_eq!(ydb_status(status).tx_error_outcome(), TxErrorOutcome::Ended);
         }
     }
 
@@ -612,33 +612,27 @@ mod error_classification_tests {
     fn transient_query_failures_may_leave_the_server_transaction_active() {
         for status in [StatusCode::Unavailable, StatusCode::Overloaded] {
             assert_eq!(
-                ydb_status(status).transaction_error_outcome(),
-                TransactionErrorOutcome::TransactionMayRemainActive
+                ydb_status(status).tx_error_outcome(),
+                TxErrorOutcome::MayRemainActive
             );
         }
     }
 
     #[test]
-    fn ambiguous_and_transport_errors_have_unknown_transaction_outcome() {
+    fn undetermined_and_transport_errors_have_undetermined_tx_outcome() {
         for error in [
             ydb_status(StatusCode::Undetermined),
             YdbError::Transport("timeout".into()),
             YdbError::Custom("malformed response".into()),
         ] {
-            assert_eq!(
-                error.transaction_error_outcome(),
-                TransactionErrorOutcome::OutcomeUnknown
-            );
+            assert_eq!(error.tx_error_outcome(), TxErrorOutcome::Undetermined);
         }
     }
 
     #[test]
-    fn unknown_status_code_has_unknown_transaction_outcome() {
+    fn unknown_status_code_has_undetermined_tx_outcome() {
         let err = YdbError::YdbStatusError(YdbStatusError::new("unknown", -1, vec![]));
-        assert_eq!(
-            err.transaction_error_outcome(),
-            TransactionErrorOutcome::OutcomeUnknown
-        );
+        assert_eq!(err.tx_error_outcome(), TxErrorOutcome::Undetermined);
     }
 
     #[test]

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -77,6 +77,8 @@ pub struct SessionPoolSettings {
     /// Close idle sessions after this duration (0 = unlimited).
     pub idle_ttl: Duration,
     pub session_create_timeout: Duration,
+    /// Maximum time for a best-effort session cleanup RPC, including `DeleteSession` and
+    /// transaction rollback performed before a session can be reused.
     pub session_delete_timeout: Duration,
     /// Max wait when [`SessionPool::acquire_explicit`] blocks on the pool semaphore.
     pub acquire_timeout: Duration,
@@ -152,7 +154,7 @@ impl SessionPoolSettings {
         self
     }
 
-    /// Maximum time for DeleteSession when the pool closes a session.
+    /// Maximum time for a best-effort session cleanup RPC.
     pub fn with_session_delete_timeout(mut self, timeout: Duration) -> Self {
         self.session_delete_timeout = timeout;
         self
@@ -199,6 +201,10 @@ impl SessionPoolLease {
 
     pub fn ensure_healthy(&self) -> YdbResult<()> {
         self.record.session.ensure_healthy()
+    }
+
+    pub(crate) fn cleanup_timeout(&self) -> Duration {
+        self.pool.settings.session_delete_timeout
     }
 
     /// Consume this lease and offer its session back to the pool. Pool policy may still discard

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -5,7 +5,7 @@
 //!
 //! - no query fails: `retry_tx` sends `CommitTransaction`;
 //! - the last query uses `.with_commit(true)`: the query commits the transaction;
-//! - a query returns a concrete failure: the whole transaction attempt is retried;
+//! - a query returns a concrete failure: the attempt is rolled back and retried;
 //! - a query returns an undetermined status: the transaction outcome is unknown;
 //! - the caller explicitly rolls back;
 //! - rollback or commit RPC outcome is unknown;
@@ -13,7 +13,7 @@
 //! The regression cases for #521 are the swallowed-error paths: if the callback
 //! returns `Ok` after the server invalidated the transaction, or after rollback
 //! failed, `retry_tx` must not report a successful commit. A concrete transient query
-//! failure ends the current attempt and retries the whole transaction.
+//! failure ends the current attempt, which is rolled back before retry.
 mod mock_server;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -517,8 +517,8 @@ async fn swallowed_invalidating_error_must_not_report_committed() -> YdbResult<(
     Ok(())
 }
 
-/// A concrete transient query failure ends the current attempt and retries the whole
-/// transaction rather than continuing or rolling back that attempt.
+/// A concrete transient query failure rolls back the current attempt and retries the whole
+/// transaction rather than continuing it.
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn transient_error_propagated_retries_whole_transaction() -> YdbResult<()> {
@@ -546,8 +546,8 @@ async fn transient_error_propagated_retries_whole_transaction() -> YdbResult<()>
     assert!(result.is_ok(), "expected eventual success, got {result:?}");
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(
-        lifecycle.rollback_count, 0,
-        "the failed query already ended the local transaction attempt"
+        lifecycle.rollback_count, 1,
+        "the failed transaction attempt must be rolled back before retry"
     );
     assert_eq!(
         lifecycle.commit_count, 1,
@@ -594,8 +594,8 @@ async fn transient_error_swallowed_retries_whole_transaction() -> YdbResult<()> 
         "only the successful retry attempt should commit"
     );
     assert_eq!(
-        lifecycle.rollback_count, 0,
-        "the concrete query failure ends its transaction attempt"
+        lifecycle.rollback_count, 1,
+        "the swallowed query error must still roll back its failed attempt"
     );
     Ok(())
 }
@@ -625,7 +625,6 @@ async fn swallowed_undetermined_query_error_is_undetermined() -> YdbResult<()> {
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.commit_count, 0);
-    assert_eq!(lifecycle.rollback_count, 0);
     Ok(())
 }
 

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -6,7 +6,7 @@
 //! - no query fails: `retry_tx` sends `CommitTransaction`;
 //! - the last query uses `.with_commit(true)`: the query commits the transaction;
 //! - a query returns a concrete failure: the whole transaction attempt is retried;
-//! - a query returns an ambiguous status: the transaction outcome is unknown;
+//! - a query returns an undetermined status: the transaction outcome is unknown;
 //! - the caller explicitly rolls back;
 //! - rollback or commit RPC outcome is unknown;
 //!
@@ -223,7 +223,7 @@ impl Handler for ScriptedQueryHandler {
 /// Every `ExecuteQuery` succeeds; `CommitTransaction` always fails at the transport level
 /// (mirrors `topic_writer_tx.rs`'s `CommitFailsHandler`: a raw RPC failure, not a status-coded
 /// response, so `need_retry` resolves to `IdempotentOnly` and the default `idempotent(false)`
-/// blocks a blind whole-transaction retry after an ambiguous commit).
+/// blocks a blind whole-transaction retry after an undetermined commit).
 #[derive(Default)]
 struct CommitTransportFailsHandler {
     replies: ReplySink,
@@ -295,7 +295,7 @@ async fn happy_path_reports_committed() -> YdbResult<()> {
     Ok(())
 }
 
-/// A failed `CommitTransaction` has an ambiguous server-side outcome, so `retry_tx`
+/// A failed `CommitTransaction` has an undetermined server-side outcome, so `retry_tx`
 /// must report the error instead of retrying the whole transaction blindly.
 #[tokio::test]
 #[tracing_test::traced_test]
@@ -314,12 +314,12 @@ async fn commit_rpc_failure_is_reported_and_not_retried() -> YdbResult<()> {
 
     assert!(
         result.is_err(),
-        "a failed commit is ambiguous and must be reported as failure, got {result:?}"
+        "a failed commit is undetermined and must be reported as failure, got {result:?}"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(
         lifecycle.commit_count, 1,
-        "commit outcome is ambiguous, so the whole tx must not be retried"
+        "commit outcome is undetermined, so the whole tx must not be retried"
     );
     assert_eq!(lifecycle.rollback_count, 0);
     Ok(())
@@ -400,7 +400,7 @@ async fn swallowed_empty_commit_via_query_response_is_not_committed() -> YdbResu
 
     assert!(
         result.is_err(),
-        "swallowing an ambiguous commit error must not report success"
+        "swallowing an undetermined commit error must not report success"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.commit_count, 0);
@@ -429,7 +429,7 @@ async fn swallowed_first_query_failure_is_not_committed_locally() -> YdbResult<(
 
     assert!(
         result.is_err(),
-        "an unconfirmed first query must leave the transaction ambiguous"
+        "an unconfirmed first query must leave the transaction undetermined"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.commit_count, 0);
@@ -604,7 +604,7 @@ async fn transient_error_swallowed_retries_whole_transaction() -> YdbResult<()> 
 /// callback swallows it, the SDK must not continue or commit that transaction.
 #[tokio::test]
 #[tracing_test::traced_test]
-async fn swallowed_undetermined_query_error_is_ambiguous() -> YdbResult<()> {
+async fn swallowed_undetermined_query_error_is_undetermined() -> YdbResult<()> {
     let (handler, tx_lifecycle) =
         ScriptedQueryHandler::new(vec![StatusCode::Success, StatusCode::Undetermined], vec![]);
     let (server, _reply_tx) = MockServer::start(handler).await;
@@ -619,7 +619,10 @@ async fn swallowed_undetermined_query_error_is_ambiguous() -> YdbResult<()> {
         }))
         .await;
 
-    assert!(result.is_err(), "an unknown transaction outcome must fail");
+    assert!(
+        result.is_err(),
+        "an undetermined transaction outcome must fail"
+    );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.commit_count, 0);
     assert_eq!(lifecycle.rollback_count, 0);

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -5,16 +5,15 @@
 //!
 //! - no query fails: `retry_tx` sends `CommitTransaction`;
 //! - the last query uses `.with_commit(true)`: the query commits the transaction;
-//! - a query returns an invalidating status: the server has already ended the transaction;
-//! - a query returns a transient/ambiguous status: the transaction may still be active;
+//! - a query returns a concrete failure: the whole transaction attempt is retried;
+//! - a query returns an ambiguous status: the transaction outcome is unknown;
 //! - the caller explicitly rolls back;
 //! - rollback or commit RPC outcome is unknown;
 //!
 //! The regression cases for #521 are the swallowed-error paths: if the callback
 //! returns `Ok` after the server invalidated the transaction, or after rollback
-//! failed, `retry_tx` must not report a successful commit. Swallowing a transient
-//! query error is different: the transaction is not known to be invalidated, so a
-//! real commit attempt decides the outcome.
+//! failed, `retry_tx` must not report a successful commit. A concrete transient query
+//! failure ends the current attempt and retries the whole transaction.
 mod mock_server;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -415,7 +414,7 @@ async fn swallowed_empty_commit_via_query_response_is_not_committed() -> YdbResu
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn swallowed_first_query_failure_is_not_committed_locally() -> YdbResult<()> {
-    let (handler, tx_lifecycle) = ScriptedQueryHandler::new(vec![StatusCode::Unavailable], vec![]);
+    let (handler, tx_lifecycle) = ScriptedQueryHandler::new(vec![StatusCode::Undetermined], vec![]);
     let (server, _reply_tx) = MockServer::start(handler).await;
     let client = make_client(&server).await?;
 
@@ -518,11 +517,11 @@ async fn swallowed_invalidating_error_must_not_report_committed() -> YdbResult<(
     Ok(())
 }
 
-/// A transient query error does not prove the server ended the transaction, so a
-/// propagated error must trigger a real rollback before retrying.
+/// A concrete transient query failure ends the current attempt and retries the whole
+/// transaction rather than continuing or rolling back that attempt.
 #[tokio::test]
 #[tracing_test::traced_test]
-async fn transient_error_propagated_rolls_back_and_retries() -> YdbResult<()> {
+async fn transient_error_propagated_retries_whole_transaction() -> YdbResult<()> {
     let (handler, tx_lifecycle) = ScriptedQueryHandler::new(
         vec![
             StatusCode::Success,     // attempt 0, 1st query: establishes tx_id
@@ -547,8 +546,8 @@ async fn transient_error_propagated_rolls_back_and_retries() -> YdbResult<()> {
     assert!(result.is_ok(), "expected eventual success, got {result:?}");
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(
-        lifecycle.rollback_count, 1,
-        "the failed first attempt must be rolled back for real"
+        lifecycle.rollback_count, 0,
+        "the failed query already ended the local transaction attempt"
     );
     assert_eq!(
         lifecycle.commit_count, 1,
@@ -557,13 +556,19 @@ async fn transient_error_propagated_rolls_back_and_retries() -> YdbResult<()> {
     Ok(())
 }
 
-/// Swallowing a transient query error is safe from false-commit reporting because
-/// `retry_tx` still verifies the final outcome with a real commit attempt.
+/// Swallowing a concrete transient query error still retries the whole transaction attempt.
 #[tokio::test]
 #[tracing_test::traced_test]
-async fn transient_error_swallowed_falls_through_to_real_commit() -> YdbResult<()> {
-    let (handler, tx_lifecycle) =
-        ScriptedQueryHandler::new(vec![StatusCode::Success, StatusCode::Unavailable], vec![]);
+async fn transient_error_swallowed_retries_whole_transaction() -> YdbResult<()> {
+    let (handler, tx_lifecycle) = ScriptedQueryHandler::new(
+        vec![
+            StatusCode::Success,
+            StatusCode::Unavailable,
+            StatusCode::Success,
+            StatusCode::Success,
+        ],
+        vec![],
+    );
     let (server, _reply_tx) = MockServer::start(handler).await;
     let client = make_client(&server).await?;
 
@@ -581,17 +586,43 @@ async fn transient_error_swallowed_falls_through_to_real_commit() -> YdbResult<(
 
     assert!(
         result.is_ok(),
-        "the tx was never invalidated, so a real commit should decide the outcome: {result:?}"
+        "the retried transaction should succeed: {result:?}"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(
         lifecycle.commit_count, 1,
-        "retry_tx must still attempt a real commit rather than trusting the swallowed error"
+        "only the successful retry attempt should commit"
     );
     assert_eq!(
         lifecycle.rollback_count, 0,
-        "single attempt, no retry expected"
+        "the concrete query failure ends its transaction attempt"
     );
+    Ok(())
+}
+
+/// `UNDETERMINED` does not establish whether the dispatched query took effect. Even if the
+/// callback swallows it, the SDK must not continue or commit that transaction.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn swallowed_undetermined_query_error_is_ambiguous() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedQueryHandler::new(vec![StatusCode::Success, StatusCode::Undetermined], vec![]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+            let _ = tx.exec("UPSERT INTO t (id, val) VALUES (2, 'y')").await;
+            Ok(())
+        }))
+        .await;
+
+    assert!(result.is_err(), "an unknown transaction outcome must fail");
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
+    assert_eq!(lifecycle.rollback_count, 0);
     Ok(())
 }
 
@@ -665,7 +696,7 @@ async fn rollback_rpc_failure_propagated_is_retried_until_rollback_succeeds() ->
 #[tracing_test::traced_test]
 async fn swallowed_rollback_failure_must_not_report_committed() -> YdbResult<()> {
     let (handler, tx_lifecycle) =
-        ScriptedQueryHandler::new(vec![StatusCode::Success], vec![StatusCode::BadSession]);
+        ScriptedQueryHandler::new(vec![StatusCode::Success], vec![StatusCode::Undetermined]);
     let (server, _reply_tx) = MockServer::start(handler).await;
     let client = make_client(&server).await?;
 

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -18,6 +18,7 @@ mod mock_server;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use ydb::{Client, ClientBuilder, Transaction, YdbResult, closure};
 use ydb_grpc::ydb_proto::query::{
@@ -78,6 +79,19 @@ struct TxLifecycle {
 }
 
 type SharedTxLifecycle = Arc<Mutex<TxLifecycle>>;
+
+async fn wait_for_rollback_count(tx_lifecycle: &SharedTxLifecycle, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if tx_lifecycle.lock().unwrap().rollback_count >= expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for transaction cleanup rollback");
+}
 
 /// Every `ExecuteQuery` succeeds. A lazy transaction ID arrives after the first response part;
 /// a query that commits the transaction omits it. `CommitTransaction` and `RollbackTransaction`
@@ -429,7 +443,7 @@ async fn swallowed_first_query_failure_is_not_committed_locally() -> YdbResult<(
 
     assert!(
         result.is_err(),
-        "an unconfirmed first query must leave the transaction undetermined"
+        "an unconfirmed first query must fail the transaction attempt"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.commit_count, 0);
@@ -466,12 +480,11 @@ async fn invalidating_error_propagated_is_retried_until_success() -> YdbResult<(
 }
 
 /// Regression test for https://github.com/ydb-platform/ydb-rs-sdk/issues/521:
-/// `retry_tx` must not report a transaction as committed when the server has
-/// already invalidated it, even if the user callback swallows the invalidating
-/// query error and returns `Ok`.
+/// `retry_tx` must not report a transaction as committed when a query fails,
+/// even if the user callback swallows that error and returns `Ok`.
 #[tokio::test]
 #[tracing_test::traced_test]
-async fn swallowed_invalidating_error_must_not_report_committed() -> YdbResult<()> {
+async fn swallowed_query_error_must_not_report_committed() -> YdbResult<()> {
     let (handler, tx_lifecycle) = ScriptedQueryHandler::new(
         vec![StatusCode::Success, StatusCode::PreconditionFailed],
         vec![],
@@ -484,7 +497,8 @@ async fn swallowed_invalidating_error_must_not_report_committed() -> YdbResult<(
         .retry_tx(closure!(async |tx: &mut Transaction| {
             tx.exec("UPSERT INTO t (id, val) VALUES (2, 'x')").await?;
 
-            // Duplicate-key-style conflict: server aborts the transaction.
+            // Duplicate-key-style conflict. The SDK cannot infer the remote transaction
+            // lifecycle from the status alone, so cleanup must attempt rollback.
             let conflict = tx.exec("INSERT INTO t (id, val) VALUES (1, 'dup')").await;
 
             // The application "handles" the error itself and continues — this is the
@@ -495,22 +509,21 @@ async fn swallowed_invalidating_error_must_not_report_committed() -> YdbResult<(
         }))
         .await;
 
-    {
-        let lifecycle = tx_lifecycle.lock().unwrap();
-        assert_eq!(
-            lifecycle.commit_count, 0,
-            "the server already invalidated the tx; the SDK must not send CommitTransaction"
-        );
-        assert_eq!(
-            lifecycle.rollback_count, 0,
-            "the server already invalidated the tx; the SDK must not send RollbackTransaction"
-        );
-    }
+    wait_for_rollback_count(&tx_lifecycle, 1).await;
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(
+        lifecycle.commit_count, 0,
+        "a failed transaction attempt must not send CommitTransaction"
+    );
+    assert_eq!(
+        lifecycle.rollback_count, 1,
+        "a started transaction must be rolled back before its session is reused"
+    );
 
     assert!(
         result.is_err(),
-        "retry_tx reported success ({result:?}) for a transaction the server had already \
-         aborted, just because the callback swallowed the invalidating query error \
+        "retry_tx reported success ({result:?}) for a failed transaction attempt just \
+         because the callback swallowed the query error \
          (https://github.com/ydb-platform/ydb-rs-sdk/issues/521)"
     );
 

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -80,23 +80,30 @@ struct TxLifecycle {
 
 type SharedTxLifecycle = Arc<Mutex<TxLifecycle>>;
 
-/// Every `ExecuteQuery` succeeds (handing back `QUERY_TX_ID`); `CommitTransaction` and
-/// `RollbackTransaction` are counted and then passed through to the mock's default handler,
-/// which replies success for both. Covers T0 (happy path), T1 (commit-via-query), T4
-/// (explicit rollback succeeds), and T6 (panic, before/after a real terminal event) — the
-/// mock behavior needed is identical across those; only the callback differs.
+/// Every `ExecuteQuery` succeeds. A lazy transaction ID arrives after the first response part;
+/// a query that commits the transaction omits it. `CommitTransaction` and `RollbackTransaction`
+/// are counted and then passed through to the mock's default handler, which replies success for
+/// both. Covers T0 (happy path), T1 (commit-via-query), T4 (explicit rollback succeeds), and T6
+/// (panic, before/after a real terminal event) — the mock behavior needed is identical across
+/// those; only the callback differs.
 #[derive(Default)]
 struct CountingHandler {
     replies: ReplySink,
     tx_lifecycle: SharedTxLifecycle,
+    empty_execute_response: bool,
 }
 
 impl CountingHandler {
     fn new() -> (Self, SharedTxLifecycle) {
+        Self::with_empty_execute_response(false)
+    }
+
+    fn with_empty_execute_response(empty_execute_response: bool) -> (Self, SharedTxLifecycle) {
         let tx_lifecycle = Arc::new(Mutex::new(TxLifecycle::default()));
         let handler = Self {
             replies: ReplySink::default(),
             tx_lifecycle: tx_lifecycle.clone(),
+            empty_execute_response,
         };
         (handler, tx_lifecycle)
     }
@@ -118,13 +125,25 @@ impl Handler for CountingHandler {
             _ => {}
         }
 
-        let Incoming::Query(QueryIncoming::ExecuteQuery(_, stream_id)) = incoming else {
+        let Incoming::Query(QueryIncoming::ExecuteQuery(request, stream_id)) = incoming else {
             return Some(incoming);
         };
-        self.replies.send(QueryReply::ExecuteQuery {
-            stream_id,
-            part: success_part(Some(QUERY_TX_ID)),
-        });
+        if !self.empty_execute_response {
+            self.replies.send(QueryReply::ExecuteQuery {
+                stream_id,
+                part: success_part(None),
+            });
+            if request
+                .tx_control
+                .as_ref()
+                .is_none_or(|control| !control.commit_tx)
+            {
+                self.replies.send(QueryReply::ExecuteQuery {
+                    stream_id,
+                    part: success_part(Some(QUERY_TX_ID)),
+                });
+            }
+        }
         self.replies
             .send(QueryReply::ExecuteQueryClose { stream_id });
         None
@@ -330,6 +349,91 @@ async fn commit_via_query_reports_committed() -> YdbResult<()> {
         lifecycle.commit_count, 0,
         "commit already happened via the query; no separate RPC expected"
     );
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn empty_commit_via_query_response_is_not_committed() -> YdbResult<()> {
+    let (handler, tx_lifecycle) = CountingHandler::with_empty_execute_response(true);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')")
+                .with_commit(true)
+                .await?;
+            Ok(())
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an empty ExecuteQuery response must not confirm commit"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn swallowed_empty_commit_via_query_response_is_not_committed() -> YdbResult<()> {
+    let (handler, tx_lifecycle) = CountingHandler::with_empty_execute_response(true);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            let commit = tx
+                .exec("UPSERT INTO t (id, val) VALUES (1, 'x')")
+                .with_commit(true)
+                .await;
+            assert!(commit.is_err(), "empty response must fail the query");
+            Ok(())
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "swallowing an ambiguous commit error must not report success"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+/// Once the first `ExecuteQuery` has been dispatched, a failed response can leave a server-side
+/// transaction whose ID the SDK never received. Swallowing that error must not turn the local
+/// transaction back into an unstarted transaction that can be "committed" without an RPC.
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn swallowed_first_query_failure_is_not_committed_locally() -> YdbResult<()> {
+    let (handler, tx_lifecycle) = ScriptedQueryHandler::new(vec![StatusCode::Unavailable], vec![]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            let query = tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await;
+            assert!(query.is_err(), "the first query must fail");
+            Ok(())
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an unconfirmed first query must leave the transaction ambiguous"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
     assert_eq!(lifecycle.rollback_count, 0);
     Ok(())
 }

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -366,6 +366,46 @@ async fn commit_via_query_reports_committed() -> YdbResult<()> {
     Ok(())
 }
 
+async fn assert_dropped_transaction_stream_is_not_committed(drain: bool) -> YdbResult<()> {
+    let (handler, tx_lifecycle) = CountingHandler::new();
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            let mut stream = tx.query("SELECT 1; SELECT 2").await?;
+            if drain {
+                while stream.next_result_set().await?.is_some() {}
+            }
+            drop(stream);
+            Ok(())
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a dropped transaction stream must fail the attempt"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn dropped_partially_consumed_transaction_stream_is_not_committed() -> YdbResult<()> {
+    // Opening primes one response part; dropping now leaves the remaining stream unread.
+    assert_dropped_transaction_stream_is_not_committed(false).await
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn dropped_drained_transaction_stream_is_not_committed() -> YdbResult<()> {
+    assert_dropped_transaction_stream_is_not_committed(true).await
+}
+
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn empty_commit_via_query_response_is_not_committed() -> YdbResult<()> {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- OpenedQueryStream has session lease owning ambiguity. Some -> owns session, None -> Query is session-less or session belongs to transaction.
- TxState carries to resources, so those resources are stores as Optional values in transaction context (session/transaction_id)
<!-- Please describe the current behavior thagt you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- QueryStream manages its session owning in explicit enum with descriptive naming. 
- TransactionState owns the resources. Active state owns lease and ServerState.
- Query completion, failure and drop explicitly return or discard the owned session.
- Failure of the first dispatched query without a confirmed transaction ID makes the transaction ambiguous and discards its session, preventing a false commit.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
