### PR TITLE
refactor(query): model dispatched transaction operations

### DIFF
--- a/ydb/src/client_query/concurrent_result_sets_test.rs
+++ b/ydb/src/client_query/concurrent_result_sets_test.rs
@@ -6,9 +6,10 @@ use super::exec::{CallOptions, build_client_execute_request_for_test};
 
 #[test]
 fn new_execute_request_defaults_concurrent_result_sets_to_false() {
-    let req = RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false);
+    let req = RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false)
+        .expect("valid request");
     assert!(!req.concurrent_result_sets);
-    let proto = req.into_proto().expect("valid proto");
+    let proto = ydb_grpc::ydb_proto::query::ExecuteQueryRequest::from(req);
     assert!(!proto.concurrent_result_sets);
 }
 
@@ -17,7 +18,7 @@ fn build_execute_request_sets_concurrent_result_sets_on_request_and_proto() {
     for want in [true, false] {
         let req = build_client_execute_request_for_test(&CallOptions::default(), want);
         assert_eq!(req.concurrent_result_sets, want);
-        let proto = req.into_proto().expect("valid proto");
+        let proto = ydb_grpc::ydb_proto::query::ExecuteQueryRequest::from(req);
         assert_eq!(proto.concurrent_result_sets, want);
     }
 }

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -80,8 +80,8 @@ pub(crate) enum TxState {
     Committed,
     /// Rollback path was chosen and the SDK must not report a commit.
     RolledBack,
-    /// A conclusive failure ended the local transaction attempt. Its session ownership has already
-    /// been resolved; retry policy decides whether to start another attempt.
+    /// A returned operation error ended the local transaction attempt. Its session ownership has
+    /// already been resolved; retry policy decides whether to start another attempt.
     AttemptFailed(YdbError),
     /// A dispatched operation's server outcome was not conclusively observed.
     Undetermined(YdbError),
@@ -243,9 +243,9 @@ impl TxExecContext {
         replacement: TxState,
         status: QueryTxCommitStatus,
     ) -> YdbResult<SessionPoolLease> {
-        let mut active = self.replace_active(replacement)?;
-        active.notify_hooks(status);
-        Ok(active.lease)
+        let mut previous_active = self.replace_active(replacement)?;
+        previous_active.notify_hooks(status);
+        Ok(previous_active.lease)
     }
 
     /// End an attempt with an unknown server outcome and discard its session.
@@ -296,17 +296,6 @@ impl TxExecContext {
         Ok(())
     }
 
-    fn resolve_finalization_error(&mut self, error: &YdbError) -> YdbResult<()> {
-        // An error that is safe to retry even for non-idempotent work guarantees that the
-        // finalization did not complete. Other retry classes do not prove the outcome of an
-        // already-dispatched commit or rollback, so keep those outcomes undetermined.
-        if error.is_retriable(Idempotency::NonIdempotent) {
-            self.fail_attempt(error)
-        } else {
-            self.finish_undetermined(error.clone())
-        }
-    }
-
     fn handle_pre_dispatch_error(&mut self, error: &YdbError) -> YdbResult<()> {
         if error.requires_session_discard() {
             self.fail_attempt(error)?;
@@ -355,14 +344,14 @@ impl Drop for TxExecContext {
             (TxOperationState::InFlight, _) => return,
         };
 
+        let cleanup_timeout = lease.cleanup_timeout();
+        let session_id = lease.session_id().to_string();
+
         spawn_pool_release(async move {
-            let rollback_ok = client
-                .rollback_transaction(lease.session_id(), tx_id.as_str())
-                .await
-                .is_ok();
-            if rollback_ok {
-                lease.return_to_pool();
-            }
+            let rollback = client
+                .rollback_transaction(&session_id, tx_id.as_str())
+                .map_err(YdbError::from);
+            finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
         });
     }
 }
@@ -855,7 +844,7 @@ pub(crate) async fn tx_commit(tx: &mut TxExecContext) -> YdbResult<()> {
             Ok(())
         }
         Err(error) => {
-            tx.resolve_finalization_error(&error)?;
+            tx.fail_attempt(&error)?;
             Err(error)
         }
     }
@@ -899,7 +888,7 @@ pub(crate) async fn tx_rollback(tx: &mut TxExecContext) -> YdbResult<()> {
             Ok(())
         }
         Err(error) => {
-            tx.resolve_finalization_error(&error)?;
+            tx.fail_attempt(&error)?;
             Err(error)
         }
     }
@@ -1080,31 +1069,6 @@ mod unit_tests {
             assert_ne!(replacement.session_id(), session_id);
             replacement.return_to_pool();
         }
