### PR TITLE
feat: Graceful session pool shutdown

### DIFF
--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -115,6 +115,17 @@ impl Client {
         self.session_pool.stats()
     }
 
+    /// Stop the shared session pool and wait for all accepted DeleteSession attempts to finish.
+    ///
+    /// This consumes the driver and stops new session acquisition. Existing session leases may
+    /// finish; shutdown waits for them before deleting idle sessions. Do not use clients,
+    /// sessions, transactions, or streams derived from this driver after shutdown begins.
+    /// Shutdown must run while the Tokio runtime that created the driver is still alive.
+    #[instrument(name = "ydb.Driver.Shutdown", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
+    pub async fn shutdown(self) -> YdbResult<()> {
+        self.session_pool.shutdown().await
+    }
+
     pub fn database(&self) -> String {
         self.credentials.database.clone()
     }

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -115,7 +115,7 @@ impl Client {
         self.session_pool.stats()
     }
 
-    /// Stop the shared session pool and wait for all accepted DeleteSession attempts to finish.
+    /// Stop the shared session pool and wait for accepted session cleanup attempts to finish.
     ///
     /// This consumes the driver and stops new session acquisition. Existing session leases may
     /// finish; shutdown waits for them before deleting idle sessions. Do not use clients,

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -21,7 +21,7 @@ use crate::types::Value;
 use crate::{TransactionOptions, TxMode, closure};
 use tracing::instrument;
 
-use crate::session_pool::{SessionPool, SessionPoolLease, spawn_pool_release};
+use crate::session_pool::{SessionPool, SessionPoolLease};
 
 use super::hooks::{QueryTxCommitStatus, QueryTxHook};
 
@@ -330,29 +330,15 @@ impl Drop for TxExecContext {
 
         active.notify_hooks(QueryTxCommitStatus::Aborted);
         let ActiveTx {
-            mut client,
             lease,
             server_progress,
             ..
         } = active;
-        let tx_id = match (server_progress.operation, server_progress.tx_id) {
-            (TxOperationState::Ready, None) => {
-                lease.return_to_pool();
-                return;
-            }
-            (TxOperationState::Ready, Some(tx_id)) => tx_id,
-            (TxOperationState::InFlight, _) => return,
-        };
-
-        let cleanup_timeout = lease.cleanup_timeout();
-        let session_id = lease.session_id().to_string();
-
-        spawn_pool_release(async move {
-            let rollback = client
-                .rollback_transaction(&session_id, tx_id.as_str())
-                .map_err(YdbError::from);
-            finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
-        });
+        match (server_progress.operation, server_progress.tx_id) {
+            (TxOperationState::Ready, None) => lease.return_to_pool(),
+            (TxOperationState::Ready, Some(tx_id)) => lease.schedule_rollback(tx_id),
+            (TxOperationState::InFlight, _) => {}
+        }
     }
 }
 

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -269,30 +269,19 @@ impl TxExecContext {
         }
 
         let ActiveTx {
-            mut client,
             lease,
             server_progress,
             ..
         } = active;
-        let tx_id = match (server_progress.operation, server_progress.tx_id) {
+        match (server_progress.operation, server_progress.tx_id) {
             (TxOperationState::Ready, None) => {
                 lease.return_to_pool();
-                return Ok(());
             }
             (TxOperationState::Ready, Some(tx_id)) | (TxOperationState::InFlight, Some(tx_id)) => {
-                tx_id
+                lease.schedule_rollback(tx_id);
             }
-            (TxOperationState::InFlight, None) => return Ok(()),
-        };
-        let cleanup_timeout = lease.cleanup_timeout();
-        let session_id = lease.session_id().to_string();
-
-        spawn_pool_release(async move {
-            let rollback = client
-                .rollback_transaction(&session_id, tx_id.as_str())
-                .map_err(YdbError::from);
-            finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
-        });
+            (TxOperationState::InFlight, None) => {}
+        }
         Ok(())
     }
 
@@ -880,15 +869,6 @@ pub(crate) async fn tx_rollback(tx: &mut TxExecContext) -> YdbResult<()> {
     }
 }
 