-    }
-
-    #[tokio::test]
-    async fn undetermined_finalization_discards_session() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let session_id = lease.session_id().to_string();
-        let mut ctx = test_transaction_context(lease).await;
-        ctx.mark_query_in_flight_for_test("tx-1");
-        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
-            "transaction outcome unknown",
-            StatusCode::Undetermined as i32,
-            vec![],
-        ));
-
-        ctx.resolve_finalization_error(&error)
-            .expect("unknown outcome must finish the transaction");
-
-        assert!(matches!(ctx.state, TxState::Undetermined(_)));
-        let replacement = pool
-            .acquire_explicit()
-            .await
-            .expect("discarded session must be replaced");
-        assert_ne!(replacement.session_id(), session_id);
-        replacement.return_to_pool();
     }
 
     #[tokio::test]

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -1045,7 +1045,7 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn transient_dispatched_error_discards_session_with_possibly_active_transaction() {
+    async fn transient_dispatched_error_discards_session_when_cleanup_fails() {
         for status in [StatusCode::Unavailable, StatusCode::Overloaded] {
             let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
             let lease = pool.acquire_explicit().await.expect("acquire test session");

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 use futures_util::TryFutureExt;
 use tokio::time::timeout;
 
-use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::client_metrics::names::MetricsNames;
+use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
@@ -823,6 +823,7 @@ pub(crate) async fn tx_commit(tx: &mut TxExecContext) -> YdbResult<()> {
         return Err(err);
     }
     let operation_timeout = remaining_retry_timeout(tx.retry_deadline);
+    let commit_counter = tx.metrics_names.client_transaction_commit_counter.clone();
     let active = tx.active_mut()?;
     if active.server_progress.operation.is_in_flight() {
         return Err(TxServerProgress::operation_in_progress_error());
@@ -833,9 +834,7 @@ pub(crate) async fn tx_commit(tx: &mut TxExecContext) -> YdbResult<()> {
         return Ok(());
     };
 
-    tx.metrics_names
-        .client_transaction_commit_counter
-        .increment(1);
+    commit_counter.increment(1);
 
     debug_assert_eq!(active.server_progress.operation, TxOperationState::Ready);
     active.server_progress.operation = TxOperationState::InFlight;
@@ -1006,7 +1005,13 @@ mod unit_tests {
             .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
             .await
             .expect("create test query client");
-        tx_exec_context(client, lease, TransactionOptions::default(), None)
+        tx_exec_context(
+            client,
+            lease,
+            TransactionOptions::default(),
+            None,
+            MetricsNames::new(None),
+        )
     }
 
     #[test]

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::time::{Duration, Instant};
 
+use futures_util::TryFutureExt;
 use tokio::time::timeout;
 
 use crate::errors::{Idempotency, YdbError, YdbResult};
+use crate::client_metrics::names::MetricsNames;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_query_service::execute_query::RawExecuteQueryRequest;
@@ -15,13 +17,13 @@ use crate::grpc_wrapper::raw_query_service::transaction_control::{
 use crate::retry_settings::RetrySettings;
 use crate::traces::helpers::ensure_len_string;
 
-use crate::client_metrics::names::MetricsNames;
-use crate::session_pool::{SessionPool, SessionPoolLease, spawn_pool_release};
 use crate::types::Value;
 use crate::{TransactionOptions, TxMode, closure};
 use tracing::instrument;
 
-use super::hooks::QueryTxHook;
+use crate::session_pool::{SessionPool, SessionPoolLease, spawn_pool_release};
+
+use super::hooks::{QueryTxCommitStatus, QueryTxHook};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CallOptions {
@@ -30,7 +32,8 @@ pub(crate) struct CallOptions {
     pub collect_stats: bool,
     /// Override Query Service `commit_tx`. `None` uses context default.
     pub commit_tx: Option<bool>,
-    /// Per-call isolation override. `None` uses the surrounding context default.
+    /// Per-call isolation override. `None` → [`TxMode::Implicit`] on client,
+    /// [`TxExecContext::tx_mode`] in interactive transactions.
     pub tx_mode: Option<TxMode>,
     /// One-shot [`QueryClient`] only: send `ExecuteQuery` with an empty `session_id`.
     pub implicit_session: bool,
@@ -69,17 +72,18 @@ impl ClientQuerySession {
     }
 }
 
-/// Complete local lifecycle state of a transaction attempt.
 pub(crate) enum TxState {
     /// An unfinished transaction always owns exactly one exclusive session lease.
     Active(ActiveTx),
-    /// Real, confirmed commit: either `CommitTransaction` succeeded or `commit_tx` completed.
+    /// No commit remains: no server transaction was created, `CommitTransaction` succeeded, or
+    /// the final query completed with `commit_tx`.
     Committed,
     /// Rollback path was chosen and the SDK must not report a commit.
     RolledBack,
-    /// A transaction operation failed; retry policy decides whether to start a new attempt.
+    /// A conclusive failure ended the local transaction attempt. Its session ownership has already
+    /// been resolved; retry policy decides whether to start another attempt.
     AttemptFailed(YdbError),
-    /// A dispatched operation did not confirm the transaction's final outcome.
+    /// A dispatched operation's server outcome was not conclusively observed.
     Undetermined(YdbError),
 }
 
@@ -89,39 +93,107 @@ impl TxState {
     }
 }
 
-/// Resources owned while the local transaction attempt remains active.
 pub(crate) struct ActiveTx {
+    client: Box<RawQueryClient>,
     lease: SessionPoolLease,
     server_progress: TxServerProgress,
-}
-
-/// SDK-observed progress of the remote transaction.
-///
-/// In-flight states retain the lease in the transaction so cancellation is conservative: dropping
-/// the transaction discards the session instead of issuing a second finalization RPC.
-enum TxServerProgress {
-    NotStarted,
-    BeginInFlight,
-    Started(String),
-    CommitInFlight(String),
-    RollbackInFlight(String),
-}
-
-pub(crate) struct TxExecContext {
-    pub connection_manager: GrpcConnectionManager,
-    pub tx_mode: TxMode,
-    /// When set, the first operation calls `BeginTransaction` RPC instead of lazy `BeginTx` in `ExecuteQuery`.
-    pub begin: bool,
-    pub state: TxState,
-    pub hooks: Vec<Box<dyn QueryTxHook>>,
-    /// Absolute deadline from [`QueryClient::retry_tx`] `.timeout()`, propagated to every RPC in the callback.
-    pub retry_deadline: Option<Instant>,
-    pub metrics_names: MetricsNames,
+    hooks: Vec<Box<dyn QueryTxHook>>,
 }
 
 pub(crate) enum ExecTarget<'a> {
     Client(&'a mut ClientExecContext),
     Tx(&'a mut TxExecContext),
+}
+
+/// Server-side progress within an active transaction.
+///
+/// Operation ownership and observed transaction identity are independent, so all four field
+/// combinations are valid. Dispatch records `InFlight` before awaiting; only observed successful
+/// completion restores `Ready`, making cancellation visible to transaction cleanup.
+struct TxServerProgress {
+    /// Whether a Query Service transaction RPC currently owns the transaction state.
+    operation: TxOperationState,
+    /// The transaction ID observed from the server, if one has been received.
+    tx_id: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TxOperationState {
+    Ready,
+    InFlight,
+}
+
+impl TxOperationState {
+    fn is_in_flight(self) -> bool {
+        self == Self::InFlight
+    }
+}
+
+impl TxServerProgress {
+    fn new() -> Self {
+        Self {
+            operation: TxOperationState::Ready,
+            tx_id: None,
+        }
+    }
+
+    fn operation_in_progress_error() -> YdbError {
+        YdbError::InternalError("query transaction operation is already in progress".to_string())
+    }
+
+    fn capture_query_transaction_id(&mut self, incoming: String) -> YdbResult<()> {
+        if !self.operation.is_in_flight() {
+            return Err(YdbError::InternalError(
+                "query response contained a transaction id while no query was in progress"
+                    .to_string(),
+            ));
+        }
+        match &self.tx_id {
+            None => {
+                self.tx_id = Some(incoming);
+                Ok(())
+            }
+            Some(existing) if existing == &incoming => Ok(()),
+            Some(existing) => Err(YdbError::InternalError(format!(
+                "query transaction id changed from {existing} to {incoming}"
+            ))),
+        }
+    }
+
+    fn ready_tx_id(&self) -> Option<&str> {
+        if self.operation == TxOperationState::Ready {
+            self.tx_id.as_deref()
+        } else {
+            None
+        }
+    }
+}
+
+impl ActiveTx {
+    fn new(client: RawQueryClient, lease: SessionPoolLease) -> Self {
+        Self {
+            client: Box::new(client),
+            lease,
+            server_progress: TxServerProgress::new(),
+            hooks: Vec::new(),
+        }
+    }
+
+    fn notify_hooks(&mut self, status: QueryTxCommitStatus) {
+        for hook in &mut self.hooks {
+            hook.after_commit(status);
+        }
+    }
+}
+
+pub(crate) struct TxExecContext {
+    pub tx_mode: TxMode,
+    /// When set, the first operation calls `BeginTransaction` RPC instead of lazy `BeginTx` in `ExecuteQuery`.
+    pub begin: bool,
+    pub state: TxState,
+    /// Absolute deadline from [`QueryClient::retry_tx`] `.timeout()`, propagated to every RPC in the callback.
+    pub retry_deadline: Option<Instant>,
+    pub metrics_names: MetricsNames,
 }
 
 impl TxExecContext {
@@ -145,10 +217,7 @@ impl TxExecContext {
 
     pub(super) fn transaction_id(&self) -> Option<&str> {
         match &self.state {
-            TxState::Active(ActiveTx {
-                server_progress: TxServerProgress::Started(id),
-                ..
-            }) => Some(id),
+            TxState::Active(active) => active.server_progress.ready_tx_id(),
             _ => None,
         }
     }
@@ -164,71 +233,171 @@ impl TxExecContext {
         }
     }
 
+    pub(super) fn register_hook(&mut self, hook: Box<dyn QueryTxHook>) -> YdbResult<()> {
+        self.active_mut()?.hooks.push(hook);
+        Ok(())
+    }
+
+    fn finish_tx(
+        &mut self,
+        replacement: TxState,
+        status: QueryTxCommitStatus,
+    ) -> YdbResult<SessionPoolLease> {
+        let mut active = self.replace_active(replacement)?;
+        active.notify_hooks(status);
+        Ok(active.lease)
+    }
+
+    /// End an attempt with an unknown server outcome and discard its session.
+    ///
+    /// The operation may still be running, so the lease is deliberately not returned regardless
+    /// of the error's ordinary session policy.
+    fn finish_undetermined(&mut self, error: YdbError) -> YdbResult<()> {
+        let lease = self.finish_tx(TxState::Undetermined(error), QueryTxCommitStatus::Aborted)?;
+        drop(lease);
+        Ok(())
+    }
+
+    /// End an observed failed operation using the transaction progress recorded before dispatch.
     fn fail_attempt(&mut self, error: &YdbError) -> YdbResult<()> {
-        let active = self.replace_active(TxState::AttemptFailed(error.clone()))?;
+        let mut active = self.replace_active(TxState::AttemptFailed(error.clone()))?;
+        active.notify_hooks(QueryTxCommitStatus::Aborted);
 
         if error.requires_session_discard() {
-            // Dropping a lease without returning it schedules session cleanup.
+            drop(active);
             return Ok(());
         }
 
-        release_unfinished_tx(self.connection_manager.clone(), active);
+        let ActiveTx {
+            mut client,
+            lease,
+            server_progress,
+            ..
+        } = active;
+        let tx_id = match (server_progress.operation, server_progress.tx_id) {
+            (TxOperationState::Ready, None) => {
+                lease.return_to_pool();
+                return Ok(());
+            }
+            (TxOperationState::Ready, Some(tx_id)) | (TxOperationState::InFlight, Some(tx_id)) => {
+                tx_id
+            }
+            (TxOperationState::InFlight, None) => return Ok(()),
+        };
+        let cleanup_timeout = lease.cleanup_timeout();
+        let session_id = lease.session_id().to_string();
+
+        spawn_pool_release(async move {
+            let rollback = client
+                .rollback_transaction(&session_id, tx_id.as_str())
+                .map_err(YdbError::from);
+            finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
+        });
+        Ok(())
+    }
+
+    fn resolve_finalization_error(&mut self, error: &YdbError) -> YdbResult<()> {
+        // An error that is safe to retry even for non-idempotent work guarantees that the
+        // finalization did not complete. Other retry classes do not prove the outcome of an
+        // already-dispatched commit or rollback, so keep those outcomes undetermined.
+        if error.is_retriable(Idempotency::NonIdempotent) {
+            self.fail_attempt(error)
+        } else {
+            self.finish_undetermined(error.clone())
+        }
+    }
+
+    fn handle_pre_dispatch_error(&mut self, error: &YdbError) -> YdbResult<()> {
+        if error.requires_session_discard() {
+            self.fail_attempt(error)?;
+        }
+        Ok(())
+    }
+
+    /// Resolve an operation that the user callback stopped observing.
+    ///
+    /// An `InFlight` state after the callback completes means an operation future or query stream
+    /// was abandoned before its outcome was observed.
+    pub(super) fn resolve_unobserved_operation(&mut self) -> YdbResult<()> {
+        let in_flight = match &self.state {
+            TxState::Active(active) => active.server_progress.operation.is_in_flight(),
+            _ => false,
+        };
+        if in_flight {
+            self.finish_undetermined(YdbError::InternalError(
+                "transaction operation was cancelled before its outcome was observed".to_string(),
+            ))?;
+        }
         Ok(())
     }
 }
 
-fn tx_finished_error() -> YdbError {
-    YdbError::Custom("transaction already finished (committed or rolled back)".to_string())
+impl Drop for TxExecContext {
+    fn drop(&mut self) {
+        let state = std::mem::replace(&mut self.state, TxState::RolledBack);
+        let TxState::Active(mut active) = state else {
+            return;
+        };
+
+        active.notify_hooks(QueryTxCommitStatus::Aborted);
+        let ActiveTx {
+            mut client,
+            lease,
+            server_progress,
+            ..
+        } = active;
+        let tx_id = match (server_progress.operation, server_progress.tx_id) {
+            (TxOperationState::Ready, None) => {
+                lease.return_to_pool();
+                return;
+            }
+            (TxOperationState::Ready, Some(tx_id)) => tx_id,
+            (TxOperationState::InFlight, _) => return,
+        };
+
+        spawn_pool_release(async move {
+            let rollback_ok = client
+                .rollback_transaction(lease.session_id(), tx_id.as_str())
+                .await
+                .is_ok();
+            if rollback_ok {
+                lease.return_to_pool();
+            }
+        });
+    }
 }
 
-/// Per-call timeout capped by the parent [`retry_tx`](crate::QueryClient::retry_tx) deadline when set.
-pub(crate) fn resolve_effective_timeout(
+fn tx_finished_error() -> YdbError {
+    YdbError::Custom("query transaction is no longer active".to_string())
+}
+
+fn remaining_retry_timeout(deadline: Option<Instant>) -> Option<Duration> {
+    deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()))
+}
+
+/// Per-call timeout capped by the parent [`retry_tx`](crate::QueryClient::retry_tx) deadline.
+fn resolve_operation_timeout(
     deadline: Option<Instant>,
     call_timeout: Option<Duration>,
 ) -> Option<Duration> {
-    let remaining = deadline.and_then(|d| d.checked_duration_since(Instant::now()));
-    match (call_timeout, remaining) {
-        (None, None) => None,
-        (Some(c), None) => Some(c),
-        (None, Some(r)) => Some(r),
-        (Some(c), Some(r)) => Some(c.min(r)),
+    match (call_timeout, remaining_retry_timeout(deadline)) {
+        (Some(call_timeout), Some(remaining)) => Some(call_timeout.min(remaining)),
+        (Some(call_timeout), None) => Some(call_timeout),
+        (None, remaining) => remaining,
     }
 }
 
-pub(crate) async fn maybe_with_operation_timeout<T, F>(
-    timeout: Option<Duration>,
+pub(crate) async fn with_optional_timeout<T, F>(
+    timeout_duration: Option<Duration>,
     operation: F,
 ) -> YdbResult<T>
 where
     F: Future<Output = YdbResult<T>>,
 {
-    match timeout {
-        Some(duration) => with_operation_timeout(duration, operation).await,
+    match timeout_duration {
+        Some(duration) => timeout(duration, operation).await?,
         None => operation.await,
     }
-}
-
-pub(crate) async fn with_operation_timeout<T, F>(
-    timeout_duration: Duration,
-    operation: F,
-) -> YdbResult<T>
-where
-    F: Future<Output = YdbResult<T>>,
-{
-    match timeout(timeout_duration, operation).await {
-        Ok(result) => result,
-        Err(_) => Err(YdbError::Transport(format!(
-            "operation timed out after {timeout_duration:?}"
-        ))),
-    }
-}
-
-async fn query_client_from_tx(tx: &TxExecContext) -> YdbResult<RawQueryClient> {
-    Box::pin(
-        tx.connection_manager
-            .get_auth_service_to_node(RawQueryClient::new, tx.session_lease()?.node_uri()),
-    )
-    .await
 }
 
 fn tx_mode_to_raw(mode: TxMode) -> YdbResult<RawTxMode> {
@@ -247,7 +416,7 @@ fn tx_mode_to_raw(mode: TxMode) -> YdbResult<RawTxMode> {
     }
 }
 
-fn ensure_interactive_tx_mode(mode: TxMode) -> YdbResult<()> {
+pub(super) fn ensure_interactive_tx_mode(mode: TxMode) -> YdbResult<()> {
     if mode == TxMode::Implicit {
         return Err(YdbError::Custom(
             "TxMode::Implicit is not available inside Transaction; \
@@ -292,43 +461,29 @@ fn default_commit_tx_client(_mode: TxMode) -> bool {
 
 /// Build `tx_control` for an interactive transaction.
 ///
-/// **Lazy start (default):** while `tx_id` is unknown, the first `ExecuteQuery` sends
-/// `BeginTx` with `commit_tx: false` — no upfront `BeginTransaction` RPC. The server
-/// returns `tx_id` in the response stream; later queries use `TxId`.
-///
-/// **Explicit begin:** when [`TxExecContext::begin`] is set or
-/// [`tx_ensure_begin`] was called, `tx_id` is already known and this
-/// function always emits `TxId`.
+/// A transaction without an id starts lazily through `BeginTx`; after explicit begin or the first
+/// query, subsequent requests address the transaction by id.
 fn tx_control_for_transaction(
     tx: &TxExecContext,
     opts: &CallOptions,
 ) -> YdbResult<Option<ydb_grpc::ydb_proto::query::TransactionControl>> {
     let commit_tx = opts.commit_tx.unwrap_or(false);
-    Ok(Some(match &tx.active()?.server_progress {
-        TxServerProgress::Started(id) => {
-            interactive_tx_mode(tx, opts)?;
-            tx_id_control(id, commit_tx)
-        }
-        TxServerProgress::NotStarted => {
-            reject_per_call_tx_mode_override(tx, opts)?;
-            ensure_interactive_tx_mode(tx.tx_mode)?;
-            begin_tx_control(tx_mode_to_raw(tx.tx_mode)?, commit_tx)
-        }
-        TxServerProgress::BeginInFlight
-        | TxServerProgress::CommitInFlight(_)
-        | TxServerProgress::RollbackInFlight(_) => {
-            return Err(YdbError::InternalError(
-                "query transaction operation is already in progress".to_string(),
-            ));
-        }
+    let progress = &tx.active()?.server_progress;
+    if progress.operation.is_in_flight() {
+        return Err(TxServerProgress::operation_in_progress_error());
+    }
+    let tx_mode = interactive_tx_mode(tx, opts)?;
+    Ok(Some(match progress.tx_id.as_deref() {
+        Some(id) => tx_id_control(id, commit_tx),
+        None => begin_tx_control(tx_mode_to_raw(tx_mode)?, commit_tx),
     }))
 }
 
-pub(crate) fn resolve_commit_tx(target: &ExecTarget, opts: &CallOptions) -> bool {
+pub(crate) fn resolve_commit_tx(core: &ExecTarget<'_>, opts: &CallOptions) -> bool {
     if let Some(commit_tx) = opts.commit_tx {
         return commit_tx;
     }
-    match target {
+    match core {
         ExecTarget::Client(_) => default_commit_tx_client(client_tx_mode(opts)),
         ExecTarget::Tx(_) => false,
     }
@@ -367,7 +522,7 @@ async fn client_implicit_session_request(
         params.clone(),
         tx_control_for_client(opts)?,
         opts.collect_stats,
-    );
+    )?;
     req.concurrent_result_sets = concurrent_result_sets;
     Ok((client, req))
 }
@@ -402,21 +557,20 @@ async fn open_pooled_query_stream(
     concurrent_result_sets: bool,
 ) -> YdbResult<OpenedClientQueryStream> {
     let tx_control = tx_control_for_client(opts)?;
-    let lease = Box::pin(ctx.session_pool.acquire_explicit()).await?;
+    let lease = ctx.session_pool.acquire_explicit().await?;
     let result = async {
         lease.ensure_healthy()?;
-        let mut client = Box::pin(
-            ctx.connection_manager
-                .get_auth_service_to_node(RawQueryClient::new, lease.node_uri()),
-        )
-        .await?;
+        let mut client = ctx
+            .connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
+            .await?;
         let mut req = RawExecuteQueryRequest::new(
             lease.session_id(),
             text,
             params.clone(),
             tx_control,
             opts.collect_stats,
-        );
+        )?;
         req.concurrent_result_sets = concurrent_result_sets;
         let stream = client.execute_query(req).await.map_err(YdbError::from)?;
         Ok(ExecuteQueryStream::new(stream))
@@ -456,7 +610,10 @@ pub(crate) async fn client_begin_stream(
         .await
 }
 
-/// Session and transaction ids for cross-service RPCs (e.g. topic `UpdateOffsetsInTransaction`).
+/// Materialize the transaction and return its session-scoped identity for a cross-service RPC.
+///
+/// This sends `BeginTransaction` when the transaction has not started yet. Both identifiers must
+/// be passed together: the transaction exists within this session and retains its exclusive lease.
 pub(crate) async fn tx_identity(tx: &mut TxExecContext) -> YdbResult<(String, String)> {
     tx_ensure_begin(tx).await?;
     let session_id = tx.session_lease()?.session_id().to_string();
@@ -467,62 +624,43 @@ pub(crate) async fn tx_identity(tx: &mut TxExecContext) -> YdbResult<(String, St
     Ok((session_id, transaction_id))
 }
 
-#[instrument(name = "ydb.ExecuteQuery", skip_all, fields(db.system.name = "ydb", ydb.Query.text = %ensure_len_string(&yql_text), ydb.Query.params = ?parameters, ydb.Query.opts = ?opts))]
-async fn tx_execute_request(
-    tx: &TxExecContext,
-    yql_text: String,
-    parameters: HashMap<String, Value>,
-    opts: &CallOptions,
-    concurrent_result_sets: bool,
-) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
-    let client = query_client_from_tx(tx).await?;
-    let mut req = RawExecuteQueryRequest::new(
-        tx.session_lease()?.session_id(),
-        yql_text,
-        parameters,
-        tx_control_for_transaction(tx, opts)?,
-        opts.collect_stats,
-    );
-    req.concurrent_result_sets = concurrent_result_sets;
-    Ok((client, req))
-}
-
 /// Open the transaction via `BeginTransaction` RPC (explicit begin).
 #[instrument(name = "ydb.Query.TransactionEnsureBegin", skip_all, fields(db.system.name = "ydb", ydb.tx.mode = ?tx.tx_mode, ydb.session.id = tracing::field::Empty), err)]
 pub(crate) async fn tx_ensure_begin(tx: &mut TxExecContext) -> YdbResult<()> {
-    match &tx.active()?.server_progress {
-        TxServerProgress::Started(_) => return Ok(()),
-        TxServerProgress::NotStarted => {}
-        TxServerProgress::BeginInFlight
-        | TxServerProgress::CommitInFlight(_)
-        | TxServerProgress::RollbackInFlight(_) => {
-            return Err(YdbError::InternalError(
-                "query transaction operation is already in progress".to_string(),
-            ));
-        }
+    let progress = &tx.active()?.server_progress;
+    if progress.operation.is_in_flight() {
+        return Err(TxServerProgress::operation_in_progress_error());
+    }
+    if progress.tx_id.is_some() {
+        return Ok(());
     }
     ensure_interactive_tx_mode(tx.tx_mode)?;
-    tx.session_lease()?.ensure_healthy()?;
     let raw_tx_mode = tx_mode_to_raw(tx.tx_mode)?;
-    let mut client = query_client_from_tx(tx).await?;
-    tx.active_mut()?.server_progress = TxServerProgress::BeginInFlight;
+    if let Err(error) = tx.session_lease()?.ensure_healthy() {
+        tx.handle_pre_dispatch_error(&error)?;
+        return Err(error);
+    }
+    let progress = &mut tx.active_mut()?.server_progress;
+    debug_assert_eq!(progress.operation, TxOperationState::Ready);
+    progress.operation = TxOperationState::InFlight;
+    let operation_timeout = remaining_retry_timeout(tx.retry_deadline);
 
     let result = {
-        let active = tx.active()?;
+        let active = tx.active_mut()?;
         let session_id = active.lease.session_id();
         tracing::Span::current().record("ydb.session.id", session_id);
-        maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
-            client
-                .begin_transaction(session_id, raw_tx_mode)
-                .await
-                .map_err(Into::into)
-        })
-        .await
+        let operation = active
+            .client
+            .begin_transaction(session_id, raw_tx_mode)
+            .map_err(YdbError::from);
+        with_optional_timeout(operation_timeout, operation).await
     };
 
     match result {
         Ok(tx_id) => {
-            tx.active_mut()?.server_progress = TxServerProgress::Started(tx_id);
+            let progress = &mut tx.active_mut()?.server_progress;
+            progress.tx_id = Some(tx_id);
+            progress.operation = TxOperationState::Ready;
             Ok(())
         }
         Err(err) => {
@@ -534,60 +672,86 @@ pub(crate) async fn tx_ensure_begin(tx: &mut TxExecContext) -> YdbResult<()> {
 
 /// Finish a successful transaction query after its response stream reaches EOF.
 pub(crate) fn tx_finish_query(tx: &mut TxExecContext, commit_at_end: bool) -> YdbResult<()> {
+    if !tx.active()?.server_progress.operation.is_in_flight() {
+        let error = YdbError::InternalError(
+            "transaction query completed while no query was in progress".to_string(),
+        );
+        tx.finish_undetermined(error.clone())?;
+        return Err(error);
+    }
+
     if commit_at_end {
         tx.metrics_names
             .client_transaction_commit_counter
             .increment(1);
-        tx.replace_active(TxState::Committed)?
-            .lease
+        tx.finish_tx(TxState::Committed, QueryTxCommitStatus::Committed)?
             .return_to_pool();
         return Ok(());
     }
 
-    let message = match &tx.active()?.server_progress {
-        TxServerProgress::Started(_) => return Ok(()),
-        TxServerProgress::BeginInFlight => "ExecuteQuery response missing transaction id",
-        TxServerProgress::NotStarted
-        | TxServerProgress::CommitInFlight(_)
-        | TxServerProgress::RollbackInFlight(_) => {
-            "query transaction reached an invalid state after ExecuteQuery"
-        }
-    };
-    let error = YdbError::InternalError(message.to_string());
-    let mut active = tx.replace_active(TxState::Undetermined(error.clone()))?;
-    active.lease.invalidate();
-    Err(error)
+    if tx.active()?.server_progress.tx_id.is_none() {
+        let error =
+            YdbError::InternalError("ExecuteQuery response missing transaction id".to_string());
+        tx.finish_undetermined(error.clone())?;
+        return Err(error);
+    }
+    tx.active_mut()?.server_progress.operation = TxOperationState::Ready;
+    Ok(())
 }
 
 async fn tx_before_commit(tx: &mut TxExecContext) -> YdbResult<()> {
-    for hook in &mut tx.hooks {
+    for hook in &mut tx.active_mut()?.hooks {
         hook.before_commit().await?;
     }
     Ok(())
 }
 
-/// Finish a failed query attempt and release its transaction resources.
-pub(crate) fn tx_handle_query_error(tx: &mut TxExecContext, err: &YdbError) {
-    if tx.state.is_active()
-        && let Err(error) = tx.fail_attempt(err)
-    {
-        tracing::error!(%error, "failed to finish transaction after query error");
+/// Resolve an error from a transaction query at the RPC dispatch boundary.
+///
+/// [`TxOperationState::InFlight`] is recorded immediately before awaiting a transaction RPC.
+/// It remains set until the response stream completes successfully. Errors before dispatch
+/// cannot have changed the server transaction; they end the attempt only when its session is
+/// unusable.
+pub(crate) fn tx_handle_query_error(tx: &mut TxExecContext, err: &YdbError) -> YdbResult<()> {
+    if tx.active()?.server_progress.operation.is_in_flight() {
+        return tx.fail_attempt(err);
+    }
+    tx.handle_pre_dispatch_error(err)
+}
+
+/// Cancel an unfinished transaction query.
+pub(crate) fn tx_cancel_query(tx: &mut TxExecContext) {
+    let TxState::Active(active) = &tx.state else {
+        return;
+    };
+    if !active.server_progress.operation.is_in_flight() {
+        tracing::error!("attempted to cancel a transaction query while no query was in progress");
+        return;
+    }
+    if let Err(error) = tx.finish_undetermined(YdbError::InternalError(
+        "query response stream was cancelled before completion".to_string(),
+    )) {
+        tracing::error!(%error, "failed to cancel query transaction stream");
     }
 }
 
-/// Cancel a transaction query whose response stream was not successfully closed.
-pub(crate) fn tx_cancel_query(tx: &mut TxExecContext) {
-    if !tx.state.is_active() {
-        return;
-    }
-
-    let error = YdbError::InternalError(
-        "query response stream was dropped before successful close".to_string(),
-    );
-    match tx.replace_active(TxState::Undetermined(error)) {
-        Ok(mut active) => active.lease.invalidate(),
-        Err(error) => tracing::error!(%error, "failed to cancel transaction query"),
-    }
+#[instrument(name = "ydb.ExecuteQuery", skip_all, fields(db.system.name = "ydb", ydb.Query.text = %ensure_len_string(&text), ydb.Query.params = ?params, ydb.Query.opts = ?opts))]
+fn tx_execute_request(
+    tx: &TxExecContext,
+    text: String,
+    params: HashMap<String, Value>,
+    opts: &CallOptions,
+    concurrent_result_sets: bool,
+) -> YdbResult<RawExecuteQueryRequest> {
+    let mut request = RawExecuteQueryRequest::new(
+        tx.session_lease()?.session_id(),
+        text,
+        params,
+        tx_control_for_transaction(tx, opts)?,
+        opts.collect_stats,
+    )?;
+    request.concurrent_result_sets = concurrent_result_sets;
+    Ok(request)
 }
 
 #[instrument(name = "ydb.Query.TransactionBeginStream", skip_all, fields(db.system.name = "ydb", ydb.tx.mode = ?tx.tx_mode, ydb.session.id = tracing::field::Empty), err)]
@@ -603,51 +767,43 @@ pub(crate) async fn tx_begin_stream(
         "implicit_session is only available on QueryClient one-shot builders"
     );
     tx.active()?;
-    let commit_at_end = opts.commit_tx.unwrap_or(false);
-    let effective_timeout = resolve_effective_timeout(tx.retry_deadline, opts.timeout);
-    let mut query_dispatched = false;
-    let result: YdbResult<ExecuteQueryStream> =
-        maybe_with_operation_timeout(effective_timeout, async {
-            tx.session_lease()?.ensure_healthy()?;
-            tracing::Span::current().record("ydb.session.id", tx.session_lease()?.session_id());
-            if tx.begin {
-                tx_ensure_begin(tx).await?;
-            }
-            if commit_at_end {
-                tx_before_commit(tx).await?;
-            }
-            let (mut client, req) =
-                tx_execute_request(tx, text, params, &opts, concurrent_result_sets).await?;
-            let starts_transaction =
-                matches!(tx.active()?.server_progress, TxServerProgress::NotStarted);
-            if starts_transaction {
-                tx.active_mut()?.server_progress = TxServerProgress::BeginInFlight;
-            }
-            query_dispatched = true;
-            let stream = client.execute_query(req).await.map_err(YdbError::from)?;
-            let mut stream = ExecuteQueryStream::new(stream);
-            stream.prime_first_part().await?;
-            if !stream.in_progress() {
-                let error = YdbError::InternalError(
-                    "ExecuteQuery response stream closed before the first part".to_string(),
-                );
-                let mut active = tx.replace_active(TxState::Undetermined(error.clone()))?;
-                active.lease.invalidate();
-                return Err(error);
-            }
-            let tx_id = stream.take_captured_tx_id();
-            apply_stream_tx_id(tx, tx_id);
-            Ok(stream)
-        })
-        .await;
-    if let Err(err) = &result {
-        if query_dispatched {
-            tx_handle_query_error(tx, err);
-        } else if let TxState::Active(active) = &mut tx.state
-            && err.requires_session_discard()
-        {
-            active.lease.invalidate();
+    let operation_timeout = resolve_operation_timeout(tx.retry_deadline, opts.timeout);
+    let result: YdbResult<ExecuteQueryStream> = with_optional_timeout(operation_timeout, async {
+        tx.session_lease()?.ensure_healthy()?;
+        tracing::Span::current().record("ydb.session.id", tx.session_lease()?.session_id());
+        if tx.begin {
+            tx_ensure_begin(tx).await?;
         }
+        if opts.commit_tx.unwrap_or(false) {
+            tx_before_commit(tx).await?;
+        }
+        let request = tx_execute_request(tx, text, params, &opts, concurrent_result_sets)?;
+        let progress = &mut tx.active_mut()?.server_progress;
+        debug_assert_eq!(progress.operation, TxOperationState::Ready);
+        progress.operation = TxOperationState::InFlight;
+        let stream = tx
+            .active_mut()?
+            .client
+            .execute_query(request)
+            .await
+            .map_err(YdbError::from)?;
+        let mut stream = ExecuteQueryStream::new(stream);
+        stream.prime_first_part().await?;
+        if !stream.in_progress() {
+            let error = YdbError::InternalError(
+                "ExecuteQuery response stream closed before the first part".to_string(),
+            );
+            return Err(error);
+        }
+        let tx_id = stream.take_captured_tx_id();
+        apply_stream_tx_id(tx, tx_id)?;
+        Ok(stream)
+    })
+    .await;
+    if let Err(err) = &result
+        && tx.state.is_active()
+    {
+        tx_handle_query_error(tx, err)?;
     }
     result
 }
@@ -658,66 +814,52 @@ pub(crate) async fn tx_commit(tx: &mut TxExecContext) -> YdbResult<()> {
         return Ok(());
     }
     if let Err(err) = tx_before_commit(tx).await {
-        let _ = tx_rollback(tx).await;
+        if let Err(error) = tx_rollback(tx).await {
+            tracing::warn!(
+                %error,
+                "rollback after transaction before-commit hook failure did not complete"
+            );
+        }
         return Err(err);
     }
-    let transaction_id = match &tx.active()?.server_progress {
-        TxServerProgress::Started(id) => Some(id.clone()),
-        TxServerProgress::NotStarted => None,
-        TxServerProgress::BeginInFlight
-        | TxServerProgress::CommitInFlight(_)
-        | TxServerProgress::RollbackInFlight(_) => {
-            return Err(YdbError::InternalError(
-                "query transaction operation is already in progress".to_string(),
-            ));
-        }
-    };
-    match transaction_id {
-        None => {
-            tx.replace_active(TxState::Committed)?
-                .lease
-                .return_to_pool();
-            return Ok(());
-        }
-        Some(id) => {
-            tx.active_mut()?.server_progress = TxServerProgress::CommitInFlight(id);
-        }
+    let operation_timeout = remaining_retry_timeout(tx.retry_deadline);
+    let active = tx.active_mut()?;
+    if active.server_progress.operation.is_in_flight() {
+        return Err(TxServerProgress::operation_in_progress_error());
     }
+    let Some(tx_id) = active.server_progress.tx_id.as_deref() else {
+        tx.finish_tx(TxState::Committed, QueryTxCommitStatus::Committed)?
+            .return_to_pool();
+        return Ok(());
+    };
+
     tx.metrics_names
         .client_transaction_commit_counter
         .increment(1);
-    let result = async {
-        let active = tx.active()?;
-        let TxServerProgress::CommitInFlight(tx_id) = &active.server_progress else {
-            return Err(YdbError::InternalError(
-                "query transaction is not committing".to_string(),
-            ));
-        };
-        let session_id = active.lease.session_id();
-        tracing::Span::current()
-            .record("ydb.session.id", session_id)
-            .record("ydb.tx.id", tx_id.as_str());
-        let mut client = tx
-            .connection_manager
-            .get_auth_service_to_node(RawQueryClient::new, active.lease.node_uri())
-            .await?;
-        maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
-            client
-                .commit_transaction(session_id, tx_id.as_str())
-                .await
-                .map_err(Into::into)
-        })
-        .await
-    }
-    .await;
 
-    let terminal = match &result {
-        Ok(()) => TxState::Committed,
-        Err(err) => TxState::Undetermined(err.clone()),
-    };
-    let active = tx.replace_active(terminal)?;
-    // Do not retry commit: a transport timeout may mean the commit succeeded server-side.
-    active.lease.finish(result)
+    debug_assert_eq!(active.server_progress.operation, TxOperationState::Ready);
+    active.server_progress.operation = TxOperationState::InFlight;
+    let session_id = active.lease.session_id();
+    tracing::Span::current()
+        .record("ydb.session.id", session_id)
+        .record("ydb.tx.id", tx_id);
+    let operation = active
+        .client
+        .commit_transaction(session_id, tx_id)
+        .map_err(YdbError::from);
+    let result = with_optional_timeout(operation_timeout, operation).await;
+
+    match result {
+        Ok(()) => {
+            tx.finish_tx(TxState::Committed, QueryTxCommitStatus::Committed)?
+                .return_to_pool();
+            Ok(())
+        }
+        Err(error) => {
+            tx.resolve_finalization_error(&error)?;
+            Err(error)
+        }
+    }
 }
 
 #[instrument(name = "ydb.Rollback", skip_all, fields(db.system.name = "ydb", ydb.tx.id = tracing::field::Empty, ydb.session.id = tracing::field::Empty), err)]
@@ -728,95 +870,40 @@ pub(crate) async fn tx_rollback(tx: &mut TxExecContext) -> YdbResult<()> {
     tx.metrics_names
         .client_transaction_rollback_counter
         .increment(1);
-    let transaction_id = match &tx.active()?.server_progress {
-        TxServerProgress::Started(id) => Some(id.clone()),
-        TxServerProgress::NotStarted => None,
-        TxServerProgress::BeginInFlight
-        | TxServerProgress::CommitInFlight(_)
-        | TxServerProgress::RollbackInFlight(_) => {
-            return Err(YdbError::InternalError(
-                "query transaction operation is already in progress".to_string(),
-            ));
-        }
+    let operation_timeout = remaining_retry_timeout(tx.retry_deadline);
+    let active = tx.active_mut()?;
+    if active.server_progress.operation.is_in_flight() {
+        return Err(TxServerProgress::operation_in_progress_error());
+    }
+    let Some(tx_id) = active.server_progress.tx_id.as_deref() else {
+        tx.finish_tx(TxState::RolledBack, QueryTxCommitStatus::Aborted)?
+            .return_to_pool();
+        return Ok(());
     };
-    match transaction_id {
-        None => {
-            tx.replace_active(TxState::RolledBack)?
-                .lease
+
+    debug_assert_eq!(active.server_progress.operation, TxOperationState::Ready);
+    active.server_progress.operation = TxOperationState::InFlight;
+    let session_id = active.lease.session_id();
+    tracing::Span::current()
+        .record("ydb.session.id", session_id)
+        .record("ydb.tx.id", tx_id);
+    let operation = active
+        .client
+        .rollback_transaction(session_id, tx_id)
+        .map_err(YdbError::from);
+    let result = with_optional_timeout(operation_timeout, operation).await;
+
+    match result {
+        Ok(()) => {
+            tx.finish_tx(TxState::RolledBack, QueryTxCommitStatus::Aborted)?
                 .return_to_pool();
-            return Ok(());
+            Ok(())
         }
-        Some(id) => {
-            tx.active_mut()?.server_progress = TxServerProgress::RollbackInFlight(id);
+        Err(error) => {
+            tx.resolve_finalization_error(&error)?;
+            Err(error)
         }
     }
-
-    let result = async {
-        let active = tx.active()?;
-        let TxServerProgress::RollbackInFlight(tx_id) = &active.server_progress else {
-            return Err(YdbError::InternalError(
-                "query transaction is not rolling back".to_string(),
-            ));
-        };
-        let session_id = active.lease.session_id();
-        tracing::Span::current()
-            .record("ydb.session.id", session_id)
-            .record("ydb.tx.id", tx_id.as_str());
-        let mut client = tx
-            .connection_manager
-            .get_auth_service_to_node(RawQueryClient::new, active.lease.node_uri())
-            .await?;
-        maybe_with_operation_timeout(resolve_effective_timeout(tx.retry_deadline, None), async {
-            client
-                .rollback_transaction(session_id, tx_id.as_str())
-                .await
-                .map_err(Into::into)
-        })
-        .await
-    }
-    .await;
-
-    let terminal = match &result {
-        Ok(()) => TxState::RolledBack,
-        Err(err) => TxState::Undetermined(err.clone()),
-    };
-    let active = tx.replace_active(terminal)?;
-    active.lease.finish(result)
-}
-
-/// Release an unfinished transaction, rolling it back first when its id is known.
-pub(super) fn release_unfinished_tx(connection_manager: GrpcConnectionManager, active: ActiveTx) {
-    let ActiveTx {
-        lease,
-        server_progress,
-    } = active;
-    let tx_id = match server_progress {
-        TxServerProgress::NotStarted => {
-            lease.return_to_pool();
-            return;
-        }
-        TxServerProgress::Started(tx_id) => tx_id,
-        TxServerProgress::BeginInFlight
-        | TxServerProgress::CommitInFlight(_)
-        | TxServerProgress::RollbackInFlight(_) => return,
-    };
-
-    let cleanup_timeout = lease.cleanup_timeout();
-    let node_uri = lease.node_uri().clone();
-    let session_id = lease.session_id().to_string();
-
-    spawn_pool_release(async move {
-        let rollback = async move {
-            let mut client = connection_manager
-                .get_auth_service_to_node(RawQueryClient::new, &node_uri)
-                .await?;
-            client
-                .rollback_transaction(&session_id, tx_id.as_str())
-                .await
-                .map_err(YdbError::from)
-        };
-        finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
-    });
 }
 
 async fn finish_rollback_cleanup<F>(lease: SessionPoolLease, cleanup_timeout: Duration, rollback: F)
@@ -829,53 +916,45 @@ where
 }
 
 pub(crate) fn tx_exec_context(
-    connection_manager: GrpcConnectionManager,
+    client: RawQueryClient,
     lease: SessionPoolLease,
     options: TransactionOptions,
     retry_deadline: Option<Instant>,
     metrics_names: MetricsNames,
 ) -> TxExecContext {
     TxExecContext {
-        connection_manager,
         tx_mode: options.mode(),
         begin: options.begin(),
-        state: TxState::Active(ActiveTx {
-            lease,
-            server_progress: TxServerProgress::NotStarted,
-        }),
-        hooks: Vec::new(),
+        state: TxState::Active(ActiveTx::new(client, lease)),
         retry_deadline,
         metrics_names,
     }
 }
 
-pub(crate) fn apply_stream_tx_id(tx: &mut TxExecContext, tx_id: Option<String>) {
-    let Some(id) = tx_id else {
-        return;
+pub(crate) fn apply_stream_tx_id(tx: &mut TxExecContext, tx_id: Option<String>) -> YdbResult<()> {
+    let Some(id) = tx_id.filter(|id| !id.is_empty()) else {
+        return Ok(());
     };
-    let Ok(active) = tx.active_mut() else {
-        tracing::warn!("query transaction received tx_id after it finished");
-        return;
-    };
-    match &active.server_progress {
-        TxServerProgress::NotStarted | TxServerProgress::BeginInFlight => {
-            active.server_progress = TxServerProgress::Started(id);
-        }
-        TxServerProgress::Started(existing) => {
-            if existing != &id {
-                tracing::warn!(
-                    existing = existing.as_str(),
-                    incoming = id.as_str(),
-                    "query transaction tx_id changed in stream; keeping first value"
-                );
-            }
-        }
-        TxServerProgress::CommitInFlight(_) | TxServerProgress::RollbackInFlight(_) => {
-            tracing::warn!(
-                incoming = id.as_str(),
-                "query transaction received tx_id while finalization was in progress"
-            );
-        }
+    if let Err(error) = tx
+        .active_mut()?
+        .server_progress
+        .capture_query_transaction_id(id)
+    {
+        tx.finish_undetermined(error.clone())?;
+        return Err(error);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+impl TxExecContext {
+    pub(super) fn mark_query_in_flight_for_test(&mut self, transaction_id: &str) {
+        let progress = &mut self
+            .active_mut()
+            .expect("active test transaction")
+            .server_progress;
+        progress.operation = TxOperationState::InFlight;
+        progress.tx_id = Some(transaction_id.to_string());
     }
 }
 
@@ -890,7 +969,8 @@ pub(super) fn build_client_execute_request_for_test(
         HashMap::new(),
         tx_control_for_client(opts).expect("valid test tx_control"),
         opts.collect_stats,
-    );
+    )
+    .expect("valid test request");
     req.concurrent_result_sets = concurrent_result_sets;
     req
 }
@@ -920,6 +1000,15 @@ mod unit_tests {
         )
     }
 
+    async fn test_transaction_context(lease: SessionPoolLease) -> TxExecContext {
+        let manager = test_connection_manager();
+        let client = manager
+            .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
+            .await
+            .expect("create test query client");
+        tx_exec_context(client, lease, TransactionOptions::default(), None)
+    }
+
     #[test]
     fn retry_helpers_and_wait() {
         let transport = YdbOrCustomerError::YDB(YdbError::Transport("timeout".into()));
@@ -930,63 +1019,35 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn transaction_rollback_is_nop_when_finished() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let mut ctx = tx_exec_context(
-            test_connection_manager(),
-            lease,
-            TransactionOptions::default(),
-            None,
-            MetricsNames::new(None),
-        );
-        ctx.active_mut()
-            .expect("active transaction")
-            .server_progress = TxServerProgress::Started("tx-1".to_string());
-        tx_handle_query_error(
-            &mut ctx,
-            &YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
-                "bad",
-                StatusCode::GenericError as i32,
+    async fn rejected_query_does_not_reuse_session_with_unfinished_tx() {
+        for tx_id in [None, Some("tx-1".to_string())] {
+            let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+            let lease = pool.acquire_explicit().await.expect("acquire test session");
+            let session_id = lease.session_id().to_string();
+            let mut ctx = test_transaction_context(lease).await;
+            let progress = &mut ctx
+                .active_mut()
+                .expect("active transaction")
+                .server_progress;
+            progress.operation = TxOperationState::InFlight;
+            progress.tx_id = tx_id;
+            let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
+                "transaction rejected",
+                StatusCode::Aborted as i32,
                 vec![],
-            )),
-        );
-        assert!(!ctx.state.is_active());
-        assert!(ctx.transaction_id().is_none());
-        tx_rollback(&mut ctx).await.expect("rollback nop");
-    }
+            ));
 
-    #[tokio::test]
-    async fn begin_in_flight_error_discards_session() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let session_id = lease.session_id().to_string();
-        let mut ctx = tx_exec_context(
-            test_connection_manager(),
-            lease,
-            TransactionOptions::default(),
-            None,
-            MetricsNames::new(None),
-        );
-        ctx.active_mut()
-            .expect("active transaction")
-            .server_progress = TxServerProgress::BeginInFlight;
-        let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
-            "transaction rejected",
-            StatusCode::Aborted as i32,
-            vec![],
-        ));
+            ctx.fail_attempt(&error)
+                .expect("rejected operation must finish the transaction");
 
-        ctx.fail_attempt(&error)
-            .expect("rejected operation must finish the transaction");
-
-        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
-        let replacement = pool
-            .acquire_explicit()
-            .await
-            .expect("session with an unconfirmed begin must be replaced");
-        assert_ne!(replacement.session_id(), session_id);
-        replacement.return_to_pool();
+            assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
+            let replacement = pool
+                .acquire_explicit()
+                .await
+                .expect("session with an unfinished transaction must be replaced");
+            assert_ne!(replacement.session_id(), session_id);
+            replacement.return_to_pool();
+        }
     }
 
     #[tokio::test]
@@ -995,16 +1056,8 @@ mod unit_tests {
             let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
             let lease = pool.acquire_explicit().await.expect("acquire test session");
             let session_id = lease.session_id().to_string();
-            let mut ctx = tx_exec_context(
-                test_connection_manager(),
-                lease,
-                TransactionOptions::default(),
-                None,
-                MetricsNames::new(None),
-            );
-            ctx.active_mut()
-                .expect("active transaction")
-                .server_progress = TxServerProgress::Started("tx-1".to_string());
+            let mut ctx = test_transaction_context(lease).await;
+            ctx.mark_query_in_flight_for_test("tx-1");
             let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
                 "temporary query failure",
                 status as i32,
@@ -1025,30 +1078,22 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn undetermined_query_error_fails_attempt_and_discards_session() {
+    async fn undetermined_finalization_discards_session() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
         let lease = pool.acquire_explicit().await.expect("acquire test session");
         let session_id = lease.session_id().to_string();
-        let mut ctx = tx_exec_context(
-            test_connection_manager(),
-            lease,
-            TransactionOptions::default(),
-            None,
-            MetricsNames::new(None),
-        );
-        ctx.active_mut()
-            .expect("active transaction")
-            .server_progress = TxServerProgress::BeginInFlight;
+        let mut ctx = test_transaction_context(lease).await;
+        ctx.mark_query_in_flight_for_test("tx-1");
         let error = YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
             "transaction outcome unknown",
             StatusCode::Undetermined as i32,
             vec![],
         ));
 
-        ctx.fail_attempt(&error)
-            .expect("undetermined outcome must finish the transaction");
+        ctx.resolve_finalization_error(&error)
+            .expect("unknown outcome must finish the transaction");
 
-        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
+        assert!(matches!(ctx.state, TxState::Undetermined(_)));
         let replacement = pool
             .acquire_explicit()
             .await
@@ -1059,25 +1104,17 @@ mod unit_tests {
 
     #[tokio::test]
     async fn in_flight_transaction_cleanup_discards_its_session() {
-        let manager = test_connection_manager();
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let session_id = lease.session_id().to_string();
-        let mut ctx = tx_exec_context(
-            manager.clone(),
-            lease,
-            TransactionOptions::default(),
-            None,
-            MetricsNames::new(None),
-        );
-        ctx.active_mut()
-            .expect("active transaction")
-            .server_progress = TxServerProgress::BeginInFlight;
-        let active = ctx
-            .replace_active(TxState::RolledBack)
-            .expect("take active transaction");
-
-        release_unfinished_tx(manager, active);
+        let session_id = {
+            let lease = pool.acquire_explicit().await.expect("acquire test session");
+            let session_id = lease.session_id().to_string();
+            let mut ctx = test_transaction_context(lease).await;
+            ctx.active_mut()
+                .expect("active transaction")
+                .server_progress
+                .operation = TxOperationState::InFlight;
+            session_id
+        };
 
         let replacement = pool
             .acquire_explicit()
@@ -1104,6 +1141,130 @@ mod unit_tests {
             .acquire_explicit()
             .await
             .expect("timed-out rollback must release the pool permit");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn unhealthy_session_before_query_ends_attempt() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let mut lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        lease.invalidate();
+        let mut ctx = test_transaction_context(lease).await;
+
+        let result = tx_begin_stream(
+            &mut ctx,
+            "SELECT 1".to_string(),
+            HashMap::new(),
+            CallOptions::default(),
+            false,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("acquire replacement session");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn request_conversion_failure_precedes_query_dispatch() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut ctx = test_transaction_context(lease).await;
+        let mut params = HashMap::new();
+        params.insert(
+            "$invalid".to_string(),
+            Value::Struct(crate::types::ValueStruct {
+                fields_name: vec!["field".to_string()],
+                values: Vec::new(),
+            }),
+        );
+
+        let result = tx_begin_stream(
+            &mut ctx,
+            "SELECT $invalid".to_string(),
+            params,
+            CallOptions::default(),
+            false,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let progress = &ctx.active().expect("active transaction").server_progress;
+        assert_eq!(progress.operation, TxOperationState::Ready);
+        assert!(progress.tx_id.is_none());
+        assert_eq!(
+            ctx.session_lease().expect("active lease").session_id(),
+            session_id
+        );
+    }
+
+    #[tokio::test]
+    async fn unhealthy_session_before_explicit_begin_ends_attempt() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let mut lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        lease.invalidate();
+        let mut ctx = test_transaction_context(lease).await;
+
+        let result = tx_ensure_begin(&mut ctx).await;
+
+        assert!(result.is_err());
+        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("acquire replacement session");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn dispatched_error_without_tx_id_discards_session() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut ctx = test_transaction_context(lease).await;
+        ctx.active_mut()
+            .expect("active transaction")
+            .server_progress
+            .operation = TxOperationState::InFlight;
+
+        tx_handle_query_error(&mut ctx, &YdbError::Transport("timeout".to_string()))
+            .expect("dispatched begin failure must finish the transaction");
+
+        assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("acquire replacement session");
+        assert_ne!(replacement.session_id(), session_id);
+        replacement.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn unobserved_transaction_operation_is_undetermined() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut ctx = test_transaction_context(lease).await;
+        ctx.mark_query_in_flight_for_test("tx-1");
+
+        ctx.resolve_unobserved_operation()
+            .expect("unobserved operation must finish the transaction");
+
+        assert!(matches!(ctx.state, TxState::Undetermined(_)));
+        let replacement = pool
+            .acquire_explicit()
+            .await
+            .expect("acquire replacement session");
         assert_ne!(replacement.session_id(), session_id);
         replacement.return_to_pool();
     }

--- a/ydb/src/client_query/explain_query.rs
+++ b/ydb/src/client_query/explain_query.rs
@@ -81,7 +81,7 @@ async fn explain_query_once(
         .await?;
 
     // Implicit session: EXPLAIN holds no server-side state, so no pool lease is taken.
-    let mut req = RawExecuteQueryRequest::new("", text, HashMap::new(), None, false);
+    let mut req = RawExecuteQueryRequest::new("", text, HashMap::new(), None, false)?;
     req.exec_mode = RawExecMode::Explain;
 
     let mut stream = ExecuteQueryStream::new(client.execute_query(req).await?);

--- a/ydb/src/client_query/integration_test.rs
+++ b/ydb/src/client_query/integration_test.rs
@@ -343,13 +343,11 @@ async fn query_with_commit_on_last_query() -> YdbResult<()> {
         .with_commit(true)
         .await?;
 
-        let err = tx
-            .query_row(format!("SELECT val FROM {table_name} WHERE id = 1"))
-            .await
-            .unwrap_err();
         assert!(
-            err.to_string().contains("already finished"),
-            "query after with_commit must fail: {err}"
+            tx.query_row(format!("SELECT val FROM {table_name} WHERE id = 1"))
+                .await
+                .is_err(),
+            "query after with_commit must fail"
         );
 
         Ok(())

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -34,8 +34,8 @@ use std::time::{Duration, Instant};
 use http::Uri;
 use tracing::instrument;
 
-use crate::client_query::exec::TxState;
 use crate::client_metrics::names::MetricsNames;
+use crate::client_query::exec::TxState;
 use crate::closure;
 use crate::errors::{
     Idempotency, YdbError, YdbOrCustomerError, YdbResult, YdbResultWithCustomerErr,
@@ -687,6 +687,7 @@ mod unit_tests {
             test_connection_manager(),
             pool.clone(),
             RetrySettings::dont_retry(),
+            MetricsNames::new(None),
         );
         let observed_pool = pool.clone();
 
@@ -707,7 +708,12 @@ mod unit_tests {
             SessionPoolSettings::new().with_limit(1),
             1,
         );
-        let client = QueryClient::new(test_connection_manager(), pool, RetrySettings::dont_retry());
+        let client = QueryClient::new(
+            test_connection_manager(),
+            pool,
+            RetrySettings::dont_retry(),
+            MetricsNames::new(None),
+        );
         let callback_called = Arc::new(AtomicBool::new(false));
         let observed_called = callback_called.clone();
 
@@ -728,7 +734,12 @@ mod unit_tests {
             SessionPoolSettings::new().with_limit(1),
             1,
         );
-        let client = QueryClient::new(test_connection_manager(), pool, RetrySettings::dont_retry());
+        let client = QueryClient::new(
+            test_connection_manager(),
+            pool,
+            RetrySettings::dont_retry(),
+            MetricsNames::new(None),
+        );
         let callback_called = Arc::new(AtomicBool::new(false));
 
         let observed_called = callback_called.clone();
@@ -766,6 +777,7 @@ mod unit_tests {
             test_connection_manager(),
             pool,
             RetrySettings::with_default_backoff(),
+            MetricsNames::new(None),
         );
         let callback_calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = callback_calls.clone();

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -35,21 +35,23 @@ use http::Uri;
 use tracing::instrument;
 
 use crate::client_query::exec::TxState;
+use crate::client_metrics::names::MetricsNames;
 use crate::closure;
 use crate::errors::{
     Idempotency, YdbError, YdbOrCustomerError, YdbResult, YdbResultWithCustomerErr,
 };
 use crate::grpc_connection_manager::GrpcConnectionManager;
+use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::result::Row;
 
 use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session_pool::SessionPool;
 use builders::{impl_client_query_methods, impl_tx_query_methods};
 use exec::{
-    ClientExecContext, TxExecContext, release_unfinished_tx, tx_commit, tx_ensure_begin,
+    ClientExecContext, TxExecContext, ensure_interactive_tx_mode, tx_commit, tx_ensure_begin,
     tx_exec_context, tx_identity, tx_rollback,
 };
-use hooks::{QueryTxCommitStatus, QueryTxHook};
+use hooks::QueryTxHook;
 
 /// Row-to-struct mapping (the sqlx `FromRow` analogue).
 pub trait FromYdbRow: Sized {
@@ -209,7 +211,7 @@ impl QueryClient {
         RetryTxBuilder::new(self, callback)
     }
 
-    async fn try_attempt_body<F, T>(
+    async fn run_tx_attempt<F, T>(
         &self,
         callback: &mut F,
         mut tx: Transaction,
@@ -230,41 +232,49 @@ impl QueryClient {
             callback.attempt(tx).await
         }
 
-        match try_attempt(callback, &mut tx).await {
-            Ok(value) => match resolve_post_callback_action(&tx.ctx.state) {
-                PostCallbackAction::Return(status) => {
-                    tx.notify_hooks(status);
-                    ControlFlow::Break(Ok(value))
+        let callback_result = try_attempt(callback, &mut tx).await;
+        if let Err(error) = tx.ctx.resolve_unobserved_operation() {
+            return ControlFlow::Break(Err(error.into()));
+        }
+
+        let value = match callback_result {
+            Ok(value) => value,
+            Err(err) => {
+                if matches!(&tx.ctx.state, TxState::Committed) {
+                    return ControlFlow::Break(Err(err));
                 }
-                PostCallbackAction::Commit => {
-                    ControlFlow::Break(match tx.commit().await {
-                        Ok(()) => {
-                            tx.notify_hooks(QueryTxCommitStatus::Committed);
-                            Ok(value)
-                        }
-                        // Commit outcome is undetermined on transport errors; never retry.
-                        Err(e) => {
-                            tx.notify_hooks(QueryTxCommitStatus::Aborted);
-                            Err(e.into())
-                        }
-                    })
+                let mut retry_error = retry_error_before_cleanup(&tx.ctx.state, err);
+                if let Err(error) = tx_rollback(&mut tx.ctx).await {
+                    tracing::warn!(
+                        %error,
+                        "rollback after transaction callback failure did not complete"
+                    );
+                    if matches!(&tx.ctx.state, TxState::Undetermined(_)) {
+                        retry_error = RetryError::UndeterminedTx(error);
+                    }
                 }
-                PostCallbackAction::Retry(err) => {
-                    tx.notify_hooks(QueryTxCommitStatus::Aborted);
-                    ControlFlow::Continue(err.into())
-                }
-                PostCallbackAction::Fail(err) => {
-                    tx.notify_hooks(QueryTxCommitStatus::Aborted);
-                    ControlFlow::Break(Err(err.into()))
+                return retry_error.retry_flow(idempotency);
+            }
+        };
+
+        let retry_error = match &tx.ctx.state {
+            TxState::Committed | TxState::RolledBack => {
+                return ControlFlow::Break(Ok(value));
+            }
+            TxState::AttemptFailed(error) => RetryError::AccordingToError(error.clone().into()),
+            TxState::Undetermined(error) => RetryError::UndeterminedTx(error.clone()),
+            TxState::Active(_) => match tx_commit(&mut tx.ctx).await {
+                Ok(()) => return ControlFlow::Break(Ok(value)),
+                Err(error) => {
+                    if matches!(&tx.ctx.state, TxState::Committed) {
+                        return ControlFlow::Break(Err(error.into()));
+                    }
+                    retry_error_for_operation(&tx.ctx.state, error)
                 }
             },
-            Err(err) => {
-                tx.rollback_quiet().await;
-                tx.notify_hooks(QueryTxCommitStatus::Aborted);
-                ControlFlow::Continue(err)
-            }
-        }?
-        .retry_flow(idempotency)
+        };
+
+        retry_error.retry_flow(idempotency)
     }
 
     #[instrument(name = "ydb.RunWithRetry", skip_all, fields(db.system.name = "ydb", ydb.Query.idempotent = idempotency.is_idempotent()), err)]
@@ -279,6 +289,7 @@ impl QueryClient {
         F: RetryTxAttempt<T>,
         T: Send,
     {
+        ensure_interactive_tx_mode(options.mode())?;
         let result = self
             .ctx
             .retry_settings
@@ -287,21 +298,21 @@ impl QueryClient {
             .retry(closure!(
                 [&client = self, callback, &options],
                 async |retry: &RetryState| {
-                    let lease = match client.ctx.session_pool.acquire_explicit().await {
-                        Ok(lease) => lease,
+                    let tx = match client
+                        .create_tx_attempt(
+                            options.clone(),
+                            wall_timeout.map(|duration| retry.start_time + duration),
+                        )
+                        .await
+                    {
+                        Ok(tx) => tx,
                         Err(err) => {
-                            return YdbOrCustomerError::from(err).retry_flow(idempotency);
+                            return YdbOrCustomerError::from(err)
+                                .retry_flow(Idempotency::Idempotent);
                         }
                     };
-                    let tx = Transaction::new(
-                        client.ctx.connection_manager.clone(),
-                        lease,
-                        options.clone(),
-                        wall_timeout.map(|d| retry.start_time + d),
-                        client.ctx.metrics_names.clone(),
-                    );
 
-                    client.try_attempt_body(callback, tx, idempotency).await
+                    client.run_tx_attempt(callback, tx, idempotency).await
                 }
             ))
             .await;
@@ -311,6 +322,31 @@ impl QueryClient {
             ControlFlow::Break(Err(err)) => Err(err),
             ControlFlow::Break(Ok(value)) => Ok(value),
         }
+    }
+
+    async fn create_tx_attempt(
+        &self,
+        options: TransactionOptions,
+        retry_deadline: Option<Instant>,
+    ) -> YdbResult<Transaction> {
+        let lease = self.ctx.session_pool.acquire_explicit().await?;
+        let query_client = match self
+            .ctx
+            .connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
+            .await
+        {
+            Ok(query_client) => query_client,
+            Err(error) => return lease.finish(Err(error)),
+        };
+
+        Ok(Transaction::new(
+            query_client,
+            lease,
+            options,
+            retry_deadline,
+            self.ctx.metrics_names.clone(),
+        ))
     }
 
     /// Analyze a query's execution plan without running it (`EXEC_MODE_EXPLAIN`).
@@ -358,20 +394,48 @@ impl QueryClient {
     }
 }
 
-enum PostCallbackAction {
-    Return(QueryTxCommitStatus),
-    Commit,
-    Retry(YdbError),
-    Fail(YdbError),
+enum RetryError {
+    /// The error's own retry classification is sufficient.
+    AccordingToError(YdbOrCustomerError),
+    /// Repeating an unknown transaction outcome additionally requires an idempotent callback.
+    UndeterminedTx(YdbError),
 }
 
-fn resolve_post_callback_action(state: &TxState) -> PostCallbackAction {
+impl RetryError {
+    fn retry_flow<T>(
+        self,
+        idempotency: Idempotency,
+    ) -> ControlFlow<YdbResultWithCustomerErr<T>, YdbOrCustomerError> {
+        match self {
+            Self::AccordingToError(error) => error.retry_flow(idempotency),
+            Self::UndeterminedTx(error) if idempotency.is_idempotent() => {
+                YdbOrCustomerError::from(error).retry_flow(idempotency)
+            }
+            Self::UndeterminedTx(error) => ControlFlow::Break(Err(error.into())),
+        }
+    }
+}
+
+/// Keep the operation error as the retry cause; undetermined state only adds the requirement that
+/// repeating the whole callback must be safe.
+fn retry_error_for_operation(state: &TxState, error: YdbError) -> RetryError {
     match state {
-        TxState::RolledBack => PostCallbackAction::Return(QueryTxCommitStatus::Aborted),
-        TxState::Committed => PostCallbackAction::Return(QueryTxCommitStatus::Committed),
-        TxState::AttemptFailed(error) => PostCallbackAction::Retry(error.clone()),
-        TxState::Undetermined(err) => PostCallbackAction::Fail(err.clone()),
-        TxState::Active(_) => PostCallbackAction::Commit,
+        TxState::Undetermined(_) => RetryError::UndeterminedTx(error),
+        TxState::Active(_)
+        | TxState::Committed
+        | TxState::RolledBack
+        | TxState::AttemptFailed(_) => RetryError::AccordingToError(error.into()),
+    }
+}
+
+/// Select the retry cause before cleanup, whose rollback attempt may replace the transaction state.
+fn retry_error_before_cleanup(state: &TxState, callback_error: YdbOrCustomerError) -> RetryError {
+    match state {
+        TxState::AttemptFailed(error) => RetryError::AccordingToError(error.clone().into()),
+        TxState::Undetermined(error) => RetryError::UndeterminedTx(error.clone()),
+        TxState::Active(_) | TxState::Committed | TxState::RolledBack => {
+            RetryError::AccordingToError(callback_error)
+        }
     }
 }
 
@@ -404,20 +468,14 @@ impl Transaction {
     impl_tx_query_methods!();
 
     fn new(
-        connection_manager: GrpcConnectionManager,
+        query_client: RawQueryClient,
         lease: crate::session_pool::SessionPoolLease,
         options: TransactionOptions,
         retry_deadline: Option<Instant>,
         metrics_names: MetricsNames,
     ) -> Self {
         Self {
-            ctx: tx_exec_context(
-                connection_manager,
-                lease,
-                options,
-                retry_deadline,
-                metrics_names,
-            ),
+            ctx: tx_exec_context(query_client, lease, options, retry_deadline, metrics_names),
         }
     }
 
@@ -425,8 +483,8 @@ impl Transaction {
         self.ctx.tx_mode
     }
 
-    pub(crate) fn register_hook(&mut self, hook: impl QueryTxHook) {
-        self.ctx.hooks.push(Box::new(hook));
+    pub(crate) fn register_hook(&mut self, hook: impl QueryTxHook) -> YdbResult<()> {
+        self.ctx.register_hook(Box::new(hook))
     }
 
     /// Explicitly open the transaction via `BeginTransaction` RPC.
@@ -435,43 +493,23 @@ impl Transaction {
     /// need `tx_id` before any YQL, or configure [`TransactionOptions::with_begin`]
     /// on the client so the first operation does this automatically.
     pub async fn begin(&mut self) -> YdbResult<()> {
-        if !self.ctx.state.is_active() {
-            return Err(YdbError::Custom("transaction already finished".to_string()));
-        }
         tx_ensure_begin(&mut self.ctx).await
     }
 
-    /// Session and transaction ids for topic offset updates inside a transaction.
+    /// Materialize the transaction and return its session-scoped identity for topic offset updates.
+    ///
+    /// The returned identifiers belong together and the transaction continues to own the session.
     pub(crate) async fn identity(&mut self) -> YdbResult<(String, String)> {
-        if !self.ctx.state.is_active() {
-            return Err(YdbError::Custom("transaction already finished".to_string()));
-        }
         tx_identity(&mut self.ctx).await
     }
 
     pub async fn rollback(&mut self) -> YdbResult<()> {
-        if !self.ctx.state.is_active() {
-            return Ok(());
-        }
         tx_rollback(&mut self.ctx).await
     }
 
-    async fn commit(&mut self) -> YdbResult<()> {
-        tx_commit(&mut self.ctx).await
-    }
-
-    async fn rollback_quiet(&mut self) {
-        if self.ctx.state.is_active() {
-            let _ = tx_rollback(&mut self.ctx).await;
-        }
-    }
-
-    fn notify_hooks(&mut self, status: QueryTxCommitStatus) {
-        for hook in &mut self.ctx.hooks {
-            hook.after_commit(status);
-        }
-    }
-
+    /// Materialize the transaction and return its session-scoped identity.
+    ///
+    /// The returned identifiers belong together and the transaction continues to own the session.
     pub(crate) async fn tx_identity(&mut self) -> YdbResult<QueryTxIdentity> {
         let (session_id, transaction_id) = tx_identity(&mut self.ctx).await?;
         Ok(QueryTxIdentity {
@@ -492,26 +530,10 @@ impl Transaction {
 }
 
 pub(crate) struct QueryTxIdentity {
+    /// Transaction identifier issued within `session_id`.
     pub(crate) transaction_id: String,
+    /// Session that owns `transaction_id` and remains leased by the transaction.
     pub(crate) session_id: String,
-}
-
-impl Drop for Transaction {
-    fn drop(&mut self) {
-        if self.ctx.state.is_active() {
-            self.notify_hooks(QueryTxCommitStatus::Aborted);
-        }
-        let state = std::mem::replace(&mut self.ctx.state, TxState::RolledBack);
-        match state {
-            TxState::Active(active) => {
-                release_unfinished_tx(self.ctx.connection_manager.clone(), active);
-            }
-            TxState::Committed
-            | TxState::RolledBack
-            | TxState::AttemptFailed(_)
-            | TxState::Undetermined(_) => {}
-        }
-    }
 }
 
 impl QueryExecutor for Transaction {
@@ -542,7 +564,6 @@ impl QueryExecutor for Transaction {
     }
 }
 
-use crate::client_metrics::names::MetricsNames;
 pub use builders::{
     CallBuilder, ClientOneShot, ExecBuilder, ExecCall, Interactive, OneResultSet, OneRow,
     OptionalRow, OptionalRowBuilder, QueryExecutor, QueryRowBuilder, QueryStreamBuilder,
@@ -558,10 +579,11 @@ pub use stream_facade::{QueryStats, QueryStream};
 mod unit_tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use crate::GrpcOptions;
     use crate::errors::YdbStatusError;
+    use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
     use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
     use crate::grpc_wrapper::raw_table_service::value::{RawColumn, RawResultSet, RawValue};
     use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
@@ -572,6 +594,17 @@ mod unit_tests {
     use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
     use builders::{exactly_one_set, take_single_row};
+
+    struct AbortCounterHook(Arc<AtomicUsize>);
+
+    #[async_trait::async_trait]
+    impl QueryTxHook for AbortCounterHook {
+        fn after_commit(&mut self, status: hooks::QueryTxCommitStatus) {
+            if status == hooks::QueryTxCommitStatus::Aborted {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
 
     fn int64_set(values: Vec<i64>) -> ResultSet {
         RawResultSet {
@@ -600,16 +633,26 @@ mod unit_tests {
         )
     }
 
-    async fn failed_transaction(pool: &SessionPool, status: StatusCode) -> (Transaction, String) {
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let session_id = lease.session_id().to_string();
-        let mut tx = Transaction::new(
-            test_connection_manager(),
+    async fn test_transaction(lease: crate::session_pool::SessionPoolLease) -> Transaction {
+        let manager = test_connection_manager();
+        let query_client = manager
+            .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
+            .await
+            .expect("create test query client");
+        Transaction::new(
+            query_client,
             lease,
             TransactionOptions::default(),
             None,
             MetricsNames::new(None),
-        );
+        )
+    }
+
+    async fn failed_transaction(pool: &SessionPool, status: StatusCode) -> (Transaction, String) {
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let session_id = lease.session_id().to_string();
+        let mut tx = test_transaction(lease).await;
+        tx.ctx.mark_query_in_flight_for_test("tx-1");
         exec::tx_handle_query_error(
             &mut tx.ctx,
             &YdbError::YdbStatusError(YdbStatusError::new(
@@ -617,7 +660,8 @@ mod unit_tests {
                 status as i32,
                 Vec::new(),
             )),
-        );
+        )
+        .expect("in-flight query error must end the transaction attempt");
         assert!(matches!(tx.ctx.state, TxState::AttemptFailed(_)));
         (tx, session_id)
     }
@@ -636,54 +680,6 @@ mod unit_tests {
         assert!(take_single_row(int64_set(vec![1, 2])).is_err());
     }
 
-    #[test]
-    fn failed_attempt_state_retries_instead_of_committing() {
-        let state = TxState::AttemptFailed(YdbError::Custom("server aborted".into()));
-        assert!(matches!(
-            resolve_post_callback_action(&state),
-            PostCallbackAction::Retry(_)
-        ));
-    }
-
-    #[test]
-    fn undetermined_state_fails_instead_of_committing() {
-        let state = TxState::Undetermined(YdbError::Custom("rollback rpc failed".into()));
-        assert!(matches!(
-            resolve_post_callback_action(&state),
-            PostCallbackAction::Fail(_)
-        ));
-    }
-
-    #[test]
-    fn committed_and_rolled_back_states_are_done_not_failed() {
-        assert!(matches!(
-            resolve_post_callback_action(&TxState::Committed),
-            PostCallbackAction::Return(QueryTxCommitStatus::Committed)
-        ));
-        assert!(matches!(
-            resolve_post_callback_action(&TxState::RolledBack),
-            PostCallbackAction::Return(QueryTxCommitStatus::Aborted)
-        ));
-    }
-
-    #[tokio::test]
-    async fn active_state_needs_a_real_commit() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let state = tx_exec_context(
-            test_connection_manager(),
-            lease,
-            TransactionOptions::default(),
-            None,
-            MetricsNames::new(None),
-        )
-        .state;
-        assert!(matches!(
-            resolve_post_callback_action(&state),
-            PostCallbackAction::Commit
-        ));
-    }
-
     #[tokio::test]
     async fn retry_transaction_owns_a_session_before_the_callback() {
         let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
@@ -691,7 +687,6 @@ mod unit_tests {
             test_connection_manager(),
             pool.clone(),
             RetrySettings::dont_retry(),
-            MetricsNames::new(None),
         );
         let observed_pool = pool.clone();
 
@@ -712,12 +707,7 @@ mod unit_tests {
             SessionPoolSettings::new().with_limit(1),
             1,
         );
-        let client = QueryClient::new(
-            test_connection_manager(),
-            pool,
-            RetrySettings::dont_retry(),
-            MetricsNames::new(None),
-        );
+        let client = QueryClient::new(test_connection_manager(), pool, RetrySettings::dont_retry());
         let callback_called = Arc::new(AtomicBool::new(false));
         let observed_called = callback_called.clone();
 
@@ -733,16 +723,63 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn failed_transaction_immediately_returns_healthy_session() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let (_tx, session_id) = failed_transaction(&pool, StatusCode::Aborted).await;
+    async fn retry_transaction_validates_mode_before_acquiring_session() {
+        let pool = SessionPool::new_explicit_bench_with_create_failures(
+            SessionPoolSettings::new().with_limit(1),
+            1,
+        );
+        let client = QueryClient::new(test_connection_manager(), pool, RetrySettings::dont_retry());
+        let callback_called = Arc::new(AtomicBool::new(false));
 
-        let lease = pool
-            .acquire_explicit()
-            .await
-            .expect("reacquire test session");
-        assert_eq!(lease.session_id(), session_id);
-        lease.return_to_pool();
+        let observed_called = callback_called.clone();
+        let invalid_mode: YdbResultWithCustomerErr<()> = client
+            .retry_tx(closure!([observed_called], async |_tx| {
+                observed_called.store(true, Ordering::Relaxed);
+                Ok(())
+            }))
+            .isolation(TxMode::Implicit)
+            .await;
+        assert!(invalid_mode.is_err());
+        assert!(!callback_called.load(Ordering::Relaxed));
+
+        let observed_called = callback_called.clone();
+        let valid_mode: YdbResultWithCustomerErr<()> = client
+            .retry_tx(closure!([observed_called], async |_tx| {
+                observed_called.store(true, Ordering::Relaxed);
+                Ok(())
+            }))
+            .await;
+        assert!(valid_mode.is_err());
+        assert!(
+            !callback_called.load(Ordering::Relaxed),
+            "invalid options must not consume the injected session failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_transaction_retries_session_acquisition_before_callback() {
+        let pool = SessionPool::new_explicit_bench_with_create_failures(
+            SessionPoolSettings::new().with_limit(1),
+            1,
+        );
+        let client = QueryClient::new(
+            test_connection_manager(),
+            pool,
+            RetrySettings::with_default_backoff(),
+        );
+        let callback_calls = Arc::new(AtomicUsize::new(0));
+        let observed_calls = callback_calls.clone();
+
+        let result: YdbResultWithCustomerErr<()> = client
+            .retry_tx(closure!([observed_calls], async |_tx| {
+                observed_calls.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }))
+            .timeout(Duration::from_secs(1))
+            .await;
+
+        result.expect("session acquisition must retry before running user code");
+        assert_eq!(callback_calls.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]
@@ -756,5 +793,47 @@ mod unit_tests {
             .expect("acquire replacement session");
         assert_ne!(lease.session_id(), session_id);
         lease.return_to_pool();
+    }
+
+    #[tokio::test]
+    async fn cancelled_query_notifies_hooks_once_before_transaction_drop() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let mut tx = test_transaction(lease).await;
+        let aborted = Arc::new(AtomicUsize::new(0));
+        tx.register_hook(AbortCounterHook(Arc::clone(&aborted)))
+            .expect("active transaction must accept a hook");
+        tx.ctx.mark_query_in_flight_for_test("tx-1");
+
+        exec::tx_cancel_query(&mut tx.ctx);
+        assert_eq!(aborted.load(Ordering::Relaxed), 1);
+
+        drop(tx);
+        assert_eq!(aborted.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn dropping_drained_unclosed_stream_marks_transaction_undetermined() {
+        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
+        let lease = pool.acquire_explicit().await.expect("acquire test session");
+        let mut tx = test_transaction(lease).await;
+        tx.ctx.mark_query_in_flight_for_test("tx-1");
+
+        {
+            let mut stream = QueryStream::from_tx(
+                ExecuteQueryStream::from_test_parts(Vec::new()),
+                &mut tx.ctx,
+                false,
+            );
+            assert!(
+                stream
+                    .next_result_set()
+                    .await
+                    .expect("drain test stream")
+                    .is_none()
+            );
+        }
+
+        assert!(matches!(tx.ctx.state, TxState::Undetermined(_)));
     }
 }

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -249,9 +249,7 @@ impl QueryClient {
                         %error,
                         "rollback after transaction callback failure did not complete"
                     );
-                    if matches!(&tx.ctx.state, TxState::Undetermined(_)) {
-                        retry_error = RetryError::UndeterminedTx(error);
-                    }
+                    retry_error = retry_error_for_operation(&tx.ctx.state, error);
                 }
                 return retry_error.retry_flow(idempotency);
             }

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -249,7 +249,12 @@ impl QueryClient {
                         %error,
                         "rollback after transaction callback failure did not complete"
                     );
-                    retry_error = retry_error_for_operation(&tx.ctx.state, error);
+                    if !matches!(
+                        &retry_error,
+                        RetryError::AccordingToError(YdbOrCustomerError::Customer(_))
+                    ) {
+                        retry_error = retry_error_for_operation(&tx.ctx.state, error);
+                    }
                 }
                 return retry_error.retry_flow(idempotency);
             }

--- a/ydb/src/client_query/query_hooks_integration_test.rs
+++ b/ydb/src/client_query/query_hooks_integration_test.rs
@@ -83,7 +83,8 @@ impl QueryTxHook for StatsHook {
 }
 
 fn register_stats_hook(tx: &mut Transaction, stats: &Arc<HookStats>) {
-    tx.register_hook(stats.hook());
+    tx.register_hook(stats.hook())
+        .expect("active transaction must accept a hook");
 }
 
 #[tokio::test]

--- a/ydb/src/client_query/retry_tx.rs
+++ b/ydb/src/client_query/retry_tx.rs
@@ -72,7 +72,10 @@ impl<'a, F, T> RetryTxBuilder<'a, F, T> {
         self
     }
 
-    /// Also retry errors that require idempotency (see [`crate::CallBuilder::idempotent`]).
+    /// Set whether the entire transaction callback is safe to repeat.
+    ///
+    /// This enables errors that require idempotency and is also required before retrying any
+    /// transaction attempt whose server outcome is unknown.
     pub fn idempotent(mut self, idempotent: bool) -> Self {
         self.idempotent = idempotent;
         self

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -11,10 +11,10 @@ use crate::grpc_wrapper::raw_query_service::fetch_script_results::RawFetchScript
 use crate::result::ResultSet;
 use crate::types::Value;
 
-use futures_util::future::BoxFuture;
+use futures_util::{TryFutureExt, future::BoxFuture};
 use tracing::instrument;
 
-use super::exec::{CallOptions, ClientExecContext, maybe_with_operation_timeout};
+use super::exec::{CallOptions, ClientExecContext, with_optional_timeout};
 
 /// Long-running script operation started by [`QueryClient::execute_script`].
 #[derive(Debug, Clone)]
@@ -184,14 +184,11 @@ async fn client_execute_script_once(
         .connection_manager
         .get_auth_service(RawQueryClient::new)
         .await?;
-    let (id, consumed_units) = match maybe_with_operation_timeout(timeout, async {
-        client.execute_script(req).await.map_err(YdbError::from)
-    })
-    .await
-    {
+    let operation = client.execute_script(req).map_err(YdbError::from);
+    let (id, consumed_units) = match with_optional_timeout(timeout, operation).await {
         Ok(value) => value,
         Err(err) => {
-            if matches!(&err, YdbError::Transport(msg) if msg.contains("timed out")) {
+            if matches!(&err, YdbError::DeadlineExceeded) {
                 tracing::warn!(
                     ?timeout,
                     "execute_script timed out waiting for RPC response; \

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -44,8 +44,14 @@ impl Drop for QueryStream<'_> {
 
 impl QueryStream<'_> {
     fn abort(&mut self) {
-        self.apply_captured_transaction_id();
+        if let Err(error) = self.apply_captured_transaction_id() {
+            tracing::warn!(%error, "failed to capture transaction id while cancelling query stream");
+        }
         self.stream.cancel();
+        self.finish_cancelled_lifecycle();
+    }
+
+    fn finish_cancelled_lifecycle(&mut self) {
         let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
         if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) = lifecycle {
             tx_cancel_query(context);
@@ -75,25 +81,27 @@ impl<'a> QueryStream<'a> {
         }
     }
 
-    fn apply_transaction_id(&mut self, transaction_id: Option<String>) {
+    fn apply_transaction_id(&mut self, transaction_id: Option<String>) -> YdbResult<()> {
         if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) =
             &mut self.lifecycle
         {
-            apply_stream_tx_id(context, transaction_id);
+            apply_stream_tx_id(context, transaction_id)?;
         }
+        Ok(())
     }
 
-    fn apply_captured_transaction_id(&mut self) {
+    fn apply_captured_transaction_id(&mut self) -> YdbResult<()> {
         let transaction_id = self.stream.take_captured_tx_id();
-        self.apply_transaction_id(transaction_id);
+        self.apply_transaction_id(transaction_id)
     }
 
-    fn handle_error(&mut self, error: &YdbError) {
+    fn handle_error(&mut self, error: &YdbError) -> YdbResult<()> {
         if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) =
             &mut self.lifecycle
         {
-            tx_handle_query_error(context, error);
+            tx_handle_query_error(context, error)?;
         }
+        Ok(())
     }
 
     fn finish(&mut self) -> YdbResult<()> {
@@ -116,26 +124,26 @@ impl<'a> QueryStream<'a> {
             Ok(v) => v,
             Err(err) => {
                 let ydb_err = YdbError::from(err);
-                self.handle_error(&ydb_err);
+                self.stream.cancel();
+                self.handle_error(&ydb_err)?;
                 if matches!(
                     &self.lifecycle,
                     QueryStreamLifecycle::Active(QueryStreamOwner::Client(_))
                 ) && !ydb_err.requires_session_discard()
                 {
-                    self.stream.cancel();
                     return Err(ydb_err);
                 }
-                self.abort();
+                self.lifecycle = QueryStreamLifecycle::Finished;
                 return Err(ydb_err);
             }
         };
         match next {
             Some((raw, transaction_id)) => {
-                self.apply_transaction_id(transaction_id);
+                self.apply_transaction_id(transaction_id)?;
                 ResultSet::try_from(raw).map(Some)
             }
             None => {
-                self.apply_captured_transaction_id();
+                self.apply_captured_transaction_id()?;
                 Ok(None)
             }
         }
@@ -150,12 +158,13 @@ impl<'a> QueryStream<'a> {
     pub async fn close(mut self) -> YdbResult<()> {
         match self.stream.close().await {
             Ok(meta) => {
-                self.apply_transaction_id(meta.tx_id);
+                self.apply_transaction_id(meta.tx_id)?;
                 self.finish()
             }
             Err(err) => {
                 let ydb_err = YdbError::from(err);
-                self.handle_error(&ydb_err);
+                self.handle_error(&ydb_err)?;
+                self.lifecycle = QueryStreamLifecycle::Finished;
                 Err(ydb_err)
             }
         }
@@ -170,13 +179,13 @@ impl<'a> QueryStream<'a> {
 /// On [`QueryClient`], the full open+drain+close cycle is retried on retryable errors.
 /// Interactive transactions are materialized once since tx retries are owned by [`QueryClient::retry_tx`] loop.
 pub(crate) async fn materialize_query(
-    target: &mut ExecTarget<'_>,
+    core: &mut ExecTarget<'_>,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
-    let commit_at_end = resolve_commit_tx(target, &opts);
-    match target {
+    let commit_at_end = resolve_commit_tx(core, &opts);
+    match core {
         ExecTarget::Client(ctx) => {
             ctx.retry_settings
                 .clone()
@@ -228,25 +237,25 @@ async fn materialize_tx_once(
     let raw_sets = match drain_result_sets(&mut stream).await {
         Ok(raw_sets) => raw_sets,
         Err(ydb_err) => {
-            tx_handle_query_error(context, &ydb_err);
+            tx_handle_query_error(context, &ydb_err)?;
             return Err(ydb_err);
         }
     };
     let sets = match convert_result_sets(raw_sets) {
         Ok(sets) => sets,
         Err(ydb_err) => {
-            tx_handle_query_error(context, &ydb_err);
+            tx_handle_query_error(context, &ydb_err)?;
             return Err(ydb_err);
         }
     };
     match stream.close().await {
         Ok(meta) => {
-            apply_stream_tx_id(context, meta.tx_id);
+            apply_stream_tx_id(context, meta.tx_id)?;
             tx_finish_query(context, commit_at_end)?;
         }
         Err(err) => {
             let ydb_err = YdbError::from(err);
-            tx_handle_query_error(context, &ydb_err);
+            tx_handle_query_error(context, &ydb_err)?;
             return Err(ydb_err);
         }
     }

--- a/ydb/src/client_topic/topicreader/reader_tx.rs
+++ b/ydb/src/client_topic/topicreader/reader_tx.rs
@@ -62,7 +62,7 @@ impl<'a> TopicReaderTx<'a> {
 
         tx.register_hook(ReaderTxHook {
             runtime: runtime.clone(),
-        });
+        })?;
 
         Ok(Self {
             inner: reader,

--- a/ydb/src/client_topic/topicwriter/writer_tx.rs
+++ b/ydb/src/client_topic/topicwriter/writer_tx.rs
@@ -67,7 +67,7 @@ impl TopicWriterTx {
         let inner = Arc::new(writer);
         tx.register_hook(WriterTxHook {
             writer: inner.clone(),
-        });
+        })?;
 
         Ok(Self { inner })
     }

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -614,6 +614,12 @@ impl From<tonic::Status> for YdbError {
     }
 }
 
+impl From<tokio::time::error::Elapsed> for YdbError {
+    fn from(_: tokio::time::error::Elapsed) -> Self {
+        Self::DeadlineExceeded
+    }
+}
+
 impl From<RawError> for YdbError {
     fn from(e: RawError) -> Self {
         match e {

--- a/ydb/src/grpc_wrapper/raw_query_service/client.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/client.rs
@@ -19,7 +19,8 @@ use crate::grpc_wrapper::runtime_interceptors::InterceptedChannel;
 use ydb_grpc::ydb_proto::query::v1::query_service_client::QueryServiceClient;
 use ydb_grpc::ydb_proto::query::{
     AttachSessionRequest, BeginTransactionRequest, CommitTransactionRequest, CreateSessionRequest,
-    DeleteSessionRequest, ExecuteQueryResponsePart, RollbackTransactionRequest, SessionState,
+    DeleteSessionRequest, ExecuteQueryRequest, ExecuteQueryResponsePart,
+    RollbackTransactionRequest, SessionState,
 };
 
 /// gRPC metadata: enable server-side session balancing on CreateSession.
@@ -62,8 +63,10 @@ impl RawQueryClient {
         &mut self,
         req: RawExecuteQueryRequest,
     ) -> RawResult<tonic::Streaming<ExecuteQueryResponsePart>> {
-        let proto = req.into_proto()?;
-        let response = self.service.execute_query(proto).await?;
+        let response = self
+            .service
+            .execute_query(ExecuteQueryRequest::from(req))
+            .await?;
         Ok(response.into_inner())
     }
 

--- a/ydb/src/grpc_wrapper/raw_query_service/execute_query.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/execute_query.rs
@@ -40,7 +40,7 @@ impl From<RawExecMode> for ExecMode {
 pub(crate) struct RawExecuteQueryRequest {
     pub session_id: String,
     pub yql_text: String,
-    pub parameters: HashMap<String, Value>,
+    parameters: HashMap<String, RawTypedValue>,
     pub tx_control: Option<ydb_grpc::ydb_proto::query::TransactionControl>,
     pub collect_stats: bool,
     pub concurrent_result_sets: bool,
@@ -54,8 +54,13 @@ impl RawExecuteQueryRequest {
         parameters: HashMap<String, Value>,
         tx_control: Option<ydb_grpc::ydb_proto::query::TransactionControl>,
         collect_stats: bool,
-    ) -> Self {
-        Self {
+    ) -> RawResult<Self> {
+        let parameters = parameters
+            .into_iter()
+            .map(|(name, value)| RawTypedValue::try_from(value).map(|value| (name, value)))
+            .collect::<RawResult<_>>()?;
+
+        Ok(Self {
             session_id: session_id.into(),
             yql_text: yql_text.into(),
             parameters,
@@ -63,38 +68,38 @@ impl RawExecuteQueryRequest {
             collect_stats,
             concurrent_result_sets: false,
             exec_mode: RawExecMode::Execute,
-        }
+        })
     }
+}
 
-    pub fn into_proto(self) -> RawResult<ExecuteQueryRequest> {
-        let mut parameters = HashMap::with_capacity(self.parameters.len());
-        for (name, val) in self.parameters {
-            let raw: RawTypedValue = val.try_into()?;
-            parameters.insert(name, raw.into());
-        }
-
-        Ok(ExecuteQueryRequest {
-            session_id: self.session_id,
-            exec_mode: ExecMode::from(self.exec_mode) as i32,
-            tx_control: self.tx_control,
+impl From<RawExecuteQueryRequest> for ExecuteQueryRequest {
+    fn from(request: RawExecuteQueryRequest) -> Self {
+        Self {
+            session_id: request.session_id,
+            exec_mode: ExecMode::from(request.exec_mode) as i32,
+            tx_control: request.tx_control,
             query: Some(execute_query_request::Query::QueryContent(QueryContent {
                 syntax: Syntax::YqlV1 as i32,
-                text: self.yql_text,
+                text: request.yql_text,
             })),
-            parameters,
-            stats_mode: if self.collect_stats {
+            parameters: request
+                .parameters
+                .into_iter()
+                .map(|(name, value)| (name, value.into()))
+                .collect(),
+            stats_mode: if request.collect_stats {
                 StatsMode::Basic as i32
             } else {
                 StatsMode::None as i32
             },
-            concurrent_result_sets: self.concurrent_result_sets,
+            concurrent_result_sets: request.concurrent_result_sets,
             response_part_limit_bytes: 0,
             pool_id: String::new(),
             stats_period_ms: 0,
             schema_inclusion_mode: SchemaInclusionMode::Unspecified as i32,
             result_set_format: Format::Unspecified as i32,
             arrow_format_settings: None,
-        })
+        }
     }
 }
 
@@ -191,9 +196,10 @@ mod unit_tests {
     use ydb_grpc::ydb_proto::table_stats::QueryStats;
 
     fn request(mode: RawExecMode) -> ExecuteQueryRequest {
-        let mut req = RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false);
+        let mut req = RawExecuteQueryRequest::new("", "SELECT 1", HashMap::new(), None, false)
+            .expect("valid request");
         req.exec_mode = mode;
-        req.into_proto().expect("no parameters to convert")
+        req.into()
     }
 
     fn part(stats: Option<QueryStats>) -> ExecuteQueryResponsePart {
@@ -209,10 +215,11 @@ mod unit_tests {
 
     #[test]
     fn exec_mode_defaults_to_execute() {
-        let req = RawExecuteQueryRequest::new("s", "SELECT 1", HashMap::new(), None, false);
+        let req = RawExecuteQueryRequest::new("s", "SELECT 1", HashMap::new(), None, false)
+            .expect("valid request");
         assert_eq!(req.exec_mode, RawExecMode::Execute);
         assert_eq!(
-            req.into_proto().expect("into_proto").exec_mode,
+            ExecuteQueryRequest::from(req).exec_mode,
             ExecMode::Execute as i32
         );
     }

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -235,7 +235,7 @@ impl SessionPoolLease {
         }
     }
 
-    /// Mark a retained lease unusable. Returning it later will schedule session cleanup.
+    #[cfg(test)]
     pub(crate) fn invalidate(&mut self) {
         self.record.session.invalidate();
     }

--- a/ydb/src/session_pool/session.rs
+++ b/ydb/src/session_pool/session.rs
@@ -98,6 +98,7 @@ impl AttachedSession {
         self.health.is_healthy()
     }
 
+    #[cfg(test)]
     pub(super) fn invalidate(&self) {
         self.health.mark_broken();
     }

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -451,9 +451,13 @@ async fn idempotent_transaction_retries_undetermined_commit_outcome() -> YdbResu
         .await;
 
     assert!(result.is_ok(), "expected successful retry, got {result:?}");
+    wait_for_rollback_count(&tx_lifecycle, 1).await;
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.commit_count, 2);
-    assert_eq!(lifecycle.rollback_count, 0);
+    assert_eq!(
+        lifecycle.rollback_count, 1,
+        "the returned commit error must be cleaned up before retry"
+    );
     Ok(())
 }
 

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -11,8 +11,8 @@
 //! - rollback or commit RPC outcome is unknown;
 //!
 //! The regression cases for #521 are the swallowed-error paths: if the callback
-//! returns `Ok` after the server invalidated the transaction, or after rollback
-//! failed, `retry_tx` must not report a successful commit. A concrete transient query
+//! returns `Ok` after a query failed, or after rollback failed, `retry_tx` must not
+//! report a successful commit. A concrete transient query
 //! failure ends the current attempt, which is rolled back before retry.
 mod mock_server;
 
@@ -20,9 +20,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ydb::{Client, ClientBuilder, Transaction, YdbResult, closure};
+use ydb::{Client, ClientBuilder, Transaction, YdbError, YdbResult, YdbStatusError, closure};
 use ydb_grpc::ydb_proto::query::{
-    ExecuteQueryResponsePart, RollbackTransactionResponse, TransactionMeta,
+    CommitTransactionResponse, ExecuteQueryResponsePart, RollbackTransactionResponse,
+    TransactionMeta,
 };
 use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
@@ -61,6 +62,13 @@ fn failing_part(status: StatusCode) -> ExecuteQueryResponsePart {
         exec_stats: None,
         tx_meta: None,
     }
+}
+
+fn status_error(status: StatusCode) -> YdbError {
+    let mut error = YdbStatusError::default();
+    error.message = "test callback error".to_string();
+    error.operation_status = status as i32;
+    YdbError::YdbStatusError(error)
 }
 
 /// Returns `script[call]`, or the script's last entry once `call` runs past the end.
@@ -287,6 +295,62 @@ impl Handler for CommitTransportFailsHandler {
     }
 }
 
+/// Every `ExecuteQuery` succeeds; `CommitTransaction` follows a per-call status script.
+struct ScriptedCommitHandler {
+    replies: ReplySink,
+    tx_lifecycle: SharedTxLifecycle,
+    commit_call: AtomicUsize,
+    commit_statuses: Vec<StatusCode>,
+}
+
+impl ScriptedCommitHandler {
+    fn new(commit_statuses: Vec<StatusCode>) -> (Self, SharedTxLifecycle) {
+        let tx_lifecycle = Arc::new(Mutex::new(TxLifecycle::default()));
+        let handler = Self {
+            replies: ReplySink::default(),
+            tx_lifecycle: tx_lifecycle.clone(),
+            commit_call: AtomicUsize::new(0),
+            commit_statuses,
+        };
+        (handler, tx_lifecycle)
+    }
+}
+
+impl Handler for ScriptedCommitHandler {
+    fn set_channel(&mut self, tx: FromHandlerToService) {
+        self.replies.set_channel(tx);
+    }
+
+    fn handle(&self, incoming: Incoming) -> Option<Incoming> {
+        if let Incoming::Query(QueryIncoming::RollbackTransaction(_, _)) = &incoming {
+            self.tx_lifecycle.lock().unwrap().rollback_count += 1;
+        }
+
+        match incoming {
+            Incoming::Query(QueryIncoming::ExecuteQuery(_, stream_id)) => {
+                self.replies.send(QueryReply::ExecuteQuery {
+                    stream_id,
+                    part: success_part(Some(QUERY_TX_ID)),
+                });
+                self.replies
+                    .send(QueryReply::ExecuteQueryClose { stream_id });
+                None
+            }
+            Incoming::Query(QueryIncoming::CommitTransaction(_, reply_tx)) => {
+                self.tx_lifecycle.lock().unwrap().commit_count += 1;
+                let call = self.commit_call.fetch_add(1, Ordering::SeqCst);
+                let status = scripted_status(&self.commit_statuses, call);
+                let _ = reply_tx.send(Ok(tonic::Response::new(CommitTransactionResponse {
+                    status: status as i32,
+                    issues: vec![],
+                })));
+                None
+            }
+            other => Some(other),
+        }
+    }
+}
+
 #[tokio::test]
 #[tracing_test::traced_test]
 async fn happy_path_reports_committed() -> YdbResult<()> {
@@ -335,6 +399,60 @@ async fn commit_rpc_failure_is_reported_and_not_retried() -> YdbResult<()> {
         lifecycle.commit_count, 1,
         "commit outcome is undetermined, so the whole tx must not be retried"
     );
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn definitive_commit_failure_retries_whole_transaction() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedCommitHandler::new(vec![StatusCode::Aborted, StatusCode::Success]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+            Ok(())
+        }))
+        .await;
+
+    assert!(result.is_ok(), "expected successful retry, got {result:?}");
+    wait_for_rollback_count(&tx_lifecycle, 1).await;
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(
+        lifecycle.commit_count, 2,
+        "the definitive commit failure must retry the whole transaction"
+    );
+    assert_eq!(
+        lifecycle.rollback_count, 1,
+        "the failed commit attempt must be rolled back before its session is reused"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn idempotent_transaction_retries_undetermined_commit_outcome() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedCommitHandler::new(vec![StatusCode::Undetermined, StatusCode::Success]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!(async |tx: &mut Transaction| {
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+            Ok(())
+        }))
+        .idempotent(true)
+        .await;
+
+    assert!(result.is_ok(), "expected successful retry, got {result:?}");
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 2);
     assert_eq!(lifecycle.rollback_count, 0);
     Ok(())
 }
@@ -404,6 +522,37 @@ async fn dropped_partially_consumed_transaction_stream_is_not_committed() -> Ydb
 #[tracing_test::traced_test]
 async fn dropped_drained_transaction_stream_is_not_committed() -> YdbResult<()> {
     assert_dropped_transaction_stream_is_not_committed(true).await
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn callback_error_after_commit_does_not_retry_transaction() -> YdbResult<()> {
+    let (handler, _tx_lifecycle) = CountingHandler::new();
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+    let attempts = Arc::new(AtomicUsize::new(0));
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!([&attempts], async |tx: &mut Transaction| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')")
+                .with_commit(true)
+                .await?;
+            if attempt == 0 {
+                return Err(status_error(StatusCode::Unavailable).into());
+            }
+            Ok(())
+        }))
+        .await;
+
+    assert!(result.is_err(), "the callback error must be returned");
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "a confirmed commit must never be retried"
+    );
+    Ok(())
 }
 
 #[tokio::test]
@@ -657,7 +806,7 @@ async fn transient_error_swallowed_retries_whole_transaction() -> YdbResult<()> 
 /// callback swallows it, the SDK must not continue or commit that transaction.
 #[tokio::test]
 #[tracing_test::traced_test]
-async fn swallowed_undetermined_query_error_is_undetermined() -> YdbResult<()> {
+async fn swallowed_undetermined_query_error_fails_attempt() -> YdbResult<()> {
     let (handler, tx_lifecycle) =
         ScriptedQueryHandler::new(vec![StatusCode::Success, StatusCode::Undetermined], vec![]);
     let (server, _reply_tx) = MockServer::start(handler).await;
@@ -674,9 +823,108 @@ async fn swallowed_undetermined_query_error_is_undetermined() -> YdbResult<()> {
 
     assert!(
         result.is_err(),
-        "an undetermined transaction outcome must fail"
+        "an undetermined query status must fail the transaction attempt"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn idempotent_transaction_retries_undetermined_query_outcome() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedQueryHandler::new(vec![StatusCode::Undetermined, StatusCode::Success], vec![]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+    let attempts = Arc::new(AtomicUsize::new(0));
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!([&attempts], async |tx: &mut Transaction| {
+            attempts.fetch_add(1, Ordering::SeqCst);
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+            Ok(())
+        }))
+        .idempotent(true)
+        .await;
+
+    assert!(result.is_ok(), "expected successful retry, got {result:?}");
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 1);
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn callback_error_does_not_override_undetermined_query_error() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedQueryHandler::new(vec![StatusCode::Undetermined, StatusCode::Success], vec![]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+    let attempts = Arc::new(AtomicUsize::new(0));
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!([&attempts], async |tx: &mut Transaction| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            let query = tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await;
+            if attempt == 0 {
+                assert!(query.is_err(), "the first query must be undetermined");
+                return Err(status_error(StatusCode::Unavailable).into());
+            }
+            query?;
+            Ok(())
+        }))
+        .await;
+
+    assert!(result.is_err(), "the undetermined outcome must be returned");
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "a callback error must not make an undetermined transaction retryable"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.commit_count, 0);
+    assert_eq!(lifecycle.rollback_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn undetermined_automatic_rollback_prevents_callback_retry() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedQueryHandler::new(vec![StatusCode::Success], vec![StatusCode::Undetermined]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+    let attempts = Arc::new(AtomicUsize::new(0));
+
+    let result: Result<(), _> = client
+        .query_client()
+        .retry_tx(closure!([&attempts], async |tx: &mut Transaction| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            if attempt > 0 {
+                // Bound the regression case instead of letting an incorrect retry loop forever.
+                return Err(status_error(StatusCode::GenericError).into());
+            }
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+            Err(status_error(StatusCode::Aborted).into())
+        }))
+        .await;
+
+    assert!(
+        result.is_err(),
+        "the rollback outcome must remain undetermined"
+    );
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "an undetermined rollback must prevent a non-idempotent callback retry"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.rollback_count, 1);
     assert_eq!(lifecycle.commit_count, 0);
     Ok(())
 }

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -82,6 +82,7 @@ fn scripted_status(script: &[StatusCode], call: usize) -> StatusCode {
 
 #[derive(Default)]
 struct TxLifecycle {
+    create_session_count: usize,
     commit_count: usize,
     rollback_count: usize,
 }
@@ -322,8 +323,14 @@ impl Handler for ScriptedCommitHandler {
     }
 
     fn handle(&self, incoming: Incoming) -> Option<Incoming> {
-        if let Incoming::Query(QueryIncoming::RollbackTransaction(_, _)) = &incoming {
-            self.tx_lifecycle.lock().unwrap().rollback_count += 1;
+        match &incoming {
+            Incoming::Query(QueryIncoming::CreateSession(_, _)) => {
+                self.tx_lifecycle.lock().unwrap().create_session_count += 1;
+            }
+            Incoming::Query(QueryIncoming::RollbackTransaction(_, _)) => {
+                self.tx_lifecycle.lock().unwrap().rollback_count += 1;
+            }
+            _ => {}
         }
 
         match incoming {
@@ -422,6 +429,10 @@ async fn definitive_commit_failure_retries_whole_transaction() -> YdbResult<()> 
     assert!(result.is_ok(), "expected successful retry, got {result:?}");
     wait_for_rollback_count(&tx_lifecycle, 1).await;
     let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(
+        lifecycle.create_session_count, 1,
+        "successful rollback cleanup must return the session for retry"
+    );
     assert_eq!(
         lifecycle.commit_count, 2,
         "the definitive commit failure must retry the whole transaction"

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -20,7 +20,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ydb::{Client, ClientBuilder, Transaction, YdbError, YdbResult, YdbStatusError, closure};
+use ydb::{
+    Client, ClientBuilder, Transaction, YdbError, YdbOrCustomerError, YdbResult, YdbStatusError,
+    closure,
+};
 use ydb_grpc::ydb_proto::query::{
     CommitTransactionResponse, ExecuteQueryResponsePart, RollbackTransactionResponse,
     TransactionMeta,
@@ -937,6 +940,41 @@ async fn undetermined_automatic_rollback_prevents_callback_retry() -> YdbResult<
         attempts.load(Ordering::SeqCst),
         1,
         "an undetermined rollback must prevent a non-idempotent callback retry"
+    );
+    let lifecycle = tx_lifecycle.lock().unwrap();
+    assert_eq!(lifecycle.rollback_count, 1);
+    assert_eq!(lifecycle.commit_count, 0);
+    Ok(())
+}
+
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn customer_error_is_not_replaced_by_rollback_failure() -> YdbResult<()> {
+    let (handler, tx_lifecycle) =
+        ScriptedQueryHandler::new(vec![StatusCode::Success], vec![StatusCode::BadSession]);
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+    let attempts = Arc::new(AtomicUsize::new(0));
+
+    let result = client
+        .query_client()
+        .retry_tx(closure!([&attempts], async |tx: &mut Transaction| {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+            if attempt == 0 {
+                return Err(YdbOrCustomerError::from_err(std::io::Error::other(
+                    "customer validation failed",
+                )));
+            }
+            Ok(())
+        }))
+        .await;
+
+    assert!(matches!(result, Err(YdbOrCustomerError::Customer(_))));
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        1,
+        "a rollback cleanup error must not make a customer error retryable"
     );
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(lifecycle.rollback_count, 1);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Transaction does not track ExecuteQuery RPC in progress. Started transaction still looks ready while query is running.
- On cancellation or Drop SDK can try rollback while another operation is still in progress.
- Session can be reused after operation with unknown server result.
- Transaction session and hooks are finished in different places.

Issue Number: N/A

## What is the new behavior?

- Transaction server state explicitly describes NotStarted, Ready and InFlight states.
- InFlight state describes Begin, Query, Commit and Rollback operations.
- Successful query returns transaction to Ready state.
- Definitive server error invalidates transaction.
- Cancellation or unknown server result makes transaction Ambiguous and discards its session.
- Drop tries rollback only for Ready transaction. InFlight transaction does not send competing rollback.
- Transaction owns its session and hooks until one terminal transition. Hooks are called exactly once.

## Other information

- This prepares transaction cleanup for CleanupWorker. Worker is not introduced in this PR.