-async fn finish_rollback_cleanup<F>(lease: SessionPoolLease, cleanup_timeout: Duration, rollback: F)
-where
-    F: Future<Output = YdbResult<()>>,
-{
-    if matches!(timeout(cleanup_timeout, rollback).await, Ok(Ok(()))) {
-        lease.return_to_pool();
-    }
-}
-
 pub(crate) fn tx_exec_context(
     client: RawQueryClient,
     lease: SessionPoolLease,
@@ -999,8 +979,8 @@ mod unit_tests {
     }
 
     #[tokio::test]
-    async fn rejected_query_does_not_reuse_session_with_unfinished_tx() {
-        for tx_id in [None, Some("tx-1".to_string())] {
+    async fn rejected_query_reuses_session_only_after_known_tx_is_rolled_back() {
+        for (tx_id, expect_reuse) in [(None, false), (Some("tx-1".to_string()), true)] {
             let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
             let lease = pool.acquire_explicit().await.expect("acquire test session");
             let session_id = lease.session_id().to_string();
@@ -1021,17 +1001,17 @@ mod unit_tests {
                 .expect("rejected operation must finish the transaction");
 
             assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
-            let replacement = pool
+            let acquired = pool
                 .acquire_explicit()
                 .await
-                .expect("session with an unfinished transaction must be replaced");
-            assert_ne!(replacement.session_id(), session_id);
-            replacement.return_to_pool();
+                .expect("a session must become available after failed-attempt cleanup");
+            assert_eq!(acquired.session_id() == session_id, expect_reuse);
+            acquired.return_to_pool();
         }
     }
 
     #[tokio::test]
-    async fn transient_dispatched_error_discards_session_when_cleanup_fails() {
+    async fn transient_dispatched_error_cleans_up_possibly_active_transaction() {
         for status in [StatusCode::Unavailable, StatusCode::Overloaded] {
             let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
             let lease = pool.acquire_explicit().await.expect("acquire test session");
@@ -1048,12 +1028,12 @@ mod unit_tests {
                 .expect("temporary failure must finish the local transaction attempt");
 
             assert!(matches!(ctx.state, TxState::AttemptFailed(_)));
-            let replacement = pool
+            let reused = pool
                 .acquire_explicit()
                 .await
-                .expect("session with an unconfirmed transaction must be replaced");
-            assert_ne!(replacement.session_id(), session_id);
-            replacement.return_to_pool();
+                .expect("session must become available after cleanup");
+            assert_eq!(reused.session_id(), session_id);
+            reused.return_to_pool();
         }
     }
 
@@ -1075,27 +1055,6 @@ mod unit_tests {
             .acquire_explicit()
             .await
             .expect("acquire replacement session");
-        assert_ne!(replacement.session_id(), session_id);
-        replacement.return_to_pool();
-    }
-
-    #[tokio::test]
-    async fn rollback_cleanup_timeout_discards_session_and_releases_pool_permit() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let session_id = lease.session_id().to_string();
-
-        finish_rollback_cleanup(
-            lease,
-            Duration::ZERO,
-            std::future::pending::<YdbResult<()>>(),
-        )
-        .await;
-
-        let replacement = pool
-            .acquire_explicit()
-            .await
-            .expect("timed-out rollback must release the pool permit");
         assert_ne!(replacement.session_id(), session_id);
         replacement.return_to_pool();
     }

--- a/ydb/src/client_query/explain_query.rs
+++ b/ydb/src/client_query/explain_query.rs
@@ -162,8 +162,8 @@ mod unit_tests {
         }
     }
 
-    #[test]
-    fn timeout_is_recorded_only_when_set() {
+    #[tokio::test]
+    async fn timeout_is_recorded_only_when_set() {
         let ctx = unreachable_ctx();
         assert_eq!(
             ExplainQueryBuilder::new(&ctx, "SELECT 1".to_string()).configured_timeout(),

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -2,10 +2,11 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinSet;
-use tracing::{error, warn};
+use tracing::{error, trace, warn};
 
+use crate::errors::{YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 
@@ -13,6 +14,7 @@ use super::session::SessionIdentity;
 
 enum CleanupCommand {
     DeleteSession(Arc<SessionIdentity>),
+    Shutdown { completed: oneshot::Sender<()> },
 }
 
 /// Submits server-side session resources to the cleanup worker.
@@ -35,6 +37,23 @@ impl SessionCleanup {
             );
         }
     }
+
+    /// Stop accepting cleanup requests and wait for every accepted deletion to finish.
+    pub(super) async fn shutdown(&self) -> YdbResult<()> {
+        let (completed, completion) = oneshot::channel();
+        self.sender
+            .send(CleanupCommand::Shutdown { completed })
+            .map_err(|_| {
+                YdbError::InternalError(
+                    "session cleanup worker stopped before shutdown was submitted".to_string(),
+                )
+            })?;
+        completion.await.map_err(|_| {
+            YdbError::InternalError(
+                "session cleanup worker stopped before shutdown completed".to_string(),
+            )
+        })
+    }
 }
 
 pub(super) fn start_session_cleanup_worker(
@@ -54,28 +73,35 @@ async fn run_cleanup_worker<Delete, DeleteFuture>(
     mut receiver: mpsc::UnboundedReceiver<CleanupCommand>,
     delete: Delete,
 ) where
-    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture,
+    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
     DeleteFuture: Future<Output = ()> + Send + 'static,
 {
     let mut tasks = JoinSet::new();
 
-    loop {
+    let shutdown_completion = loop {
         tokio::select! {
             command = receiver.recv() => match command {
                 Some(CleanupCommand::DeleteSession(identity)) => {
                     tasks.spawn(delete(identity));
                 }
+                Some(CleanupCommand::Shutdown { completed }) => {
+                    break Some(completed);
+                }
                 None => {
-                    drain_delete_tasks(&mut tasks).await;
-                    return;
+                    break None;
                 }
             },
-            result = tasks.join_next(), if !tasks.is_empty() => {
-                if let Some(result) = result {
-                    report_delete_task_result(result);
-                }
+            Some(result) = tasks.join_next(), if !tasks.is_empty() => {
+                report_delete_task_result(result);
             }
         }
+    };
+
+    drain_delete_tasks(&mut tasks).await;
+    if let Some(completed) = shutdown_completion
+        && completed.send(()).is_err()
+    {
+        trace!("session cleanup shutdown caller was dropped");
     }
 }
 
@@ -120,7 +146,133 @@ async fn delete_session(
 
 #[cfg(test)]
 pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
+    start_test_session_cleanup_worker(|_| async {})
+}
+
+#[cfg(test)]
+pub(super) fn start_test_session_cleanup_worker<Delete, DeleteFuture>(
+    delete: Delete,
+) -> SessionCleanup
+where
+    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
+    DeleteFuture: Future<Output = ()> + Send + 'static,
+{
     let (sender, receiver) = mpsc::unbounded_channel();
-    tokio::spawn(run_cleanup_worker(receiver, |_| async {}));
+    tokio::spawn(run_cleanup_worker(receiver, delete));
     SessionCleanup { sender }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use http::Uri;
+    use tokio::sync::{Semaphore, mpsc};
+
+    use super::*;
+
+    fn identity(session_id: &str) -> Arc<SessionIdentity> {
+        Arc::new(SessionIdentity {
+            session_id: session_id.to_string(),
+            node_uri: Uri::from_static("http://127.0.0.1/test"),
+        })
+    }
+
+    fn start_test_worker<Delete, DeleteFuture>(
+        delete: Delete,
+    ) -> (SessionCleanup, tokio::task::JoinHandle<()>)
+    where
+        Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
+        DeleteFuture: Future<Output = ()> + Send + 'static,
+    {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let worker = tokio::spawn(run_cleanup_worker(receiver, delete));
+        (SessionCleanup { sender }, worker)
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_all_concurrent_deletes_and_stops_worker() {
+        let (started_sender, mut started_receiver) = mpsc::unbounded_channel();
+        let release = Arc::new(Semaphore::new(0));
+        let (cleanup, worker) = start_test_worker({
+            let release = release.clone();
+            move |identity| {
+                let started_sender = started_sender.clone();
+                let release = release.clone();
+                async move {
+                    let _ = started_sender.send(identity.session_id.clone());
+                    if let Ok(permit) = release.acquire().await {
+                        permit.forget();
+                    }
+                }
+            }
+        });
+
+        for session_id in ["one", "two", "three"] {
+            cleanup.submit_delete(identity(session_id));
+        }
+
+        let shutdown_cleanup = cleanup.clone();
+        let shutdown = tokio::spawn(async move { shutdown_cleanup.shutdown().await });
+
+        let mut started = Vec::new();
+        for _ in 0..3 {
+            started.push(
+                tokio::time::timeout(Duration::from_secs(1), started_receiver.recv())
+                    .await
+                    .expect("all deletes must start concurrently")
+                    .expect("delete observer must remain open"),
+            );
+        }
+        started.sort();
+        assert_eq!(started, ["one", "three", "two"]);
+        assert!(!shutdown.is_finished());
+
+        release.add_permits(3);
+        shutdown
+            .await
+            .expect("shutdown task must finish")
+            .expect("cleanup shutdown must succeed");
+        worker.await.expect("cleanup worker must stop");
+        assert!(cleanup.sender.is_closed());
+        assert!(
+            cleanup
+                .sender
+                .send(CleanupCommand::DeleteSession(identity("late")))
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn closing_channel_drains_queued_deletes() {
+        let completed = Arc::new(Mutex::new(Vec::new()));
+        let (cleanup, worker) = start_test_worker({
+            let completed = completed.clone();
+            move |identity| {
+                let completed = completed.clone();
+                async move {
+                    completed
+                        .lock()
+                        .expect("completed lock must not be poisoned")
+                        .push(identity.session_id.clone());
+                }
+            }
+        });
+
+        cleanup.submit_delete(identity("one"));
+        cleanup.submit_delete(identity("two"));
+        drop(cleanup);
+
+        tokio::time::timeout(Duration::from_secs(1), worker)
+            .await
+            .expect("cleanup worker must drain and stop")
+            .expect("cleanup worker task must succeed");
+        let mut completed = completed
+            .lock()
+            .expect("completed lock must not be poisoned")
+            .clone();
+        completed.sort();
+        assert_eq!(completed, ["one", "two"]);
+    }
 }

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -92,29 +92,43 @@ async fn run_cleanup_worker<Execute, ExecuteFuture>(
 {
     let mut tasks = JoinSet::new();
 
-    let shutdown_completion = loop {
+    let mut shutdown_completion = None;
+    loop {
+        // Cleanup tasks may submit follow-up work. In particular, a failed rollback drops its
+        // lease, which submits DeleteSession. Session-pool shutdown has already stopped external
+        // producers, so the worker is quiescent once both the task set and command queue are empty.
+        if shutdown_completion.is_some() && tasks.is_empty() && receiver.is_empty() {
+            break;
+        }
+
         tokio::select! {
             command = receiver.recv() => match command {
                 Some(CleanupCommand::Run(task)) => {
                     tasks.spawn(execute(task));
                 }
                 Some(CleanupCommand::Shutdown { completed }) => {
-                    break Some(completed);
+                    if shutdown_completion.is_some() {
+                        error!("session cleanup worker received multiple shutdown commands");
+                    } else {
+                        shutdown_completion = Some(completed);
+                    }
                 }
                 None => {
-                    break None;
+                    drain_cleanup_tasks(&mut tasks).await;
+                    return;
                 }
             },
             Some(result) = tasks.join_next(), if !tasks.is_empty() => {
                 report_cleanup_task_result(result);
             }
         }
-    };
+    }
 
-    drain_cleanup_tasks(&mut tasks).await;
-    if let Some(completed) = shutdown_completion
-        && completed.send(()).is_err()
-    {
+    let Some(completed) = shutdown_completion else {
+        error!("session cleanup worker exited without a shutdown command");
+        return;
+    };
+    if completed.send(()).is_err() {
         trace!("session cleanup shutdown caller was dropped");
     }
 }
@@ -237,7 +251,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
+    use std::sync::{Mutex, OnceLock};
     use std::time::Duration;
 
     use http::Uri;
@@ -363,5 +377,43 @@ mod tests {
             .clone();
         completed.sort();
         assert_eq!(completed, ["one", "two"]);
+    }
+
+    #[tokio::test]
+    async fn shutdown_drains_cleanup_submitted_by_running_task() {
+        let completed = Arc::new(Mutex::new(Vec::new()));
+        let cleanup_slot = Arc::new(OnceLock::<SessionCleanup>::new());
+        let (cleanup, worker) = start_test_worker({
+            let completed = completed.clone();
+            let cleanup_slot = cleanup_slot.clone();
+            move |task| {
+                let completed = completed.clone();
+                let cleanup_slot = cleanup_slot.clone();
+                async move {
+                    if let CleanupTask::DeleteSession(session) = task {
+                        completed
+                            .lock()
+                            .expect("completed lock must not be poisoned")
+                            .push(session.session_id.clone());
+                        if session.session_id == "parent" {
+                            cleanup_slot
+                                .get()
+                                .expect("cleanup handle must be initialized")
+                                .submit_delete(identity("child"));
+                        }
+                    }
+                }
+            }
+        });
+        assert!(cleanup_slot.set(cleanup.clone()).is_ok());
+
+        cleanup.submit_delete(identity("parent"));
+        cleanup.shutdown().await.expect("shutdown must succeed");
+        worker.await.expect("cleanup worker must stop");
+
+        let completed = completed
+            .lock()
+            .expect("completed lock must not be poisoned");
+        assert_eq!(*completed, ["parent", "child"]);
     }
 }

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -10,10 +10,21 @@ use crate::errors::{YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 
+use super::SessionPoolLease;
 use super::session::SessionIdentity;
 
-enum CleanupCommand {
+#[derive(Debug)]
+pub(super) enum CleanupTask {
     DeleteSession(Arc<SessionIdentity>),
+    RollbackTransaction {
+        lease: SessionPoolLease,
+        transaction_id: String,
+    },
+}
+
+#[derive(Debug)]
+enum CleanupCommand {
+    Run(CleanupTask),
     Shutdown { completed: oneshot::Sender<()> },
 }
 
@@ -25,20 +36,23 @@ pub(super) struct SessionCleanup {
 
 impl SessionCleanup {
     pub(super) fn submit_delete(&self, identity: Arc<SessionIdentity>) {
-        if self
-            .sender
-            .send(CleanupCommand::DeleteSession(identity.clone()))
-            .is_err()
-        {
-            error!(
-                session_id = %identity.session_id,
-                node_uri = %identity.node_uri,
-                "session cleanup worker is stopped; DeleteSession was not submitted"
-            );
+        self.submit(CleanupTask::DeleteSession(identity));
+    }
+
+    pub(super) fn submit_rollback(&self, lease: SessionPoolLease, transaction_id: String) {
+        self.submit(CleanupTask::RollbackTransaction {
+            lease,
+            transaction_id,
+        });
+    }
+
+    fn submit(&self, task: CleanupTask) {
+        if let Err(error) = self.sender.send(CleanupCommand::Run(task)) {
+            error!(command = ?error.0, "session cleanup worker is stopped; cleanup was not submitted");
         }
     }
 
-    /// Stop accepting cleanup requests and wait for every accepted deletion to finish.
+    /// Stop accepting cleanup requests and wait for every accepted task to finish.
     pub(super) async fn shutdown(&self) -> YdbResult<()> {
         let (completed, completion) = oneshot::channel();
         self.sender
@@ -58,31 +72,31 @@ impl SessionCleanup {
 
 pub(super) fn start_session_cleanup_worker(
     connection_manager: GrpcConnectionManager,
-    delete_timeout: Duration,
+    cleanup_timeout: Duration,
 ) -> SessionCleanup {
     let (sender, receiver) = mpsc::unbounded_channel();
-    let delete = move |identity| {
+    let execute = move |task| {
         let connection_manager = connection_manager.clone();
-        async move { delete_session(connection_manager, delete_timeout, identity).await }
+        async move { execute_cleanup_task(connection_manager, cleanup_timeout, task).await }
     };
-    tokio::spawn(run_cleanup_worker(receiver, delete));
+    tokio::spawn(run_cleanup_worker(receiver, execute));
     SessionCleanup { sender }
 }
 
-async fn run_cleanup_worker<Delete, DeleteFuture>(
+async fn run_cleanup_worker<Execute, ExecuteFuture>(
     mut receiver: mpsc::UnboundedReceiver<CleanupCommand>,
-    delete: Delete,
+    execute: Execute,
 ) where
-    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
-    DeleteFuture: Future<Output = ()> + Send + 'static,
+    Execute: Fn(CleanupTask) -> ExecuteFuture + Send + 'static,
+    ExecuteFuture: Future<Output = ()> + Send + 'static,
 {
     let mut tasks = JoinSet::new();
 
     let shutdown_completion = loop {
         tokio::select! {
             command = receiver.recv() => match command {
-                Some(CleanupCommand::DeleteSession(identity)) => {
-                    tasks.spawn(delete(identity));
+                Some(CleanupCommand::Run(task)) => {
+                    tasks.spawn(execute(task));
                 }
                 Some(CleanupCommand::Shutdown { completed }) => {
                     break Some(completed);
@@ -92,12 +106,12 @@ async fn run_cleanup_worker<Delete, DeleteFuture>(
                 }
             },
             Some(result) = tasks.join_next(), if !tasks.is_empty() => {
-                report_delete_task_result(result);
+                report_cleanup_task_result(result);
             }
         }
     };
 
-    drain_delete_tasks(&mut tasks).await;
+    drain_cleanup_tasks(&mut tasks).await;
     if let Some(completed) = shutdown_completion
         && completed.send(()).is_err()
     {
@@ -105,15 +119,33 @@ async fn run_cleanup_worker<Delete, DeleteFuture>(
     }
 }
 
-async fn drain_delete_tasks(tasks: &mut JoinSet<()>) {
+async fn drain_cleanup_tasks(tasks: &mut JoinSet<()>) {
     while let Some(result) = tasks.join_next().await {
-        report_delete_task_result(result);
+        report_cleanup_task_result(result);
     }
 }
 
-fn report_delete_task_result(result: Result<(), tokio::task::JoinError>) {
+fn report_cleanup_task_result(result: Result<(), tokio::task::JoinError>) {
     if let Err(err) = result {
         error!(error = %err, "session cleanup task failed");
+    }
+}
+
+async fn execute_cleanup_task(
+    connection_manager: GrpcConnectionManager,
+    cleanup_timeout: Duration,
+    task: CleanupTask,
+) {
+    match task {
+        CleanupTask::DeleteSession(identity) => {
+            delete_session(connection_manager, cleanup_timeout, identity).await;
+        }
+        CleanupTask::RollbackTransaction {
+            lease,
+            transaction_id,
+        } => {
+            rollback_transaction(connection_manager, cleanup_timeout, lease, transaction_id).await;
+        }
     }
 }
 
@@ -144,21 +176,62 @@ async fn delete_session(
     }
 }
 
-#[cfg(test)]
-pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
-    start_test_session_cleanup_worker(|_| async {})
+async fn rollback_transaction(
+    connection_manager: GrpcConnectionManager,
+    cleanup_timeout: Duration,
+    lease: SessionPoolLease,
+    transaction_id: String,
+) {
+    let rollback = async {
+        let mut client = connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
+            .await?;
+        client
+            .rollback_transaction(lease.session_id(), &transaction_id)
+            .await
+            .map_err(YdbError::from)
+    };
+
+    match tokio::time::timeout(cleanup_timeout, rollback).await {
+        Ok(Ok(())) => lease.return_to_pool(),
+        Ok(Err(err)) => {
+            warn!(
+                session_id = lease.session_id(),
+                transaction_id,
+                error = %err,
+                "RollbackTransaction during session cleanup failed"
+            );
+        }
+        Err(_) => {
+            warn!(
+                session_id = lease.session_id(),
+                transaction_id,
+                ?cleanup_timeout,
+                "RollbackTransaction during session cleanup timed out"
+            );
+        }
+    }
 }
 
 #[cfg(test)]
-pub(super) fn start_test_session_cleanup_worker<Delete, DeleteFuture>(
-    delete: Delete,
+pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
+    start_test_session_cleanup_worker(|task| async move {
+        if let CleanupTask::RollbackTransaction { lease, .. } = task {
+            lease.return_to_pool();
+        }
+    })
+}
+
+#[cfg(test)]
+pub(super) fn start_test_session_cleanup_worker<Execute, ExecuteFuture>(
+    execute: Execute,
 ) -> SessionCleanup
 where
-    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
-    DeleteFuture: Future<Output = ()> + Send + 'static,
+    Execute: Fn(CleanupTask) -> ExecuteFuture + Send + 'static,
+    ExecuteFuture: Future<Output = ()> + Send + 'static,
 {
     let (sender, receiver) = mpsc::unbounded_channel();
-    tokio::spawn(run_cleanup_worker(receiver, delete));
+    tokio::spawn(run_cleanup_worker(receiver, execute));
     SessionCleanup { sender }
 }
 
@@ -179,15 +252,15 @@ mod tests {
         })
     }
 
-    fn start_test_worker<Delete, DeleteFuture>(
-        delete: Delete,
+    fn start_test_worker<Execute, ExecuteFuture>(
+        execute: Execute,
     ) -> (SessionCleanup, tokio::task::JoinHandle<()>)
     where
-        Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture + Send + 'static,
-        DeleteFuture: Future<Output = ()> + Send + 'static,
+        Execute: Fn(CleanupTask) -> ExecuteFuture + Send + 'static,
+        ExecuteFuture: Future<Output = ()> + Send + 'static,
     {
         let (sender, receiver) = mpsc::unbounded_channel();
-        let worker = tokio::spawn(run_cleanup_worker(receiver, delete));
+        let worker = tokio::spawn(run_cleanup_worker(receiver, execute));
         (SessionCleanup { sender }, worker)
     }
 
@@ -197,13 +270,20 @@ mod tests {
         let release = Arc::new(Semaphore::new(0));
         let (cleanup, worker) = start_test_worker({
             let release = release.clone();
-            move |identity| {
+            move |task| {
                 let started_sender = started_sender.clone();
                 let release = release.clone();
                 async move {
-                    let _ = started_sender.send(identity.session_id.clone());
-                    if let Ok(permit) = release.acquire().await {
-                        permit.forget();
+                    match task {
+                        CleanupTask::DeleteSession(identity) => {
+                            let _ = started_sender.send(identity.session_id.clone());
+                            if let Ok(permit) = release.acquire().await {
+                                permit.forget();
+                            }
+                        }
+                        CleanupTask::RollbackTransaction { lease, .. } => {
+                            lease.return_to_pool();
+                        }
                     }
                 }
             }
@@ -239,7 +319,9 @@ mod tests {
         assert!(
             cleanup
                 .sender
-                .send(CleanupCommand::DeleteSession(identity("late")))
+                .send(CleanupCommand::Run(CleanupTask::DeleteSession(identity(
+                    "late",
+                ))))
                 .is_err()
         );
     }
@@ -249,13 +331,20 @@ mod tests {
         let completed = Arc::new(Mutex::new(Vec::new()));
         let (cleanup, worker) = start_test_worker({
             let completed = completed.clone();
-            move |identity| {
+            move |task| {
                 let completed = completed.clone();
                 async move {
-                    completed
-                        .lock()
-                        .expect("completed lock must not be poisoned")
-                        .push(identity.session_id.clone());
+                    match task {
+                        CleanupTask::DeleteSession(identity) => {
+                            completed
+                                .lock()
+                                .expect("completed lock must not be poisoned")
+                                .push(identity.session_id.clone());
+                        }
+                        CleanupTask::RollbackTransaction { lease, .. } => {
+                            lease.return_to_pool();
+                        }
+                    }
                 }
             }
         });

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -165,27 +165,26 @@ async fn execute_cleanup_task(
 
 async fn delete_session(
     connection_manager: GrpcConnectionManager,
-    delete_timeout: Duration,
+    cleanup_timeout: Duration,
     identity: Arc<SessionIdentity>,
 ) {
-    let mut client = match connection_manager
-        .get_auth_service_to_node(RawQueryClient::new, &identity.node_uri)
-        .await
-    {
-        Ok(client) => client,
-        Err(err) => {
-            warn!(session_id = %identity.session_id, error = %err, "failed to connect for DeleteSession");
-            return;
-        }
+    let delete = async {
+        let mut client = connection_manager
+            .get_auth_service_to_node(RawQueryClient::new, &identity.node_uri)
+            .await?;
+        client
+            .delete_session(&identity.session_id)
+            .await
+            .map_err(YdbError::from)
     };
 
-    match tokio::time::timeout(delete_timeout, client.delete_session(&identity.session_id)).await {
+    match tokio::time::timeout(cleanup_timeout, delete).await {
         Ok(Ok(())) => {}
         Ok(Err(err)) => {
-            warn!(session_id = %identity.session_id, error = %err, "DeleteSession failed")
+            warn!(session_id = %identity.session_id, error = %err, "DeleteSession cleanup failed")
         }
         Err(_) => {
-            warn!(session_id = %identity.session_id, ?delete_timeout, "DeleteSession timed out")
+            warn!(session_id = %identity.session_id, ?cleanup_timeout, "DeleteSession cleanup timed out")
         }
     }
 }

--- a/ydb/src/session_pool/cleanup_worker.rs
+++ b/ydb/src/session_pool/cleanup_worker.rs
@@ -1,0 +1,126 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tracing::{error, warn};
+
+use crate::grpc_connection_manager::GrpcConnectionManager;
+use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
+
+use super::session::SessionIdentity;
+
+enum CleanupCommand {
+    DeleteSession(Arc<SessionIdentity>),
+}
+
+/// Submits server-side session resources to the cleanup worker.
+#[derive(Clone)]
+pub(super) struct SessionCleanup {
+    sender: mpsc::UnboundedSender<CleanupCommand>,
+}
+
+impl SessionCleanup {
+    pub(super) fn submit_delete(&self, identity: Arc<SessionIdentity>) {
+        if self
+            .sender
+            .send(CleanupCommand::DeleteSession(identity.clone()))
+            .is_err()
+        {
+            error!(
+                session_id = %identity.session_id,
+                node_uri = %identity.node_uri,
+                "session cleanup worker is stopped; DeleteSession was not submitted"
+            );
+        }
+    }
+}
+
+pub(super) fn start_session_cleanup_worker(
+    connection_manager: GrpcConnectionManager,
+    delete_timeout: Duration,
+) -> SessionCleanup {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    let delete = move |identity| {
+        let connection_manager = connection_manager.clone();
+        async move { delete_session(connection_manager, delete_timeout, identity).await }
+    };
+    tokio::spawn(run_cleanup_worker(receiver, delete));
+    SessionCleanup { sender }
+}
+
+async fn run_cleanup_worker<Delete, DeleteFuture>(
+    mut receiver: mpsc::UnboundedReceiver<CleanupCommand>,
+    delete: Delete,
+) where
+    Delete: Fn(Arc<SessionIdentity>) -> DeleteFuture,
+    DeleteFuture: Future<Output = ()> + Send + 'static,
+{
+    let mut tasks = JoinSet::new();
+
+    loop {
+        tokio::select! {
+            command = receiver.recv() => match command {
+                Some(CleanupCommand::DeleteSession(identity)) => {
+                    tasks.spawn(delete(identity));
+                }
+                None => {
+                    drain_delete_tasks(&mut tasks).await;
+                    return;
+                }
+            },
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                if let Some(result) = result {
+                    report_delete_task_result(result);
+                }
+            }
+        }
+    }
+}
+
+async fn drain_delete_tasks(tasks: &mut JoinSet<()>) {
+    while let Some(result) = tasks.join_next().await {
+        report_delete_task_result(result);
+    }
+}
+
+fn report_delete_task_result(result: Result<(), tokio::task::JoinError>) {
+    if let Err(err) = result {
+        error!(error = %err, "session cleanup task failed");
+    }
+}
+
+async fn delete_session(
+    connection_manager: GrpcConnectionManager,
+    delete_timeout: Duration,
+    identity: Arc<SessionIdentity>,
+) {
+    let mut client = match connection_manager
+        .get_auth_service_to_node(RawQueryClient::new, &identity.node_uri)
+        .await
+    {
+        Ok(client) => client,
+        Err(err) => {
+            warn!(session_id = %identity.session_id, error = %err, "failed to connect for DeleteSession");
+            return;
+        }
+    };
+
+    match tokio::time::timeout(delete_timeout, client.delete_session(&identity.session_id)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            warn!(session_id = %identity.session_id, error = %err, "DeleteSession failed")
+        }
+        Err(_) => {
+            warn!(session_id = %identity.session_id, ?delete_timeout, "DeleteSession timed out")
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) fn start_noop_session_cleanup_worker() -> SessionCleanup {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    tokio::spawn(run_cleanup_worker(receiver, |_| async {}));
+    SessionCleanup { sender }
+}

--- a/ydb/src/session_pool/mod.rs
+++ b/ydb/src/session_pool/mod.rs
@@ -1,3 +1,4 @@
+mod cleanup_worker;
 mod pool;
 mod session;
 mod table_pool;

--- a/ydb/src/session_pool/mod.rs
+++ b/ydb/src/session_pool/mod.rs
@@ -8,7 +8,7 @@ mod regression_tests;
 
 pub use pool::{SessionPoolSettings, SessionPoolStats};
 
-pub(crate) use pool::{SessionPool, SessionPoolLease, spawn_pool_release};
+pub(crate) use pool::{SessionPool, SessionPoolLease};
 
 pub(crate) use table_pool::TableSessionPool;
 

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -203,10 +203,6 @@ impl SessionPoolLease {
         self.record.session.ensure_healthy()
     }
 
-    pub(crate) fn cleanup_timeout(&self) -> Duration {
-        self.pool.settings.session_delete_timeout
-    }
-
     /// Consume this lease and offer its session back to the pool. Pool policy may still discard
     /// an unhealthy, expired, or excess session.
     #[instrument(name = "ydb.SessionPool.ReturnSession", skip_all, fields(db.system.name = "ydb"))]

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -173,9 +173,11 @@ impl SessionPoolSettings {
 /// Call [`Self::return_to_pool`] to make a healthy session reusable. Dropping a lease without
 /// returning it schedules session cleanup.
 pub(crate) struct SessionPoolLease {
+    /// Drop the session before releasing the permit so shutdown cannot pass its lease barrier
+    /// before this lease has submitted cleanup.
+    record: SessionRecord,
     /// One permit represents this lease's exclusive use of one pool-capacity slot.
     permit: OwnedSemaphorePermit,
-    record: SessionRecord,
     pool: Arc<SessionPoolInner>,
 }
 
@@ -186,8 +188,8 @@ impl SessionPoolLease {
         pool: Arc<SessionPoolInner>,
     ) -> Self {
         Self {
-            permit,
             record: session.record,
+            permit,
             pool,
         }
     }
@@ -274,7 +276,7 @@ impl SessionPoolObserver {
         let Some(pool) = self.pool.upgrade() else {
             return;
         };
-        let _ = pool.drain_idle_for_node(node_uri);
+        pool.discard_idle_for_node(node_uri);
     }
 }
 
@@ -351,6 +353,17 @@ impl SessionPool {
         self.inner.stats()
     }
 
+    pub(crate) async fn shutdown(self) -> YdbResult<()> {
+        let _permits = self.inner.acquire_all_permits().await?;
+        self.inner.semaphore.close();
+        self.inner
+            .explicit_idle
+            .lock()
+            .expect("explicit idle lock")
+            .clear();
+        self.inner.cleanup.shutdown().await
+    }
+
     #[instrument(name = "ydb.SessionPool.AcquireSession", skip_all, fields(db.system.name = "ydb"), err)]
     pub async fn acquire_explicit(&self) -> YdbResult<SessionPoolLease> {
         let permit = self.inner.acquire_permit().await?;
@@ -377,6 +390,24 @@ impl SessionPool {
 }
 
 impl SessionPoolInner {
+    async fn acquire_all_permits(&self) -> YdbResult<OwnedSemaphorePermit> {
+        let permit_count = u32::try_from(self.settings.limit).map_err(|_| {
+            YdbError::InternalError(format!(
+                "session pool limit {} exceeds shutdown barrier capacity",
+                self.settings.limit
+            ))
+        })?;
+        self.semaphore
+            .clone()
+            .acquire_many_owned(permit_count)
+            .await
+            .map_err(|_| {
+                YdbError::InternalError(
+                    "session pool closed before shutdown acquired every lease".to_string(),
+                )
+            })
+    }
+
     fn acquire_timeout(&self) -> Duration {
         Duration::from_millis(self.acquire_timeout_ms.load(Ordering::Relaxed))
     }
@@ -479,18 +510,11 @@ impl SessionPoolInner {
         Ok(())
     }
 
-    fn drain_idle_for_node(&self, node_uri: &Uri) -> Vec<IdleSession> {
+    fn discard_idle_for_node(&self, node_uri: &Uri) {
         let mut idle = self.explicit_idle.lock().expect("explicit idle lock");
-        let mut drained = Vec::new();
-        let mut i = 0;
-        while i < idle.len() {
-            if idle[i].record.session.node_uri() == node_uri {
-                drained.push(idle.swap_remove(i));
-            } else {
-                i += 1;
-            }
-        }
-        drained
+        // Removed sessions must submit cleanup before releasing this lock. Shutdown uses the same
+        // mutex to drain the remaining idle sessions before terminating the cleanup worker.
+        idle.retain(|item| item.record.session.node_uri() != node_uri);
     }
 
     async fn create_explicit_session(&self) -> YdbResult<IdleSession> {
@@ -593,7 +617,6 @@ impl SessionPoolInner {
         item.last_used = Instant::now();
 
         if self.should_close_explicit(&item) {
-            drop(permit);
             drop(item);
         } else {
             let overflow = {
@@ -605,11 +628,13 @@ impl SessionPoolInner {
                     Some(item)
                 }
             };
-            drop(permit);
             if let Some(item) = overflow {
                 drop(item);
             }
         }
+        // Releasing the permit is the final ownership step. Shutdown uses all permits as a
+        // barrier, so every discarded session must submit cleanup before this point.
+        drop(permit);
     }
 }
 
@@ -639,12 +664,20 @@ fn session_should_close(
 impl SessionPool {
     /// Explicit pool backed by in-memory stub sessions (no CreateSession / Attach / Delete RPC).
     pub(crate) fn new_explicit_bench(settings: SessionPoolSettings) -> Self {
+        use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
+
+        Self::new_explicit_bench_with_cleanup(settings, start_noop_session_cleanup_worker())
+    }
+
+    fn new_explicit_bench_with_cleanup(
+        settings: SessionPoolSettings,
+        cleanup: SessionCleanup,
+    ) -> Self {
         use crate::GrpcOptions;
         use crate::discovery::StaticDiscovery;
         use crate::grpc_connection_manager::GrpcConnectionManager;
         use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
         use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
-        use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
 
         let settings = normalize_pool_settings(settings);
         let warm_up = settings.warm_up;
@@ -662,7 +695,6 @@ impl SessionPool {
             StaticDiscovery::new_from_str("grpc://127.0.0.1:2136")
                 .expect("static bench discovery must be valid"),
         );
-        let cleanup = start_noop_session_cleanup_worker();
         let inner = Arc::new_cyclic(|weak| SessionPoolInner {
             settings: settings.clone(),
             acquire_timeout_ms: AtomicU64::new(0),
@@ -722,6 +754,13 @@ impl SessionPool {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::task::Poll;
+
+    use futures_util::poll;
+    use tokio::sync::mpsc;
+
+    use crate::session_pool::cleanup_worker::start_test_session_cleanup_worker;
+
     use super::*;
 
     #[test]
@@ -778,5 +817,93 @@ mod unit_tests {
         assert!(session_should_close(
             &settings, 0, created, last_used, false,
         ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_discards_idle_sessions_and_closes_pool() {
+        let pool = SessionPool::new_explicit_bench(
+            SessionPoolSettings::new().with_limit(2).with_warm_up(2),
+        );
+        let observer = pool.clone();
+
+        pool.shutdown().await.expect("pool shutdown must succeed");
+
+        assert_eq!(observer.stats().idle, 0);
+        assert!(observer.acquire_explicit().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_idle_and_dropped_lease_cleanup() {
+        let (deleted_sender, mut deleted_receiver) = mpsc::unbounded_channel();
+        let cleanup = start_test_session_cleanup_worker(move |identity| {
+            let deleted_sender = deleted_sender.clone();
+            async move {
+                deleted_sender
+                    .send(identity.session_id.clone())
+                    .expect("delete observer must remain open");
+            }
+        });
+        let pool = SessionPool::new_explicit_bench_with_cleanup(
+            SessionPoolSettings::new().with_limit(2).with_warm_up(2),
+            cleanup,
+        );
+        let lease = pool
+            .acquire_explicit()
+            .await
+            .expect("bench lease must be available");
+        let leased_session_id = lease.session_id().to_string();
+        assert_eq!(pool.stats().idle, 1);
+
+        let mut shutdown = Box::pin(pool.shutdown());
+        assert!(matches!(poll!(shutdown.as_mut()), Poll::Pending));
+
+        drop(lease);
+        shutdown.await.expect("pool shutdown must succeed");
+
+        let mut deleted = Vec::with_capacity(2);
+        for _ in 0..2 {
+            deleted.push(
+                deleted_receiver
+                    .try_recv()
+                    .expect("shutdown must finish both session deletions"),
+            );
+        }
+        assert!(deleted_receiver.try_recv().is_err());
+        assert!(deleted.contains(&leased_session_id));
+        deleted.sort();
+        deleted.dedup();
+        assert_eq!(deleted.len(), 2, "each session must be deleted once");
+    }
+
+    #[tokio::test]
+    async fn shutdown_blocks_new_leases_and_waits_for_outstanding_leases() {
+        let pool = SessionPool::new_explicit_bench(
+            SessionPoolSettings::new().with_limit(2).with_warm_up(2),
+        );
+        let first_lease = pool
+            .acquire_explicit()
+            .await
+            .expect("bench lease must be available");
+        let second_lease = pool
+            .acquire_explicit()
+            .await
+            .expect("second bench lease must be available");
+        let observer = pool.clone();
+        let mut shutdown = Box::pin(pool.shutdown());
+
+        // Queue the all-permits shutdown barrier before the late single-permit acquisition.
+        assert!(matches!(poll!(shutdown.as_mut()), Poll::Pending));
+
+        let mut late_acquire = Box::pin(observer.acquire_explicit());
+        assert!(matches!(poll!(late_acquire.as_mut()), Poll::Pending));
+
+        first_lease.return_to_pool();
+        second_lease.return_to_pool();
+
+        shutdown.await.expect("pool shutdown must succeed");
+        assert!(
+            late_acquire.await.is_err(),
+            "session acquisition must not pass a pending shutdown barrier"
+        );
     }
 }

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
@@ -40,20 +41,6 @@ fn normalize_pool_settings(mut settings: SessionPoolSettings) -> SessionPoolSett
     settings.limit = settings.limit.max(1);
     settings.warm_up = settings.warm_up.min(settings.limit);
     settings
-}
-
-pub(crate) fn spawn_pool_release<F>(future: F)
-where
-    F: std::future::Future<Output = ()> + Send + 'static,
-{
-    match tokio::runtime::Handle::try_current() {
-        Ok(handle) => {
-            handle.spawn(future);
-        }
-        Err(_) => {
-            warn!("no active tokio runtime; skipping async session pool release during shutdown");
-        }
-    }
 }
 
 /// Settings for the driver session pool (CreateSession + AttachSession).
@@ -155,7 +142,7 @@ impl SessionPoolSettings {
         self
     }
 
-    /// Maximum time for a best-effort session cleanup RPC.
+    /// Maximum time for a best-effort `RollbackTransaction` or `DeleteSession` cleanup RPC.
     pub fn with_session_delete_timeout(mut self, timeout: Duration) -> Self {
         self.session_delete_timeout = timeout;
         self
@@ -179,6 +166,16 @@ pub(crate) struct SessionPoolLease {
     /// One permit represents this lease's exclusive use of one pool-capacity slot.
     permit: OwnedSemaphorePermit,
     pool: Arc<SessionPoolInner>,
+}
+
+impl fmt::Debug for SessionPoolLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionPoolLease")
+            .field("session_id", &self.session_id())
+            .field("node_uri", &self.node_uri())
+            .finish_non_exhaustive()
+    }
 }
 
 impl SessionPoolLease {
@@ -241,6 +238,12 @@ impl SessionPoolLease {
     #[cfg(test)]
     pub(crate) fn invalidate(&mut self) {
         self.record.session.invalidate();
+    }
+
+    /// Submit best-effort transaction rollback while preserving this lease until it finishes.
+    pub(crate) fn schedule_rollback(self, transaction_id: String) {
+        let cleanup = self.pool.cleanup.clone();
+        cleanup.submit_rollback(self, transaction_id);
     }
 }
 
@@ -356,11 +359,14 @@ impl SessionPool {
     pub(crate) async fn shutdown(self) -> YdbResult<()> {
         let _permits = self.inner.acquire_all_permits().await?;
         self.inner.semaphore.close();
-        self.inner
-            .explicit_idle
-            .lock()
-            .expect("explicit idle lock")
-            .clear();
+        {
+            let mut idle = self.inner.explicit_idle.lock().map_err(|_| {
+                YdbError::InternalError(
+                    "session pool idle lock was poisoned during shutdown".to_string(),
+                )
+            })?;
+            idle.clear();
+        }
         self.inner.cleanup.shutdown().await
     }
 
@@ -759,7 +765,7 @@ mod unit_tests {
     use futures_util::poll;
     use tokio::sync::mpsc;
 
-    use crate::session_pool::cleanup_worker::start_test_session_cleanup_worker;
+    use crate::session_pool::cleanup_worker::{CleanupTask, start_test_session_cleanup_worker};
 
     use super::*;
 
@@ -835,12 +841,19 @@ mod unit_tests {
     #[tokio::test]
     async fn shutdown_waits_for_idle_and_dropped_lease_cleanup() {
         let (deleted_sender, mut deleted_receiver) = mpsc::unbounded_channel();
-        let cleanup = start_test_session_cleanup_worker(move |identity| {
+        let cleanup = start_test_session_cleanup_worker(move |task| {
             let deleted_sender = deleted_sender.clone();
             async move {
-                deleted_sender
-                    .send(identity.session_id.clone())
-                    .expect("delete observer must remain open");
+                match task {
+                    CleanupTask::DeleteSession(identity) => {
+                        deleted_sender
+                            .send(identity.session_id.clone())
+                            .expect("delete observer must remain open");
+                    }
+                    CleanupTask::RollbackTransaction { lease, .. } => {
+                        lease.return_to_pool();
+                    }
+                }
             }
         });
         let pool = SessionPool::new_explicit_bench_with_cleanup(

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -12,7 +12,8 @@ use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_services::Service;
 
-use super::session::{AttachedSession, CreatedSession, SessionCleanup};
+use super::cleanup_worker::{SessionCleanup, start_session_cleanup_worker};
+use super::session::{AttachedSession, CreatedSession};
 
 /// Default pool size for [`SessionPoolSettings::default()`] and the driver built-in pool.
 ///
@@ -309,7 +310,7 @@ impl SessionPool {
                 connection_manager: connection_manager.clone(),
                 semaphore: Arc::new(Semaphore::new(limit)),
                 explicit_idle: Mutex::new(Vec::new()),
-                cleanup: SessionCleanup::new(
+                cleanup: start_session_cleanup_worker(
                     connection_manager.clone(),
                     settings.session_delete_timeout,
                 ),
@@ -643,6 +644,7 @@ impl SessionPool {
         use crate::grpc_connection_manager::GrpcConnectionManager;
         use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
         use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
+        use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
 
         let settings = normalize_pool_settings(settings);
         let warm_up = settings.warm_up;
@@ -660,13 +662,14 @@ impl SessionPool {
             StaticDiscovery::new_from_str("grpc://127.0.0.1:2136")
                 .expect("static bench discovery must be valid"),
         );
+        let cleanup = start_noop_session_cleanup_worker();
         let inner = Arc::new_cyclic(|weak| SessionPoolInner {
             settings: settings.clone(),
             acquire_timeout_ms: AtomicU64::new(0),
             connection_manager: connection_manager.clone(),
             semaphore: Arc::new(Semaphore::new(limit)),
             explicit_idle: Mutex::new(Vec::new()),
-            cleanup: SessionCleanup::new(connection_manager.clone(), Duration::ZERO),
+            cleanup: cleanup.clone(),
             observer: SessionPoolObserver {
                 discovery: discovery.clone(),
                 pool: weak.clone(),

--- a/ydb/src/session_pool/session.rs
+++ b/ydb/src/session_pool/session.rs
@@ -6,7 +6,6 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
 use futures_util::StreamExt;
 use http::Uri;
@@ -14,14 +13,19 @@ use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::errors::{YdbError, YdbResult, YdbStatusError};
-use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
 use crate::grpc_wrapper::raw_query_service::session_state::RawSessionState;
 use ydb_grpc::ydb_proto::query::SessionState;
 use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
+use super::cleanup_worker::SessionCleanup;
 use super::pool::SessionPoolObserver;
-use super::spawn_pool_release;
+
+/// Immutable identity shared by the session owner, AttachSession listener, and cleanup worker.
+pub(super) struct SessionIdentity {
+    pub(super) session_id: String,
+    pub(super) node_uri: Uri,
+}
 
 /// A server session returned by CreateSession but not attached yet.
 pub(super) struct CreatedSession {
@@ -159,12 +163,6 @@ impl Drop for SessionResource {
     }
 }
 
-/// Immutable identity shared by the AttachSession listener and cleanup path.
-struct SessionIdentity {
-    session_id: String,
-    node_uri: Uri,
-}
-
 /// One-way health signal shared with the AttachSession listener.
 ///
 /// No other data is published through this flag, so relaxed ordering is sufficient.
@@ -196,57 +194,6 @@ impl Drop for AttachSessionListener {
             #[cfg(test)]
             Self::Stub => {}
         }
-    }
-}
-
-/// Submits best-effort deletion for a server-side session resource.
-#[derive(Clone)]
-pub(super) struct SessionCleanup {
-    connection_manager: GrpcConnectionManager,
-    delete_timeout: Duration,
-}
-
-impl SessionCleanup {
-    pub(super) fn new(connection_manager: GrpcConnectionManager, delete_timeout: Duration) -> Self {
-        Self {
-            connection_manager,
-            delete_timeout,
-        }
-    }
-
-    fn submit_delete(&self, identity: Arc<SessionIdentity>) {
-        if cfg!(test) {
-            // Cleanup submission remains suppressed in test binaries until it is routed through
-            // the cleanup worker's testable command channel.
-            return;
-        }
-
-        let connection_manager = self.connection_manager.clone();
-        let delete_timeout = self.delete_timeout;
-        spawn_pool_release(async move {
-            let mut client = match connection_manager
-                .get_auth_service_to_node(RawQueryClient::new, &identity.node_uri)
-                .await
-            {
-                Ok(client) => client,
-                Err(err) => {
-                    warn!(session_id = %identity.session_id, error = %err, "failed to connect for DeleteSession");
-                    return;
-                }
-            };
-
-            match tokio::time::timeout(delete_timeout, client.delete_session(&identity.session_id))
-                .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => {
-                    warn!(session_id = %identity.session_id, error = %err, "DeleteSession failed")
-                }
-                Err(_) => {
-                    warn!(session_id = %identity.session_id, ?delete_timeout, "DeleteSession timed out")
-                }
-            }
-        });
     }
 }
 
@@ -307,20 +254,8 @@ async fn listen_attach_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::GrpcOptions;
-    use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
-    use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
-
-    fn connection_manager() -> GrpcConnectionManager {
-        GrpcConnectionManager::new(
-            SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
-                Uri::from_static("http://127.0.0.1/bench"),
-            ))),
-            "bench".to_string(),
-            MultiInterceptor::new(),
-            GrpcOptions::default(),
-        )
-    }
+    use crate::session_pool::cleanup_worker::start_noop_session_cleanup_worker;
+    use std::time::Duration;
 
     #[tokio::test]
     async fn attached_session_drop_aborts_its_listener() {
@@ -334,7 +269,7 @@ mod tests {
             }
         }
 
-        let cleanup = SessionCleanup::new(connection_manager(), Duration::ZERO);
+        let cleanup = start_noop_session_cleanup_worker();
         let (ready_sender, ready_receiver) = tokio::sync::oneshot::channel();
         let (dropped_sender, dropped_receiver) = tokio::sync::oneshot::channel();
         let listener = tokio::spawn(async move {

--- a/ydb/src/session_pool/session.rs
+++ b/ydb/src/session_pool/session.rs
@@ -22,6 +22,7 @@ use super::cleanup_worker::SessionCleanup;
 use super::pool::SessionPoolObserver;
 
 /// Immutable identity shared by the session owner, AttachSession listener, and cleanup worker.
+#[derive(Debug)]
 pub(super) struct SessionIdentity {
     pub(super) session_id: String,
     pub(super) node_uri: Uri,

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -814,6 +814,7 @@ async fn transient_error_propagated_retries_whole_transaction() -> YdbResult<()>
         .await;
 
     assert!(result.is_ok(), "expected eventual success, got {result:?}");
+    client.shutdown().await?;
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(
         lifecycle.rollback_count, 1,
@@ -858,6 +859,7 @@ async fn transient_error_swallowed_retries_whole_transaction() -> YdbResult<()> 
         result.is_ok(),
         "the retried transaction should succeed: {result:?}"
     );
+    client.shutdown().await?;
     let lifecycle = tx_lifecycle.lock().unwrap();
     assert_eq!(
         lifecycle.commit_count, 1,

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -18,8 +18,11 @@ mod mock_server;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::task::Poll;
 use std::time::Duration;
 
+use futures_util::poll;
+use tokio::sync::{Semaphore, mpsc};
 use ydb::{
     Client, ClientBuilder, Transaction, YdbError, YdbOrCustomerError, YdbResult, YdbStatusError,
     closure,
@@ -172,6 +175,53 @@ impl Handler for CountingHandler {
         self.replies
             .send(QueryReply::ExecuteQueryClose { stream_id });
         None
+    }
+}
+
+struct BlockingRollbackHandler {
+    replies: ReplySink,
+    rollback_started: mpsc::UnboundedSender<()>,
+    rollback_release: Arc<Semaphore>,
+    rollback_count: Arc<AtomicUsize>,
+}
+
+impl Handler for BlockingRollbackHandler {
+    fn set_channel(&mut self, tx: FromHandlerToService) {
+        self.replies.set_channel(tx);
+    }
+
+    fn handle(&self, incoming: Incoming) -> Option<Incoming> {
+        match incoming {
+            Incoming::Query(QueryIncoming::ExecuteQuery(_, stream_id)) => {
+                self.replies.send(QueryReply::ExecuteQuery {
+                    stream_id,
+                    part: success_part(Some(QUERY_TX_ID)),
+                });
+                self.replies
+                    .send(QueryReply::ExecuteQueryClose { stream_id });
+                None
+            }
+            Incoming::Query(QueryIncoming::RollbackTransaction(_, reply_tx)) => {
+                self.rollback_count.fetch_add(1, Ordering::SeqCst);
+                self.rollback_started
+                    .send(())
+                    .expect("rollback observer must remain open");
+                let rollback_release = self.rollback_release.clone();
+                tokio::spawn(async move {
+                    rollback_release
+                        .acquire()
+                        .await
+                        .expect("rollback release must remain open")
+                        .forget();
+                    let _ = reply_tx.send(Ok(tonic::Response::new(RollbackTransactionResponse {
+                        status: StatusCode::Success as i32,
+                        issues: Vec::new(),
+                    })));
+                });
+                None
+            }
+            other => Some(other),
+        }
     }
 }
 
@@ -1082,5 +1132,57 @@ async fn swallowed_rollback_failure_must_not_report_committed() -> YdbResult<()>
          RPC failed and the server-side transaction outcome is unknown"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_dropped_transaction_rollback() -> YdbResult<()> {
+    let (rollback_started, mut rollback_started_receiver) = mpsc::unbounded_channel();
+    let rollback_release = Arc::new(Semaphore::new(0));
+    let rollback_count = Arc::new(AtomicUsize::new(0));
+    let handler = BlockingRollbackHandler {
+        replies: ReplySink::default(),
+        rollback_started,
+        rollback_release: rollback_release.clone(),
+        rollback_count: rollback_count.clone(),
+    };
+    let (server, _reply_tx) = MockServer::start(handler).await;
+    let client = make_client(&server).await?;
+    let query = client.query_client();
+    let (attempt_ready, mut attempt_ready_receiver) = mpsc::unbounded_channel();
+    let attempt = tokio::spawn(async move {
+        query
+            .retry_tx(closure!([attempt_ready], async |tx: &mut Transaction| {
+                tx.exec("UPSERT INTO t (id, val) VALUES (1, 'x')").await?;
+                attempt_ready
+                    .send(())
+                    .expect("attempt observer must remain open");
+                std::future::pending::<ydb::YdbResultWithCustomerErr<()>>().await
+            }))
+            .await
+    });
+    attempt_ready_receiver
+        .recv()
+        .await
+        .expect("transaction attempt must start");
+
+    attempt.abort();
+    assert!(
+        attempt
+            .await
+            .expect_err("transaction attempt must be cancelled")
+            .is_cancelled()
+    );
+    tokio::time::timeout(Duration::from_secs(1), rollback_started_receiver.recv())
+        .await
+        .expect("rollback must start before the cleanup timeout")
+        .expect("rollback observer must remain open");
+
+    let mut shutdown = Box::pin(client.shutdown());
+    assert!(matches!(poll!(shutdown.as_mut()), Poll::Pending));
+
+    rollback_release.add_permits(1);
+    shutdown.await?;
+    assert_eq!(rollback_count.load(Ordering::SeqCst), 1);
     Ok(())
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Session deletion and transaction rollbacks runs in detached tasks, which cannot be awaited.
- Dropping tokio runtime can abort those tasks
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #555, related #560

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Session pool owns CleanupWorker thread
- Deletions and rollbacks are synchroniously submitted to that worker manually/on drop
- Upon shutdown Driver awaits all cleanup worker tasks

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
