### PR TITLE
feat(query)!: stream logical result sets lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,32 @@ For a single YQL statement you usually do not need `retry_tx` — call a builder
 | [`exec`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html) | `()` | DDL, DML without rows (`CREATE TABLE`, `UPSERT`, `DELETE`) |
 | [`query_row`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html) | one [`Row`](https://docs.rs/ydb/latest/ydb/struct.Row.html) | exactly one row (`SELECT COUNT(*) …`) |
 | [`query_result_set`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html) | one [`ResultSet`](https://docs.rs/ydb/latest/ydb/struct.ResultSet.html) | all rows of one result set |
-| [`query`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html) | [`QueryStream`](https://docs.rs/ydb/latest/ydb/struct.QueryStream.html) | multiple result sets, large reads |
+| [`query`](https://docs.rs/ydb/latest/ydb/struct.QueryClient.html) | `Vec<ResultSet>` | all rows of multiple result sets |
+
+Every `QueryClient` query-execution method above materializes its complete result before returning
+and retries the full operation on retryable failures. Queries inside `retry_tx` can instead stream
+large results lazily:
+
+```rust
+use futures_util::TryStreamExt;
+use ydb::{Transaction, closure};
+
+qc.retry_tx(closure!(async |tx: &mut Transaction| {
+    let mut results = tx.query("SELECT 1 AS a; SELECT 2 AS b").await?;
+    while let Some(mut result_set) = results.next_result_set().await? {
+        while let Some(part) = result_set.try_next().await? {
+            for _row in part {
+                // process rows from this response part
+            }
+        }
+    }
+    Ok(())
+})).await?;
+```
+
+Only one lazy transaction result set can be active at a time. Dropping one early causes its unread
+chunks to be discarded before `next_result_set()` returns the next result set; `discard().await`
+performs that drain immediately and reports any error it encounters.
 
 Parameters chain at the call site:
 

--- a/ydb/examples/basic/series_ops.rs
+++ b/ydb/examples/basic/series_ops.rs
@@ -1,9 +1,7 @@
 use std::fmt::Write;
 use std::time::{Duration, SystemTime};
 
-use ydb::{
-    Bytes, ExecBuilder, QueryClient, QueryStreamBuilder, TxMode, Value, YdbResult, ydb_struct,
-};
+use ydb::{Bytes, ExecBuilder, QueryBuilder, QueryClient, TxMode, Value, YdbResult, ydb_struct};
 
 use super::data::SampleData;
 
@@ -13,7 +11,7 @@ fn idem_exec<'a>(b: ExecBuilder<'a>) -> ExecBuilder<'a> {
     b.idempotent(true).timeout(EXAMPLE_TIMEOUT)
 }
 
-fn idem_query<'a>(b: QueryStreamBuilder<'a>) -> QueryStreamBuilder<'a> {
+fn idem_query<'a>(b: QueryBuilder<'a>) -> QueryBuilder<'a> {
     b.idempotent(true).timeout(EXAMPLE_TIMEOUT)
 }
 
@@ -118,9 +116,9 @@ pub async fn read_series(qc: &mut QueryClient, prefix: &str) -> YdbResult<()> {
         table_path(prefix, "series")
     );
 
-    let mut stream = idem_query(qc.query(sql).with_tx_mode(TxMode::SnapshotReadOnly)).await?;
+    let result_sets = idem_query(qc.query(sql).with_tx_mode(TxMode::SnapshotReadOnly)).await?;
 
-    while let Some(result_set) = stream.next_result_set().await? {
+    for result_set in result_sets {
         for mut row in result_set {
             let series_id: Option<Bytes> = row.remove_field_by_name("series_id")?.try_into()?;
             let series_bytes: Vec<u8> = series_id.expect("series_id present").into();
@@ -135,7 +133,6 @@ pub async fn read_series(qc: &mut QueryClient, prefix: &str) -> YdbResult<()> {
             );
         }
     }
-    stream.close().await?;
     Ok(())
 }
 

--- a/ydb/examples/query-service-stream.rs
+++ b/ydb/examples/query-service-stream.rs
@@ -1,5 +1,6 @@
 //! Multi-result-set streaming inside `retry_tx` (lazy tx on implicit session).
 
+use futures_util::TryStreamExt;
 use ydb::{ClientBuilder, Transaction, closure};
 
 #[tokio::main]
@@ -26,16 +27,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             //
             // The single-stream-per-transaction invariant comes for free.
 
-            let mut set_count = 0;
-            while let Some(result_set) = stream.next_result_set().await? {
-                for mut row in result_set {
-                    let _ = row.remove_field_by_name("a");
+            let mut result_set_count = 0;
+            while let Some(mut result_set) = stream.next_result_set().await? {
+                while let Some(part) = result_set.try_next().await? {
+                    for mut row in part {
+                        let _ = row.remove_field_by_name("a");
+                    }
                 }
-                set_count += 1;
+                result_set_count += 1;
             }
-            stream.close().await?;
 
-            Ok(set_count)
+            Ok(result_set_count)
         }))
         .await?;
 

--- a/ydb/examples/topic-read-in-transaction-example.rs
+++ b/ydb/examples/topic-read-in-transaction-example.rs
@@ -104,6 +104,7 @@ Topic Status: test_topic
 
 */
 
+use futures_util::TryStreamExt;
 use std::time::Duration;
 use tokio::time::timeout;
 use ydb::{
@@ -450,23 +451,23 @@ async fn main() -> YdbResult<()> {
                 .await?;
 
             let mut rows = Vec::new();
-            if let Some(result_set) = stream.next_result_set().await? {
-                for mut row in result_set {
-                    let topic: String = row.remove_field_by_name("topic")?.try_into()?;
-                    let partition: i64 = row.remove_field_by_name("partition")?.try_into()?;
-                    let offset: i64 = row.remove_field_by_name("offset")?.try_into()?;
-                    let body: Option<String> = row.remove_field_by_name("body")?.try_into()?;
+            while let Some(mut result_set) = stream.next_result_set().await? {
+                while let Some(part) = result_set.try_next().await? {
+                    for mut row in part {
+                        let topic: String = row.remove_field_by_name("topic")?.try_into()?;
+                        let partition: i64 = row.remove_field_by_name("partition")?.try_into()?;
+                        let offset: i64 = row.remove_field_by_name("offset")?.try_into()?;
+                        let body: Option<String> = row.remove_field_by_name("body")?.try_into()?;
 
-                    rows.push(TableRow {
-                        topic,
-                        partition,
-                        offset,
-                        body: body.unwrap_or_default(),
-                    });
+                        rows.push(TableRow {
+                            topic,
+                            partition,
+                            offset,
+                            body: body.unwrap_or_default(),
+                        });
+                    }
                 }
             }
-            stream.close().await?;
-
             Ok(rows)
         }))
         .await;

--- a/ydb/examples/vector-search.rs
+++ b/ydb/examples/vector-search.rs
@@ -3,7 +3,7 @@
 
 use std::time::Duration;
 
-use ydb::{Bytes, ClientBuilder, ExecBuilder, QueryStreamBuilder, Value, YdbResult, ydb_struct};
+use ydb::{Bytes, ClientBuilder, ExecBuilder, QueryBuilder, Value, YdbResult, ydb_struct};
 
 const EXAMPLE_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -11,7 +11,7 @@ fn idem_exec<'a>(b: ExecBuilder<'a>) -> ExecBuilder<'a> {
     b.idempotent(true).timeout(EXAMPLE_TIMEOUT)
 }
 
-fn idem_query<'a>(b: QueryStreamBuilder<'a>) -> QueryStreamBuilder<'a> {
+fn idem_query<'a>(b: QueryBuilder<'a>) -> QueryBuilder<'a> {
     b.idempotent(true).timeout(EXAMPLE_TIMEOUT)
 }
 
@@ -160,14 +160,14 @@ async fn search_items_as_bytes(
         "#
     );
 
-    let mut stream = idem_query(
+    let result_sets = idem_query(
         qc.query(query)
             .param("$embedding", convert_vector_to_bytes(embedding)),
     )
     .await?;
 
     let mut hits = Vec::new();
-    while let Some(result_set) = stream.next_result_set().await? {
+    for result_set in result_sets {
         for mut row in result_set {
             let id: Option<String> = row.remove_field_by_name("id")?.try_into()?;
             let document: Option<String> = row.remove_field_by_name("document")?.try_into()?;
@@ -179,7 +179,6 @@ async fn search_items_as_bytes(
             });
         }
     }
-    stream.close().await?;
     Ok(hits)
 }
 

--- a/ydb/src/client_query/builders.rs
+++ b/ydb/src/client_query/builders.rs
@@ -16,11 +16,13 @@ use super::exec::{
 use super::stream_facade::{QueryStream, materialize_query};
 
 use futures_util::future::BoxFuture;
+use futures_util::{FutureExt, TryFutureExt};
 
 pub enum ExecCall {}
 pub struct OneRow<T>(PhantomData<T>);
 pub struct OptionalRow<T>(PhantomData<T>);
 pub enum OneResultSet {}
+pub enum Materialized {}
 pub enum Streamed {}
 
 /// One-shot [`QueryClient`] calls (`exec`, `query_row`, …).
@@ -32,7 +34,8 @@ pub type ExecBuilder<'a, S = ClientOneShot> = CallBuilder<'a, ExecCall, S>;
 pub type QueryRowBuilder<'a, T = Row, S = ClientOneShot> = CallBuilder<'a, OneRow<T>, S>;
 pub type OptionalRowBuilder<'a, T = Row, S = ClientOneShot> = CallBuilder<'a, OptionalRow<T>, S>;
 pub type ResultSetBuilder<'a, S = ClientOneShot> = CallBuilder<'a, OneResultSet, S>;
-pub type QueryStreamBuilder<'a, S = ClientOneShot> = CallBuilder<'a, Streamed, S>;
+pub type QueryBuilder<'a> = CallBuilder<'a, Materialized, ClientOneShot>;
+pub type QueryStreamBuilder<'a> = CallBuilder<'a, Streamed, Interactive>;
 
 pub struct CallBuilder<'a, K, S = ClientOneShot> {
     core: ExecTarget<'a>,
@@ -102,8 +105,7 @@ impl<'a, K, S> CallBuilder<'a, K, S> {
     ///
     /// On [`QueryClient`], this sets the deadline for the retry loop (all attempts and
     /// backoff). Without `.timeout()`, retries continue until a non-retryable error.
-    /// Materializing builders (`exec`, `query_result_set`, `query_row`) retry the full
-    /// open+drain+close cycle; streaming [`Self::query`] retries only stream open.
+    /// All [`QueryClient`] builders retry the full open+drain+close cycle.
     ///
     /// Inside an interactive transaction this bounds a single attempt and is capped by the
     /// remaining [`QueryClient::retry_tx`] `.timeout()` when set. There is no in-place
@@ -135,8 +137,8 @@ impl<'a, K, S> CallBuilder<'a, K, S> {
     /// `commit_tx: false` unless [`Self::with_commit(true)`] is set on the last query.
     ///
     /// When using [`Self::query`] with `with_commit(true)` inside a transaction, you must
-    /// fully drain the stream and call [`QueryStream::close`] — dropping the stream early
-    /// cancels the gRPC call and does not commit.
+    /// fully drain the stream or call [`QueryStream::finish`] — dropping the stream early cancels
+    /// the gRPC call and does not commit.
     pub fn with_commit(mut self, commit: bool) -> Self {
         self.opts.commit_tx = Some(commit);
         self
@@ -199,11 +201,8 @@ impl<'a, S> IntoFuture for CallBuilder<'a, ExecCall, S> {
     type Output = YdbResult<()>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
-    fn into_future(mut self) -> Self::IntoFuture {
-        Box::pin(async move {
-            materialize_query(&mut self.core, self.text, self.params, self.opts).await?;
-            Ok(())
-        })
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(materialize_query(self.core, self.text, self.params, self.opts).map_ok(drop))
     }
 }
 
@@ -211,24 +210,23 @@ impl<'a, T: FromYdbRow + 'a, S> IntoFuture for CallBuilder<'a, OneRow<T>, S> {
     type Output = YdbResult<T>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
-    fn into_future(mut self) -> Self::IntoFuture {
+    fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
             let start = Instant::now();
-            let set = exactly_one_set(
-                materialize_query(&mut self.core, self.text, self.params, self.opts).await?,
-            )?;
-            let row = take_single_row(set)?.ok_or(YdbError::NoRows)?;
-            let delta = start.elapsed();
-            match &self.core {
-                ExecTarget::Client(core) => core
-                    .metrics_names
-                    .client_row_query_time_histogram
-                    .record(delta.as_secs_f64()),
+            let histogram = match &self.core {
+                ExecTarget::Client(core) => {
+                    core.metrics_names.client_row_query_time_histogram.clone()
+                }
                 ExecTarget::Tx(core) => core
                     .metrics_names
                     .client_transaction_row_query_time_histogram
-                    .record(delta.as_secs_f64()),
-            }
+                    .clone(),
+            };
+            let set = exactly_one_set(
+                materialize_query(self.core, self.text, self.params, self.opts).await?,
+            )?;
+            let row = take_single_row(set)?.ok_or(YdbError::NoRows)?;
+            histogram.record(start.elapsed().as_secs_f64());
             T::from_row(row)
         })
     }
@@ -238,24 +236,23 @@ impl<'a, T: FromYdbRow + 'a, S> IntoFuture for CallBuilder<'a, OptionalRow<T>, S
     type Output = YdbResult<Option<T>>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
-    fn into_future(mut self) -> Self::IntoFuture {
+    fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
             let start = Instant::now();
-            let set = exactly_one_set(
-                materialize_query(&mut self.core, self.text, self.params, self.opts).await?,
-            )?;
-            let row = take_single_row(set)?.map(T::from_row).transpose();
-            let delta = start.elapsed();
-            match &self.core {
-                ExecTarget::Client(core) => core
-                    .metrics_names
-                    .client_row_query_time_histogram
-                    .record(delta.as_secs_f64()),
+            let histogram = match &self.core {
+                ExecTarget::Client(core) => {
+                    core.metrics_names.client_row_query_time_histogram.clone()
+                }
                 ExecTarget::Tx(core) => core
                     .metrics_names
                     .client_transaction_row_query_time_histogram
-                    .record(delta.as_secs_f64()),
-            }
+                    .clone(),
+            };
+            let set = exactly_one_set(
+                materialize_query(self.core, self.text, self.params, self.opts).await?,
+            )?;
+            let row = take_single_row(set)?.map(T::from_row).transpose();
+            histogram.record(start.elapsed().as_secs_f64());
             row
         })
     }
@@ -265,16 +262,29 @@ impl<'a, S> IntoFuture for CallBuilder<'a, OneResultSet, S> {
     type Output = YdbResult<ResultSet>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
-    fn into_future(mut self) -> Self::IntoFuture {
-        Box::pin(async move {
-            exactly_one_set(
-                materialize_query(&mut self.core, self.text, self.params, self.opts).await?,
-            )
-        })
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(
+            materialize_query(self.core, self.text, self.params, self.opts)
+                .map(|result| result.and_then(exactly_one_set)),
+        )
     }
 }
 
-impl<'a, S> IntoFuture for CallBuilder<'a, Streamed, S> {
+impl<'a> IntoFuture for CallBuilder<'a, Materialized, ClientOneShot> {
+    type Output = YdbResult<Vec<ResultSet>>;
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(materialize_query(
+            self.core,
+            self.text,
+            self.params,
+            self.opts,
+        ))
+    }
+}
+
+impl<'a> IntoFuture for CallBuilder<'a, Streamed, Interactive> {
     type Output = YdbResult<QueryStream<'a>>;
     type IntoFuture = BoxFuture<'a, Self::Output>;
 
@@ -298,19 +308,14 @@ impl<'a, S> IntoFuture for CallBuilder<'a, Streamed, S> {
     }
 }
 
-/// Query execution entry points for [`QueryClient`](crate::QueryClient) and
+/// Materialized query execution entry points shared by [`QueryClient`](crate::QueryClient) and
 /// [`Transaction`](crate::Transaction).
 ///
-/// One-shot helpers are layered on [`Self::query`]:
-///
-/// - [`Self::query`] — streaming response (lazy via [`QueryStream`])
-/// - [`Self::query_result_set`] — `query` + drain + exactly one result set
-/// - [`Self::query_row`] — `query_result_set` + at most one row
-/// - [`Self::exec`] — `query` + drain and discard (success = no error)
+/// [`QueryClient::query`](crate::QueryClient::query) returns all result sets in memory, while
+/// [`Transaction::query`](crate::Transaction::query) exposes the lazy [`QueryStream`].
 pub trait QueryExecutor {
     type Scope;
     fn exec(&mut self, text: impl Into<String>) -> ExecBuilder<'_, Self::Scope>;
-    fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_, Self::Scope>;
     fn query_result_set(&mut self, text: impl Into<String>) -> ResultSetBuilder<'_, Self::Scope>;
     fn query_row(&mut self, text: impl Into<String>) -> QueryRowBuilder<'_, Row, Self::Scope>;
 }
@@ -321,7 +326,7 @@ macro_rules! impl_client_query_methods {
             CallBuilder::new_client(&mut self.ctx, text.into())
         }
 
-        pub fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_, ClientOneShot> {
+        pub fn query(&mut self, text: impl Into<String>) -> QueryBuilder<'_> {
             CallBuilder::new_client(&mut self.ctx, text.into())
         }
 
@@ -347,7 +352,7 @@ macro_rules! impl_tx_query_methods {
             CallBuilder::new_tx(&mut self.ctx, text.into())
         }
 
-        pub fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_, Interactive> {
+        pub fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_> {
             CallBuilder::new_tx(&mut self.ctx, text.into())
         }
 

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -778,7 +778,7 @@ pub(crate) async fn tx_begin_stream(
             .map_err(YdbError::from)?;
         let mut stream = ExecuteQueryStream::new(stream);
         stream.prime_first_part().await?;
-        if !stream.in_progress() {
+        if !stream.is_active() {
             let error = YdbError::InternalError(
                 "ExecuteQuery response stream closed before the first part".to_string(),
             );

--- a/ydb/src/client_query/explain_query.rs
+++ b/ydb/src/client_query/explain_query.rs
@@ -85,9 +85,8 @@ async fn explain_query_once(
     req.exec_mode = RawExecMode::Explain;
 
     let mut stream = ExecuteQueryStream::new(client.execute_query(req).await?);
-    // Drains the stream and checks every part's status. EXPLAIN sends no result sets, so the
-    // returned vector is empty; the plan arrives as stream metadata.
-    stream.materialize_all_result_sets().await?;
+    // Drains the stream and checks every part's status. The plan arrives as stream metadata.
+    stream.drain().await?;
     Ok(stream.take_query_plan())
 }
 

--- a/ydb/src/client_query/integration_test.rs
+++ b/ydb/src/client_query/integration_test.rs
@@ -4,6 +4,7 @@ use crate::session_pool::SessionPoolSettings;
 use crate::test_integration_helper::{create_client, create_client_with_session_pool};
 use crate::types::Value;
 use crate::{Transaction, closure, ydb_struct};
+use futures_util::TryStreamExt;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
 use tracing_test::traced_test;
@@ -97,12 +98,12 @@ async fn query_client_multi_result_set() -> YdbResult<()> {
     let set_count = qc
         .retry_tx(closure!(async |tx: &mut Transaction| {
             let mut stream = tx.query("SELECT 42 AS a; SELECT 1 AS b, 2 AS c;").await?;
-            let mut count = 0usize;
-            while stream.next_result_set().await?.is_some() {
-                count += 1;
+            let mut set_count = 0;
+            while let Some(mut result_set) = stream.next_result_set().await? {
+                while result_set.try_next().await?.is_some() {}
+                set_count += 1;
             }
-            stream.close().await?;
-            Ok(count)
+            Ok(set_count)
         }))
         .timeout(TEST_TIMEOUT)
         .await?;

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -6,6 +6,7 @@ mod builders;
 mod exec;
 mod explain_query;
 pub(crate) mod hooks;
+mod result_set_cursor;
 mod retry_tx;
 mod script;
 mod stream_facade;
@@ -449,10 +450,6 @@ impl QueryExecutor for QueryClient {
         QueryClient::exec(self, text)
     }
 
-    fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_, Self::Scope> {
-        QueryClient::query(self, text)
-    }
-
     fn query_result_set(&mut self, text: impl Into<String>) -> ResultSetBuilder<'_, Self::Scope> {
         QueryClient::query_result_set(self, text)
     }
@@ -550,10 +547,6 @@ impl QueryExecutor for Transaction {
         Transaction::exec(self, text)
     }
 
-    fn query(&mut self, text: impl Into<String>) -> QueryStreamBuilder<'_, Self::Scope> {
-        Transaction::query(self, text)
-    }
-
     fn query_result_set(&mut self, text: impl Into<String>) -> ResultSetBuilder<'_, Self::Scope> {
         Transaction::query_result_set(self, text)
     }
@@ -568,15 +561,15 @@ impl QueryExecutor for Transaction {
 }
 
 pub use builders::{
-    CallBuilder, ClientOneShot, ExecBuilder, ExecCall, Interactive, OneResultSet, OneRow,
-    OptionalRow, OptionalRowBuilder, QueryExecutor, QueryRowBuilder, QueryStreamBuilder,
-    ResultSetBuilder, Streamed,
+    CallBuilder, ClientOneShot, ExecBuilder, ExecCall, Interactive, Materialized, OneResultSet,
+    OneRow, OptionalRow, OptionalRowBuilder, QueryBuilder, QueryExecutor, QueryRowBuilder,
+    QueryStreamBuilder, ResultSetBuilder, Streamed,
 };
 pub use explain_query::{ExplainQueryBuilder, ExplainResult};
 pub use retry_tx::{RetryTxAttempt, RetryTxBuilder};
 pub use script::{ExecuteScriptBuilder, FetchScriptResultsBuilder};
 pub use script::{ExecuteScriptOperation, FetchScriptResult};
-pub use stream_facade::{QueryStats, QueryStream};
+pub use stream_facade::{QueryResultSet, QueryStats, QueryStream};
 
 #[cfg(test)]
 mod unit_tests {
@@ -586,7 +579,6 @@ mod unit_tests {
 
     use crate::GrpcOptions;
     use crate::errors::YdbStatusError;
-    use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
     use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
     use crate::grpc_wrapper::raw_table_service::value::{RawColumn, RawResultSet, RawValue};
     use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
@@ -825,30 +817,5 @@ mod unit_tests {
 
         drop(tx);
         assert_eq!(aborted.load(Ordering::Relaxed), 1);
-    }
-
-    #[tokio::test]
-    async fn dropping_drained_unclosed_stream_marks_transaction_undetermined() {
-        let pool = SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1));
-        let lease = pool.acquire_explicit().await.expect("acquire test session");
-        let mut tx = test_transaction(lease).await;
-        tx.ctx.mark_query_in_flight_for_test("tx-1");
-
-        {
-            let mut stream = QueryStream::from_tx(
-                ExecuteQueryStream::from_test_parts(Vec::new()),
-                &mut tx.ctx,
-                false,
-            );
-            assert!(
-                stream
-                    .next_result_set()
-                    .await
-                    .expect("drain test stream")
-                    .is_none()
-            );
-        }
-
-        assert!(matches!(tx.ctx.state, TxState::Undetermined(_)));
     }
 }

--- a/ydb/src/client_query/result_set_cursor.rs
+++ b/ydb/src/client_query/result_set_cursor.rs
@@ -1,0 +1,207 @@
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
+
+use futures_util::Stream;
+
+use crate::errors::YdbResult;
+use crate::grpc_wrapper::raw_query_service::stream::RawQueryResultPart;
+
+/// Routes consecutive raw parts into logical result sets without owning transport lifecycle.
+pub(super) struct ResultSetCursor<S> {
+    source: S,
+    pending_result: Option<RawQueryResultPart>,
+    // This marker stays set across cancellation points so the next result-set request can finish
+    // discarding a partially consumed logical set before exposing the following one.
+    active_result_set: Option<i64>,
+}
+
+impl<S> ResultSetCursor<S> {
+    pub(super) fn new(source: S) -> Self {
+        Self {
+            source,
+            pending_result: None,
+            active_result_set: None,
+        }
+    }
+
+    pub(super) fn source(&self) -> &S {
+        &self.source
+    }
+
+    pub(super) fn source_mut(&mut self) -> &mut S {
+        &mut self.source
+    }
+
+    pub(super) fn clear_active_result_set(&mut self) {
+        self.active_result_set = None;
+    }
+}
+
+impl<S> ResultSetCursor<S>
+where
+    S: Stream<Item = YdbResult<RawQueryResultPart>> + Unpin,
+{
+    fn poll_next_raw(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<YdbResult<RawQueryResultPart>>> {
+        if let Some(part) = self.pending_result.take() {
+            return Poll::Ready(Some(Ok(part)));
+        }
+        Pin::new(&mut self.source).poll_next(cx)
+    }
+
+    pub(super) async fn next_raw(&mut self) -> YdbResult<Option<RawQueryResultPart>> {
+        std::future::poll_fn(|cx| self.poll_next_raw(cx))
+            .await
+            .transpose()
+    }
+
+    async fn discard_active_result_set(&mut self) -> YdbResult<()> {
+        let Some(active_index) = self.active_result_set else {
+            return Ok(());
+        };
+
+        while let Some(part) = self.next_raw().await? {
+            if part.result_set_index != active_index {
+                self.pending_result = Some(part);
+                break;
+            }
+        }
+        self.active_result_set = None;
+        Ok(())
+    }
+
+    pub(super) async fn next_result_set_index(&mut self) -> YdbResult<Option<i64>> {
+        self.discard_active_result_set().await?;
+        let Some(part) = self.next_raw().await? else {
+            return Ok(None);
+        };
+        let result_set_index = part.result_set_index;
+        self.pending_result = Some(part);
+        self.active_result_set = Some(result_set_index);
+        Ok(Some(result_set_index))
+    }
+
+    pub(super) fn poll_next_result_set_part(
+        &mut self,
+        result_set_index: i64,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<YdbResult<RawQueryResultPart>>> {
+        match ready!(self.poll_next_raw(cx)) {
+            Some(Ok(part)) if part.result_set_index == result_set_index => {
+                Poll::Ready(Some(Ok(part)))
+            }
+            Some(Ok(part)) => {
+                self.pending_result = Some(part);
+                self.active_result_set = None;
+                Poll::Ready(None)
+            }
+            Some(Err(err)) => {
+                self.active_result_set = None;
+                Poll::Ready(Some(Err(err)))
+            }
+            None => {
+                self.active_result_set = None;
+                Poll::Ready(None)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::{FutureExt, stream};
+
+    use crate::errors::YdbResult;
+    use crate::grpc_wrapper::raw_query_service::stream::RawQueryResultPart;
+    use crate::grpc_wrapper::raw_table_service::value::RawResultSet;
+
+    use super::ResultSetCursor;
+
+    fn raw_part(result_set_index: i64) -> RawQueryResultPart {
+        RawQueryResultPart {
+            result_set_index,
+            result_set: RawResultSet::default(),
+        }
+    }
+
+    async fn next_group_part<S>(
+        cursor: &mut ResultSetCursor<S>,
+        result_set_index: i64,
+    ) -> YdbResult<Option<RawQueryResultPart>>
+    where
+        S: futures_util::Stream<Item = YdbResult<RawQueryResultPart>> + Unpin,
+    {
+        std::future::poll_fn(|cx| cursor.poll_next_result_set_part(result_set_index, cx))
+            .await
+            .transpose()
+    }
+
+    #[tokio::test]
+    async fn groups_consecutive_parts_without_transport() -> YdbResult<()> {
+        let source =
+            stream::iter([0, 0, 1, 1].map(|result_set_index| Ok(raw_part(result_set_index))));
+        let mut cursor = ResultSetCursor::new(source);
+
+        assert_eq!(cursor.next_result_set_index().await?, Some(0));
+        assert_eq!(
+            next_group_part(&mut cursor, 0)
+                .await?
+                .expect("first part")
+                .result_set_index,
+            0
+        );
+        assert_eq!(
+            next_group_part(&mut cursor, 0)
+                .await?
+                .expect("first continuation")
+                .result_set_index,
+            0
+        );
+        assert!(next_group_part(&mut cursor, 0).await?.is_none());
+
+        assert_eq!(cursor.next_result_set_index().await?, Some(1));
+        assert_eq!(
+            next_group_part(&mut cursor, 1)
+                .await?
+                .expect("second part")
+                .result_set_index,
+            1
+        );
+        assert_eq!(
+            next_group_part(&mut cursor, 1)
+                .await?
+                .expect("second continuation")
+                .result_set_index,
+            1
+        );
+        assert!(next_group_part(&mut cursor, 1).await?.is_none());
+        assert_eq!(cursor.next_result_set_index().await?, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn preserves_its_group_when_a_drain_is_cancelled() -> YdbResult<()> {
+        let (parts_tx, mut parts_rx) = tokio::sync::mpsc::unbounded_channel();
+        parts_tx
+            .send(Ok(raw_part(0)))
+            .expect("send first result part");
+        let source = stream::poll_fn(move |cx| parts_rx.poll_recv(cx));
+        let mut cursor = ResultSetCursor::new(source);
+
+        assert_eq!(cursor.next_result_set_index().await?, Some(0));
+        assert!(cursor.next_result_set_index().now_or_never().is_none());
+
+        parts_tx
+            .send(Ok(raw_part(0)))
+            .expect("send first-set continuation");
+        parts_tx
+            .send(Ok(raw_part(1)))
+            .expect("send second result set");
+        drop(parts_tx);
+
+        assert_eq!(cursor.next_result_set_index().await?, Some(1));
+        Ok(())
+    }
+}

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -1,9 +1,14 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
 use std::time::Duration;
+
+use futures_util::stream::FusedStream;
+use futures_util::{Stream, TryStreamExt};
 
 use crate::closure;
 use crate::errors::{YdbError, YdbResult};
-use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
+use crate::grpc_wrapper::raw_query_service::stream::{ExecuteQueryStream, RawQueryResultPart};
 use crate::grpc_wrapper::raw_table_service::value::RawResultSet;
 use crate::result::ResultSet;
 use crate::types::Value;
@@ -13,12 +18,21 @@ use super::exec::{
     TxExecContext, apply_stream_tx_id, client_begin_stream_once, resolve_commit_tx,
     tx_begin_stream, tx_cancel_query, tx_finish_query, tx_handle_query_error,
 };
+use super::result_set_cursor::ResultSetCursor;
 
-/// Streaming query result. Drain all result sets and call [`Self::close`] to return an owned
-/// pooled session for reuse. Dropping the stream cancels it and discards that session.
-/// Inside a transaction, [`CallBuilder::with_commit(true)`] commits only on successful close.
-#[must_use = "QueryStream must be fully consumed and closed"]
+/// A transaction query response exposed as a sequence of lazy logical result sets.
+///
+/// Call [`Self::next_result_set`] until it returns `None` to confirm successful response completion.
+/// This makes an ordinary transaction ready for its next operation, or completes one configured
+/// with `with_commit(true)`. [`Self::finish`] drains unread result sets when their rows are not
+/// needed. Dropping the query stream earlier cancels the gRPC call and invalidates the transaction.
+#[must_use = "QueryStream must be fully consumed or finished"]
 pub struct QueryStream<'a> {
+    cursor: ResultSetCursor<ManagedQueryParts<'a>>,
+}
+
+/// Turns the decoded gRPC response into a lifecycle-aware stream of result parts.
+struct ManagedQueryParts<'a> {
     stream: ExecuteQueryStream,
     lifecycle: QueryStreamLifecycle<'a>,
 }
@@ -36,38 +50,59 @@ enum QueryStreamOwner<'a> {
     },
 }
 
-impl Drop for QueryStream<'_> {
+impl Drop for ManagedQueryParts<'_> {
     fn drop(&mut self) {
         self.abort();
     }
 }
 
-impl QueryStream<'_> {
-    fn abort(&mut self) {
-        if let Err(error) = self.apply_captured_transaction_id() {
-            tracing::warn!(%error, "failed to capture transaction id while cancelling query stream");
-        }
-        self.stream.cancel();
-        self.finish_cancelled_lifecycle();
-    }
+impl Stream for ManagedQueryParts<'_> {
+    type Item = YdbResult<RawQueryResultPart>;
 
-    fn finish_cancelled_lifecycle(&mut self) {
-        let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
-        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) = lifecycle {
-            tx_cancel_query(context);
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match ready!(Pin::new(&mut this.stream).poll_next(cx)) {
+            Some(Ok(part)) => match this.apply_captured_transaction_id() {
+                Ok(()) => Poll::Ready(Some(Ok(part))),
+                Err(error) => {
+                    let error = this.terminate_with_error(error);
+                    Poll::Ready(Some(Err(error)))
+                }
+            },
+            Some(Err(err)) => {
+                let error = YdbError::from(err);
+                let error = this.terminate_with_error(error);
+                Poll::Ready(Some(Err(error)))
+            }
+            None => {
+                if let Err(error) = this.apply_captured_transaction_id() {
+                    let error = this.terminate_with_error(error);
+                    return Poll::Ready(Some(Err(error)));
+                }
+                match this.complete() {
+                    Ok(()) => Poll::Ready(None),
+                    Err(error) => Poll::Ready(Some(Err(error))),
+                }
+            }
         }
     }
 }
 
-impl<'a> QueryStream<'a> {
-    pub(crate) fn from_client(opened: OpenedClientQueryStream) -> Self {
+impl FusedStream for ManagedQueryParts<'_> {
+    fn is_terminated(&self) -> bool {
+        matches!(self.lifecycle, QueryStreamLifecycle::Finished)
+    }
+}
+
+impl<'a> ManagedQueryParts<'a> {
+    fn from_client(opened: OpenedClientQueryStream) -> Self {
         Self {
             stream: opened.stream,
             lifecycle: QueryStreamLifecycle::Active(QueryStreamOwner::Client(opened.session)),
         }
     }
 
-    pub(crate) fn from_tx(
+    fn from_tx(
         stream: ExecuteQueryStream,
         context: &'a mut TxExecContext,
         commit_at_end: bool,
@@ -81,7 +116,8 @@ impl<'a> QueryStream<'a> {
         }
     }
 
-    fn apply_transaction_id(&mut self, transaction_id: Option<String>) -> YdbResult<()> {
+    fn apply_captured_transaction_id(&mut self) -> YdbResult<()> {
+        let transaction_id = self.stream.take_captured_tx_id();
         if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) =
             &mut self.lifecycle
         {
@@ -90,21 +126,22 @@ impl<'a> QueryStream<'a> {
         Ok(())
     }
 
-    fn apply_captured_transaction_id(&mut self) -> YdbResult<()> {
-        let transaction_id = self.stream.take_captured_tx_id();
-        self.apply_transaction_id(transaction_id)
-    }
-
-    fn handle_error(&mut self, error: &YdbError) -> YdbResult<()> {
+    fn terminate_with_error(&mut self, error: YdbError) -> YdbError {
+        let mut reported_error = error;
         if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) =
             &mut self.lifecycle
+            && context.state.is_active()
+            && let Err(error) = tx_handle_query_error(context, &reported_error)
         {
-            tx_handle_query_error(context, error)?;
+            reported_error = error;
         }
-        Ok(())
+        // If the error did not already end the transaction, cancelling its still-owned stream
+        // finalizes the transaction lifecycle.
+        self.abort();
+        reported_error
     }
 
-    fn finish(&mut self) -> YdbResult<()> {
+    fn complete(&mut self) -> YdbResult<()> {
         let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
         match lifecycle {
             QueryStreamLifecycle::Active(QueryStreamOwner::Client(session)) => {
@@ -119,59 +156,153 @@ impl<'a> QueryStream<'a> {
         }
     }
 
-    pub async fn next_result_set(&mut self) -> YdbResult<Option<ResultSet>> {
-        let next = match self.stream.next_result_set().await {
-            Ok(v) => v,
-            Err(err) => {
-                let ydb_err = YdbError::from(err);
-                self.stream.cancel();
-                self.handle_error(&ydb_err)?;
-                if matches!(
-                    &self.lifecycle,
-                    QueryStreamLifecycle::Active(QueryStreamOwner::Client(_))
-                ) && !ydb_err.requires_session_discard()
-                {
-                    return Err(ydb_err);
-                }
-                self.lifecycle = QueryStreamLifecycle::Finished;
-                return Err(ydb_err);
-            }
-        };
-        match next {
-            Some((raw, transaction_id)) => {
-                self.apply_transaction_id(transaction_id)?;
-                ResultSet::try_from(raw).map(Some)
-            }
-            None => {
-                self.apply_captured_transaction_id()?;
-                Ok(None)
-            }
+    fn abort(&mut self) {
+        if let Err(error) = self.apply_captured_transaction_id() {
+            tracing::warn!(%error, "failed to capture transaction id while cancelling query stream");
+        }
+        self.stream.cancel();
+        let lifecycle = std::mem::replace(&mut self.lifecycle, QueryStreamLifecycle::Finished);
+        if let QueryStreamLifecycle::Active(QueryStreamOwner::Tx { context, .. }) = lifecycle {
+            tx_cancel_query(context);
+        }
+    }
+}
+
+impl<'a> QueryStream<'a> {
+    pub(crate) fn from_client(opened: OpenedClientQueryStream) -> Self {
+        Self {
+            cursor: ResultSetCursor::new(ManagedQueryParts::from_client(opened)),
+        }
+    }
+
+    pub(crate) fn from_tx(
+        stream: ExecuteQueryStream,
+        context: &'a mut TxExecContext,
+        commit_at_end: bool,
+    ) -> Self {
+        Self {
+            cursor: ResultSetCursor::new(ManagedQueryParts::from_tx(
+                stream,
+                context,
+                commit_at_end,
+            )),
         }
     }
 
     pub fn stats(&self) -> Option<QueryStats> {
-        self.stream
+        self.cursor
+            .source()
+            .stream
             .stats()
             .map(|total_duration| QueryStats { total_duration })
     }
 
-    pub async fn close(mut self) -> YdbResult<()> {
-        match self.stream.close().await {
-            Ok(meta) => {
-                self.apply_transaction_id(meta.tx_id)?;
-                self.finish()
+    /// Return the next logical result set as a lazy stream of its response parts.
+    ///
+    /// Only one result set can be active at a time. Each yielded [`ResultSet`] is one response
+    /// part and can be consumed row by row with [`ResultSet::rows`]. If the returned result set is
+    /// dropped before it reaches `None`, its unread parts are discarded by the next call to this
+    /// method. Errors and query metadata encountered while discarding are still processed.
+    pub async fn next_result_set(&mut self) -> YdbResult<Option<QueryResultSet<'_, 'a>>> {
+        let Some(result_set_index) = self.cursor.next_result_set_index().await? else {
+            return Ok(None);
+        };
+        Ok(Some(QueryResultSet {
+            query: self,
+            result_set_index,
+            terminated: false,
+        }))
+    }
+
+    /// Drain unread result parts and wait for successful query completion.
+    ///
+    /// An ordinary query leaves the transaction active and ready for its next operation. A query
+    /// configured with `with_commit(true)` completes the transaction and returns its session only
+    /// after YDB closes the response stream successfully.
+    pub async fn finish(mut self) -> YdbResult<()> {
+        self.cursor.clear_active_result_set();
+        while self.cursor.next_raw().await?.is_some() {}
+        Ok(())
+    }
+}
+
+/// A lazy stream of response parts belonging to one logical query result set.
+///
+/// Obtain this value through [`QueryStream::next_result_set`]. Consume it through `None` or call
+/// [`Self::discard`] to discard its remaining parts immediately. Dropping it early defers that
+/// discard until the next call to [`QueryStream::next_result_set`].
+#[must_use = "QueryResultSet must be consumed or discarded"]
+pub struct QueryResultSet<'stream, 'query> {
+    query: &'stream mut QueryStream<'query>,
+    result_set_index: i64,
+    terminated: bool,
+}
+
+impl QueryResultSet<'_, '_> {
+    /// Zero-based index of this logical result set.
+    pub fn result_set_index(&self) -> i64 {
+        self.result_set_index
+    }
+
+    /// Drain and discard all unread parts of this result set.
+    pub async fn discard(mut self) -> YdbResult<()> {
+        while self.try_next().await?.is_some() {}
+        Ok(())
+    }
+
+    fn terminate(&mut self) {
+        self.terminated = true;
+        self.query.cursor.clear_active_result_set();
+    }
+
+    fn poll_next_result_set_part(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<YdbResult<ResultSet>>> {
+        if self.terminated {
+            return Poll::Ready(None);
+        }
+
+        match ready!(
+            self.query
+                .cursor
+                .poll_next_result_set_part(self.result_set_index, cx)
+        ) {
+            Some(Ok(part)) => match ResultSet::try_from(part.result_set) {
+                Ok(result_set) => Poll::Ready(Some(Ok(result_set))),
+                Err(err) => {
+                    let err = self.query.cursor.source_mut().terminate_with_error(err);
+                    self.terminate();
+                    Poll::Ready(Some(Err(err)))
+                }
+            },
+            Some(Err(err)) => {
+                self.terminate();
+                Poll::Ready(Some(Err(err)))
             }
-            Err(err) => {
-                let ydb_err = YdbError::from(err);
-                self.handle_error(&ydb_err)?;
-                self.lifecycle = QueryStreamLifecycle::Finished;
-                Err(ydb_err)
+            None => {
+                self.terminate();
+                Poll::Ready(None)
             }
         }
     }
 }
 
-/// Drain a [`query`](super::QueryExecutor::query) stream into materialized result sets.
+impl Stream for QueryResultSet<'_, '_> {
+    type Item = YdbResult<ResultSet>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().poll_next_result_set_part(cx)
+    }
+}
+
+impl FusedStream for QueryResultSet<'_, '_> {
+    fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+}
+
+/// Drain a query stream into materialized result sets.
 ///
 /// Used by one-shot builders (`exec`, `query_result_set`, `query_row`) on both
 /// [`QueryClient`](super::QueryClient) and [`Transaction`](super::Transaction).
@@ -179,12 +310,12 @@ impl<'a> QueryStream<'a> {
 /// On [`QueryClient`], the full open+drain+close cycle is retried on retryable errors.
 /// Interactive transactions are materialized once since tx retries are owned by [`QueryClient::retry_tx`] loop.
 pub(crate) async fn materialize_query(
-    core: &mut ExecTarget<'_>,
+    core: ExecTarget<'_>,
     text: String,
     params: HashMap<String, Value>,
     opts: CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
-    let commit_at_end = resolve_commit_tx(core, &opts);
+    let commit_at_end = resolve_commit_tx(&core, &opts);
     match core {
         ExecTarget::Client(ctx) => {
             ctx.retry_settings
@@ -199,7 +330,8 @@ pub(crate) async fn materialize_query(
                 .await
         }
         ExecTarget::Tx(context) => {
-            materialize_tx_once(context, text, params, opts, commit_at_end).await
+            let stream = tx_begin_stream(context, text, params, opts, true).await?;
+            materialize_stream(QueryStream::from_tx(stream, context, commit_at_end)).await
         }
     }
 }
@@ -210,71 +342,22 @@ async fn materialize_client_once(
     params: &HashMap<String, Value>,
     opts: &CallOptions,
 ) -> YdbResult<Vec<ResultSet>> {
-    let mut opened = client_begin_stream_once(ctx, text, params, opts, true).await?;
-    let result: YdbResult<Vec<RawResultSet>> = async {
-        let raw_sets = drain_result_sets(&mut opened.stream).await?;
-        opened.stream.close().await?;
-        Ok(raw_sets)
-    }
-    .await;
-    match result {
-        Ok(raw_sets) => {
-            opened.session.release();
-            convert_result_sets(raw_sets)
-        }
-        Err(error) => Err(error),
-    }
+    let opened = client_begin_stream_once(ctx, text, params, opts, true).await?;
+    materialize_stream(QueryStream::from_client(opened)).await
 }
 
-async fn materialize_tx_once(
-    context: &mut TxExecContext,
-    text: String,
-    params: HashMap<String, Value>,
-    opts: CallOptions,
-    commit_at_end: bool,
-) -> YdbResult<Vec<ResultSet>> {
-    let mut stream = tx_begin_stream(context, text, params, opts, true).await?;
-    let raw_sets = match drain_result_sets(&mut stream).await {
-        Ok(raw_sets) => raw_sets,
-        Err(ydb_err) => {
-            tx_handle_query_error(context, &ydb_err)?;
-            return Err(ydb_err);
+async fn materialize_stream(mut stream: QueryStream<'_>) -> YdbResult<Vec<ResultSet>> {
+    let mut by_index: BTreeMap<i64, RawResultSet> = BTreeMap::new();
+    while let Some(part) = stream.cursor.next_raw().await? {
+        let result_set = by_index.entry(part.result_set_index).or_default();
+        result_set.truncated |= part.result_set.truncated;
+        if result_set.columns.is_empty() {
+            result_set.columns = part.result_set.columns;
         }
-    };
-    let sets = match convert_result_sets(raw_sets) {
-        Ok(sets) => sets,
-        Err(ydb_err) => {
-            tx_handle_query_error(context, &ydb_err)?;
-            return Err(ydb_err);
-        }
-    };
-    match stream.close().await {
-        Ok(meta) => {
-            apply_stream_tx_id(context, meta.tx_id)?;
-            tx_finish_query(context, commit_at_end)?;
-        }
-        Err(err) => {
-            let ydb_err = YdbError::from(err);
-            tx_handle_query_error(context, &ydb_err)?;
-            return Err(ydb_err);
-        }
+        result_set.rows.extend(part.result_set.rows);
     }
-    Ok(sets)
-}
 
-async fn drain_result_sets(stream: &mut ExecuteQueryStream) -> YdbResult<Vec<RawResultSet>> {
-    stream
-        .materialize_all_result_sets()
-        .await
-        .map_err(YdbError::from)
-}
-
-fn convert_result_sets(raw_sets: Vec<RawResultSet>) -> YdbResult<Vec<ResultSet>> {
-    let mut sets = Vec::with_capacity(raw_sets.len());
-    for raw in raw_sets {
-        sets.push(ResultSet::try_from(raw)?);
-    }
-    Ok(sets)
+    by_index.into_values().map(ResultSet::try_from).collect()
 }
 
 #[derive(Debug, Default)]

--- a/ydb/src/grpc_wrapper/raw_query_service/execute_query.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/execute_query.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 
 use crate::grpc_wrapper::raw_errors::RawResult;
 use crate::grpc_wrapper::raw_query_service::status::check_status;
-use crate::grpc_wrapper::raw_table_service::value::{
-    RawColumn, RawResultSet, RawTypedValue, RawValue,
-};
+use crate::grpc_wrapper::raw_table_service::value::{RawColumn, RawTypedValue};
 use crate::types::Value;
 use ydb_grpc::ydb_proto::query::{
     ExecMode, ExecuteQueryRequest, ExecuteQueryResponsePart, QueryContent, SchemaInclusionMode,
@@ -155,33 +153,7 @@ pub(crate) fn plan_from_part(part: &ExecuteQueryResponsePart) -> Option<RawQuery
     })
 }
 
-pub(crate) fn append_rows_from_part(
-    columns: &mut Vec<RawColumn>,
-    rows: &mut Vec<Vec<RawValue>>,
-    truncated: &mut bool,
-    part: ExecuteQueryResponsePart,
-) -> RawResult<()> {
-    let Some(proto_set) = part.result_set else {
-        return Ok(());
-    };
-    let part_set = RawResultSet::try_from(proto_set)?;
-    *truncated |= part_set.truncated;
-    if !columns.is_empty()
-        && !part_set.columns.is_empty()
-        && !columns_compatible(columns, &part_set.columns)
-    {
-        return Err(crate::grpc_wrapper::raw_errors::RawError::custom(
-            "column metadata mismatch between stream parts".to_string(),
-        ));
-    }
-    if columns.is_empty() {
-        *columns = part_set.columns;
-    }
-    rows.extend(part_set.rows);
-    Ok(())
-}
-
-fn columns_compatible(existing: &[RawColumn], new_cols: &[RawColumn]) -> bool {
+pub(super) fn columns_compatible(existing: &[RawColumn], new_cols: &[RawColumn]) -> bool {
     existing.len() == new_cols.len()
         && existing
             .iter()

--- a/ydb/src/grpc_wrapper/raw_query_service/stream.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/stream.rs
@@ -1,37 +1,39 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context, Poll, ready};
 use std::time::Duration;
 
-use tracing::warn;
+use futures_util::{Stream, TryStreamExt};
 
-use crate::grpc_wrapper::raw_errors::RawResult;
+use crate::grpc_wrapper::raw_errors::{RawError, RawResult};
 use crate::grpc_wrapper::raw_query_service::execute_query::{
-    RawQueryStatsPlan, append_rows_from_part, check_part, plan_from_part, stats_from_part,
+    RawQueryStatsPlan, check_part, columns_compatible, plan_from_part, stats_from_part,
     tx_id_from_part,
 };
-use crate::grpc_wrapper::raw_table_service::value::RawResultSet;
+use crate::grpc_wrapper::raw_table_service::value::{RawColumn, RawResultSet};
 use ydb_grpc::ydb_proto::query::ExecuteQueryResponsePart;
 
-pub(crate) struct StreamCloseMeta {
-    pub tx_id: Option<String>,
+pub(crate) struct RawQueryResultPart {
+    pub(crate) result_set_index: i64,
+    pub(crate) result_set: RawResultSet,
+}
+
+struct ActiveQueryResponse {
+    stream: tonic::Streaming<ExecuteQueryResponsePart>,
+    pending_result: Option<RawQueryResultPart>,
 }
 
 #[derive(Default)]
-struct PartialResultSet {
-    columns: Vec<crate::grpc_wrapper::raw_table_service::value::RawColumn>,
-    rows: Vec<Vec<crate::grpc_wrapper::raw_table_service::value::RawValue>>,
-    truncated: bool,
+struct QueryResponseMetadata {
+    tx_id: Option<String>,
+    stats: Option<Duration>,
+    plan: Option<RawQueryStatsPlan>,
+    columns_by_result_set: HashMap<i64, Vec<RawColumn>>,
 }
 
 pub(crate) struct ExecuteQueryStream {
-    grpc: Option<tonic::Streaming<ExecuteQueryResponsePart>>,
-    next_index: i64,
-    pending_part: Option<ExecuteQueryResponsePart>,
-    captured_tx_id: Option<String>,
-    finished: bool,
-    stats: Option<Duration>,
-    plan: Option<RawQueryStatsPlan>,
-    #[cfg(test)]
-    test_parts: Option<Vec<ExecuteQueryResponsePart>>,
+    active: Option<ActiveQueryResponse>,
+    metadata: QueryResponseMetadata,
 }
 
 impl Drop for ExecuteQueryStream {
@@ -40,38 +42,58 @@ impl Drop for ExecuteQueryStream {
     }
 }
 
+impl Stream for ExecuteQueryStream {
+    type Item = RawResult<RawQueryResultPart>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            let Some(active) = &mut this.active else {
+                return Poll::Ready(None);
+            };
+            let received = if let Some(part) = active.pending_result.take() {
+                return Poll::Ready(Some(Ok(part)));
+            } else {
+                ready!(Pin::new(&mut active.stream).poll_next(cx))
+            };
+
+            let Some(received) = received else {
+                this.active = None;
+                return Poll::Ready(None);
+            };
+            let part = match received {
+                Ok(part) => part,
+                Err(status) => {
+                    this.active = None;
+                    return Poll::Ready(Some(Err(RawError::from(status))));
+                }
+            };
+
+            match this.decode_part(part) {
+                Ok(Some(part)) => return Poll::Ready(Some(Ok(part))),
+                Ok(None) => continue,
+                Err(err) => {
+                    this.active = None;
+                    return Poll::Ready(Some(Err(err)));
+                }
+            }
+        }
+    }
+}
+
 impl ExecuteQueryStream {
     pub fn new(stream: tonic::Streaming<ExecuteQueryResponsePart>) -> Self {
         Self {
-            grpc: Some(stream),
-            next_index: 0,
-            pending_part: None,
-            captured_tx_id: None,
-            finished: false,
-            stats: None,
-            plan: None,
-            #[cfg(test)]
-            test_parts: None,
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from_test_parts(mut parts: Vec<ExecuteQueryResponsePart>) -> Self {
-        parts.reverse();
-        Self {
-            grpc: None,
-            next_index: 0,
-            pending_part: None,
-            captured_tx_id: None,
-            finished: false,
-            stats: None,
-            plan: None,
-            test_parts: Some(parts),
+            active: Some(ActiveQueryResponse {
+                stream,
+                pending_result: None,
+            }),
+            metadata: QueryResponseMetadata::default(),
         }
     }
 
     pub fn stats(&self) -> Option<Duration> {
-        self.stats
+        self.metadata.stats
     }
 
     /// Query plan and AST from `exec_stats`, whichever the server filled in.
@@ -79,441 +101,110 @@ impl ExecuteQueryStream {
     /// In practice only `EXPLAIN` responses carry them: `collect_stats` sends `STATS_MODE_BASIC`,
     /// which reports neither. See [`RawQueryStatsPlan`] for the full matrix.
     pub(crate) fn take_query_plan(&mut self) -> Option<RawQueryStatsPlan> {
-        self.plan.take()
+        self.metadata.plan.take()
     }
 
-    fn absorb_part_metadata(&mut self, part: &ExecuteQueryResponsePart) -> Option<String> {
+    fn absorb_part_metadata(&mut self, part: &ExecuteQueryResponsePart) {
         if let Some(duration) = stats_from_part(part) {
-            self.stats = Some(duration);
+            self.metadata.stats = Some(duration);
         }
         if let Some(plan) = plan_from_part(part) {
-            self.plan = Some(plan);
+            self.metadata.plan = Some(plan);
         }
         if let Some(id) = tx_id_from_part(part) {
-            self.captured_tx_id = Some(id.clone());
-            return Some(id);
-        }
-        None
-    }
-
-    fn ingest_part(&mut self, part: &ExecuteQueryResponsePart) -> RawResult<Option<String>> {
-        let tx_id = self.absorb_part_metadata(part);
-        check_part(part)?;
-        Ok(tx_id)
-    }
-
-    async fn recv_part(&mut self) -> RawResult<Option<ExecuteQueryResponsePart>> {
-        if self.finished {
-            return Ok(None);
-        }
-        if let Some(part) = self.pending_part.take() {
-            return Ok(Some(part));
-        }
-        #[cfg(test)]
-        if let Some(parts) = &mut self.test_parts {
-            return match parts.pop() {
-                Some(part) => Ok(Some(part)),
-                None => {
-                    self.finished = true;
-                    Ok(None)
-                }
-            };
-        }
-        match self.grpc.as_mut() {
-            Some(stream) => match stream.message().await? {
-                Some(part) => Ok(Some(part)),
-                None => {
-                    self.finished = true;
-                    Ok(None)
-                }
-            },
-            None => {
-                self.finished = true;
-                Ok(None)
-            }
+            self.metadata.tx_id = Some(id);
         }
     }
 
-    fn append_part_to_index(
-        by_index: &mut BTreeMap<i64, PartialResultSet>,
+    fn decode_part(
+        &mut self,
         part: ExecuteQueryResponsePart,
-    ) -> RawResult<()> {
-        if part.result_set.is_none() {
-            return Ok(());
-        }
-        let index = part.result_set_index;
-        let partial = by_index.entry(index).or_default();
-        append_rows_from_part(
-            &mut partial.columns,
-            &mut partial.rows,
-            &mut partial.truncated,
-            part,
-        )
-    }
-
-    /// Drain the stream and assemble all result sets, buffering parts by
-    /// `result_set_index`. Required when `concurrent_result_sets=true` because
-    /// the server may interleave parts from different result sets.
-    pub async fn materialize_all_result_sets(&mut self) -> RawResult<Vec<RawResultSet>> {
-        let mut by_index: BTreeMap<i64, PartialResultSet> = BTreeMap::new();
-
-        let result: RawResult<Vec<RawResultSet>> = async {
-            while let Some(part) = self.recv_part().await? {
-                self.ingest_part(&part)?;
-                Self::append_part_to_index(&mut by_index, part)?;
-            }
-
-            Ok(by_index
-                .into_values()
-                .map(|partial| RawResultSet {
-                    columns: partial.columns,
-                    rows: partial.rows,
-                    truncated: partial.truncated,
-                })
-                .collect())
-        }
-        .await;
-
-        drop(self.grpc.take());
-        self.finished = true;
-        result
-    }
-
-    /// Read the first response part so transaction `tx_id` is captured before iteration.
-    pub async fn prime_first_part(&mut self) -> RawResult<()> {
-        if self.pending_part.is_some() || self.grpc.is_none() || self.finished {
-            return Ok(());
-        }
-        let Some(stream) = self.grpc.as_mut() else {
-            return Ok(());
+    ) -> RawResult<Option<RawQueryResultPart>> {
+        self.absorb_part_metadata(&part);
+        check_part(&part)?;
+        let result_set_index = part.result_set_index;
+        let Some(result_set) = part.result_set else {
+            return Ok(None);
         };
-        match stream.message().await? {
-            Some(part) => {
-                self.ingest_part(&part)?;
-                self.pending_part = Some(part);
+        let mut result_set = RawResultSet::try_from(result_set)?;
+        self.apply_result_set_columns(result_set_index, &mut result_set)?;
+        Ok(Some(RawQueryResultPart {
+            result_set_index,
+            result_set,
+        }))
+    }
+
+    fn apply_result_set_columns(
+        &mut self,
+        result_set_index: i64,
+        result_set: &mut RawResultSet,
+    ) -> RawResult<()> {
+        if let Some(columns) = self.metadata.columns_by_result_set.get(&result_set_index) {
+            if result_set.columns.is_empty() {
+                result_set.columns = columns.clone();
+            } else if !columns_compatible(columns, &result_set.columns) {
+                return Err(RawError::custom(format!(
+                    "column metadata mismatch for result set {result_set_index}"
+                )));
             }
-            None => self.finished = true,
+        } else if !result_set.columns.is_empty() {
+            self.metadata
+                .columns_by_result_set
+                .insert(result_set_index, result_set.columns.clone());
+        } else if !result_set.rows.is_empty() {
+            return Err(RawError::custom(format!(
+                "result set {result_set_index} contains rows before column metadata"
+            )));
         }
         Ok(())
     }
 
-    pub async fn next_result_set(&mut self) -> RawResult<Option<(RawResultSet, Option<String>)>> {
-        if self.grpc.is_none() || self.finished {
-            return Ok(None);
+    pub(crate) async fn drain(&mut self) -> RawResult<()> {
+        while self.try_next().await?.is_some() {}
+        Ok(())
+    }
+
+    /// Read the first response part so transaction `tx_id` is captured before iteration.
+    pub async fn prime_first_part(&mut self) -> RawResult<()> {
+        let Some(active) = &mut self.active else {
+            return Ok(());
+        };
+        if active.pending_result.is_some() {
+            return Ok(());
         }
+        let Some(part) = active.stream.message().await? else {
+            self.active = None;
+            return Ok(());
+        };
 
-        let mut columns = Vec::new();
-        let mut rows = Vec::new();
-        let mut truncated = false;
-        let mut tx_id = None;
-
-        loop {
-            let target_index = self.next_index;
-            let part = if let Some(part) = self.pending_part.take() {
-                part
-            } else {
-                match self.grpc.as_mut() {
-                    Some(stream) => match stream.message().await? {
-                        Some(part) => part,
-                        None => {
-                            self.finished = true;
-                            if rows.is_empty() && columns.is_empty() {
-                                return Ok(None);
-                            }
-                            return Ok(Some((
-                                RawResultSet {
-                                    columns,
-                                    rows,
-                                    truncated,
-                                },
-                                tx_id,
-                            )));
-                        }
-                    },
-                    None => {
-                        self.finished = true;
-                        return Ok(None);
-                    }
-                }
-            };
-
-            let tx_id_from_part = self.ingest_part(&part)?;
-            if tx_id_from_part.is_some() {
-                tx_id = tx_id_from_part;
+        match self.decode_part(part) {
+            Ok(Some(part)) => {
+                let Some(active) = &mut self.active else {
+                    return Err(RawError::custom(
+                        "query response became inactive while priming its first part".to_string(),
+                    ));
+                };
+                active.pending_result = Some(part);
             }
-
-            if part.result_set_index < target_index {
-                warn!(
-                    got = part.result_set_index,
-                    expected = target_index,
-                    "dropping stream part with stale result_set_index"
-                );
-                continue;
-            }
-
-            if part.result_set_index > target_index {
-                if rows.is_empty() && columns.is_empty() {
-                    if part.result_set_index > self.next_index + 1 {
-                        warn!(
-                            from = self.next_index,
-                            to = part.result_set_index,
-                            "skipping result set indices in stream"
-                        );
-                    }
-                    self.next_index = part.result_set_index;
-                } else {
-                    self.pending_part = Some(part);
-                    self.next_index += 1;
-                    return Ok(Some((
-                        RawResultSet {
-                            columns,
-                            rows,
-                            truncated,
-                        },
-                        tx_id,
-                    )));
-                }
-            }
-
-            append_rows_from_part(&mut columns, &mut rows, &mut truncated, part)?;
-
-            let stream = self.grpc.as_mut().expect("grpc stream");
-            let collecting_index = self.next_index;
-            match stream.message().await? {
-                Some(next) => {
-                    let tx_id_from_part = self.ingest_part(&next)?;
-                    if tx_id_from_part.is_some() {
-                        tx_id = tx_id_from_part;
-                    }
-                    if next.result_set_index > collecting_index {
-                        self.pending_part = Some(next);
-                        self.next_index += 1;
-                        return Ok(Some((
-                            RawResultSet {
-                                columns,
-                                rows,
-                                truncated,
-                            },
-                            tx_id,
-                        )));
-                    }
-                    if next.result_set_index < collecting_index {
-                        warn!(
-                            got = next.result_set_index,
-                            expected = collecting_index,
-                            "dropping stream part with stale result_set_index"
-                        );
-                        continue;
-                    }
-                    append_rows_from_part(&mut columns, &mut rows, &mut truncated, next)?;
-                }
-                None => {
-                    self.finished = true;
-                    self.next_index += 1;
-                    if rows.is_empty() && columns.is_empty() {
-                        return Ok(None);
-                    }
-                    return Ok(Some((
-                        RawResultSet {
-                            columns,
-                            rows,
-                            truncated,
-                        },
-                        tx_id,
-                    )));
-                }
+            Ok(None) => {}
+            Err(error) => {
+                self.active = None;
+                return Err(error);
             }
         }
+        Ok(())
     }
 
     pub fn take_captured_tx_id(&mut self) -> Option<String> {
-        if let Some(id) = self.captured_tx_id.take() {
-            return Some(id);
-        }
-        self.pending_part.as_ref().and_then(tx_id_from_part)
+        self.metadata.tx_id.take()
     }
 
-    pub(crate) fn in_progress(&self) -> bool {
-        !self.finished
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.is_some()
     }
 
     /// Drop the gRPC stream without draining unread parts (sends RST_STREAM).
     pub fn cancel(&mut self) {
-        if let Some(part) = self.pending_part.take() {
-            self.absorb_part_metadata(&part);
-        }
-        drop(self.grpc.take());
-        self.finished = true;
-    }
-
-    pub async fn close(&mut self) -> RawResult<StreamCloseMeta> {
-        if let Some(part) = self.pending_part.take() {
-            self.absorb_part_metadata(&part);
-        }
-        drop(self.grpc.take());
-        self.finished = true;
-        Ok(StreamCloseMeta {
-            tx_id: self.captured_tx_id.take(),
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::grpc_wrapper::raw_table_service::value::{RawResultSet, RawValue};
-    use ydb_grpc::ydb_proto::query::ExecuteQueryResponsePart;
-    use ydb_grpc::ydb_proto::status_ids::StatusCode;
-
-    fn part_with_row(index: i64, column: &str, value: i64) -> ExecuteQueryResponsePart {
-        let col_type = crate::grpc_wrapper::raw_table_service::value::r#type::RawType::Int64.into();
-        let row = ydb_grpc::ydb_proto::Value {
-            items: vec![RawValue::Int64(value).into()],
-            ..Default::default()
-        };
-        part_with_rows(
-            index,
-            Some(vec![ydb_grpc::ydb_proto::Column {
-                name: column.to_string(),
-                r#type: Some(col_type),
-            }]),
-            vec![row],
-        )
-    }
-
-    fn part_with_rows(
-        index: i64,
-        columns: Option<Vec<ydb_grpc::ydb_proto::Column>>,
-        rows: Vec<ydb_grpc::ydb_proto::Value>,
-    ) -> ExecuteQueryResponsePart {
-        ExecuteQueryResponsePart {
-            status: StatusCode::Success as i32,
-            issues: vec![],
-            result_set_index: index,
-            result_set: columns.map(|columns| ydb_grpc::ydb_proto::ResultSet {
-                columns,
-                rows,
-                truncated: false,
-                ..Default::default()
-            }),
-            exec_stats: None,
-            tx_meta: None,
-        }
-    }
-
-    fn error_part(index: i64) -> ExecuteQueryResponsePart {
-        ExecuteQueryResponsePart {
-            status: StatusCode::BadRequest as i32,
-            issues: vec![],
-            result_set_index: index,
-            result_set: None,
-            exec_stats: None,
-            tx_meta: None,
-        }
-    }
-
-    fn metadata_only_part(index: i64) -> ExecuteQueryResponsePart {
-        ExecuteQueryResponsePart {
-            status: StatusCode::Success as i32,
-            issues: vec![],
-            result_set_index: index,
-            result_set: None,
-            exec_stats: None,
-            tx_meta: None,
-        }
-    }
-
-    fn row_values(set: &RawResultSet) -> Vec<i64> {
-        set.rows
-            .iter()
-            .map(|row| match row.first() {
-                Some(RawValue::Int64(v)) => *v,
-                other => panic!("unexpected cell: {other:?}"),
-            })
-            .collect()
-    }
-
-    #[tokio::test]
-    async fn materialize_all_result_sets_reassembles_interleaved_parts() {
-        // Server may deliver RS0/RS1 parts out of order when concurrent_result_sets=true.
-        let mut stream = ExecuteQueryStream::from_test_parts(vec![
-            part_with_row(0, "a", 10),
-            part_with_row(1, "b", 20),
-            part_with_row(0, "a", 11),
-            part_with_row(1, "b", 21),
-        ]);
-
-        let sets = stream
-            .materialize_all_result_sets()
-            .await
-            .expect("materialize stream");
-
-        assert_eq!(sets.len(), 2);
-        assert_eq!(row_values(&sets[0]), vec![10, 11]);
-        assert_eq!(row_values(&sets[1]), vec![20, 21]);
-    }
-
-    #[tokio::test]
-    async fn materialize_all_result_sets_accepts_empty_continuation_parts() {
-        let col_type = crate::grpc_wrapper::raw_table_service::value::r#type::RawType::Int64.into();
-        let row = |v: i64| ydb_grpc::ydb_proto::Value {
-            items: vec![RawValue::Int64(v).into()],
-            ..Default::default()
-        };
-        let columns = vec![ydb_grpc::ydb_proto::Column {
-            name: "a".to_string(),
-            r#type: Some(col_type),
-        }];
-
-        let mut stream = ExecuteQueryStream::from_test_parts(vec![
-            part_with_rows(0, Some(columns.clone()), vec![row(10)]),
-            part_with_rows(0, None, vec![]),
-            part_with_rows(0, Some(vec![]), vec![row(11)]),
-        ]);
-
-        let sets = stream
-            .materialize_all_result_sets()
-            .await
-            .expect("materialize stream");
-
-        assert_eq!(sets.len(), 1);
-        assert_eq!(row_values(&sets[0]), vec![10, 11]);
-        assert!(stream.finished);
-        assert!(stream.grpc.is_none());
-    }
-
-    #[tokio::test]
-    async fn materialize_all_result_sets_propagates_part_errors() {
-        let mut stream =
-            ExecuteQueryStream::from_test_parts(vec![part_with_row(0, "a", 10), error_part(1)]);
-
-        let err = stream
-            .materialize_all_result_sets()
-            .await
-            .expect_err("expected part status error");
-
-        assert!(matches!(
-            err,
-            crate::grpc_wrapper::raw_errors::RawError::YdbStatus(_)
-        ));
-        assert!(stream.finished);
-        assert!(stream.grpc.is_none());
-    }
-
-    #[tokio::test]
-    async fn materialize_all_result_sets_skips_metadata_only_parts() {
-        let mut stream = ExecuteQueryStream::from_test_parts(vec![
-            metadata_only_part(0),
-            part_with_row(0, "a", 10),
-            metadata_only_part(1),
-        ]);
-
-        let sets = stream
-            .materialize_all_result_sets()
-            .await
-            .expect("materialize stream");
-
-        assert_eq!(sets.len(), 1);
-        assert_eq!(row_values(&sets[0]), vec![10]);
+        self.active = None;
     }
 }

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -173,10 +173,10 @@ pub use grpc_options::{GrpcOptions, HasGrpcOptions};
 pub use client_query::{
     CallBuilder, ClientOneShot, ExecBuilder, ExecCall, ExecuteScriptBuilder,
     ExecuteScriptOperation, ExplainQueryBuilder, ExplainResult, FetchScriptResult,
-    FetchScriptResultsBuilder, FromYdbRow, Interactive, OneResultSet, OneRow, OptionalRow,
-    OptionalRowBuilder, QueryClient, QueryExecutor, QueryRowBuilder, QueryStats, QueryStream,
-    QueryStreamBuilder, ResultSetBuilder, RetryTxAttempt, RetryTxBuilder, Streamed, Transaction,
-    TransactionOptions, TxMode,
+    FetchScriptResultsBuilder, FromYdbRow, Interactive, Materialized, OneResultSet, OneRow,
+    OptionalRow, OptionalRowBuilder, QueryBuilder, QueryClient, QueryExecutor, QueryResultSet,
+    QueryRowBuilder, QueryStats, QueryStream, QueryStreamBuilder, ResultSetBuilder, RetryTxAttempt,
+    RetryTxBuilder, Streamed, Transaction, TransactionOptions, TxMode,
 };
 
 // full enum pub types

--- a/ydb/src/topics_writer_tx_test.rs
+++ b/ydb/src/topics_writer_tx_test.rs
@@ -50,6 +50,7 @@ async fn topic_writer_tx_write_and_commit() -> YdbResult<()> {
                     Ok(true)
                 }
             ))
+            .timeout(Duration::from_secs(10))
             .await?;
     }
 

--- a/ydb/tests/query_stream.rs
+++ b/ydb/tests/query_stream.rs
@@ -1,0 +1,223 @@
+#![recursion_limit = "256"]
+mod mock_server;
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use ydb::{Client, ClientBuilder, SessionPoolSettings, Value, YdbResult};
+use ydb_grpc::ydb_proto::query::ExecuteQueryResponsePart;
+use ydb_grpc::ydb_proto::status_ids::StatusCode;
+use ydb_grpc::ydb_proto::{Column, ResultSet, Type, Value as ProtoValue, r#type, value};
+
+use crate::mock_server::handler::{FromHandlerToService, Handler, Incoming, ReplySink};
+use crate::mock_server::query::{QueryIncoming, QueryReply};
+use crate::mock_server::server::MockServer;
+
+const DATABASE: &str = "/local";
+
+enum StreamEnd {
+    Close,
+    Fail(tonic::Status),
+}
+
+struct StreamScript {
+    parts: Vec<ExecuteQueryResponsePart>,
+    end: StreamEnd,
+}
+
+impl StreamScript {
+    fn closed(parts: Vec<ExecuteQueryResponsePart>) -> Self {
+        Self {
+            parts,
+            end: StreamEnd::Close,
+        }
+    }
+
+    fn failed(parts: Vec<ExecuteQueryResponsePart>, status: tonic::Status) -> Self {
+        Self {
+            parts,
+            end: StreamEnd::Fail(status),
+        }
+    }
+}
+
+struct ScriptedStreamHandler {
+    replies: ReplySink,
+    scripts: Mutex<VecDeque<StreamScript>>,
+}
+
+impl ScriptedStreamHandler {
+    fn new(scripts: impl IntoIterator<Item = StreamScript>) -> Self {
+        Self {
+            replies: ReplySink::default(),
+            scripts: Mutex::new(scripts.into_iter().collect()),
+        }
+    }
+}
+
+impl Handler for ScriptedStreamHandler {
+    fn set_channel(&mut self, tx: FromHandlerToService) {
+        self.replies.set_channel(tx);
+    }
+
+    fn handle(&self, incoming: Incoming) -> Option<Incoming> {
+        let Incoming::Query(QueryIncoming::ExecuteQuery(_, stream_id)) = incoming else {
+            return Some(incoming);
+        };
+        let script = self
+            .scripts
+            .lock()
+            .expect("query stream script lock")
+            .pop_front()
+            .expect("one script per ExecuteQuery call");
+        for part in script.parts {
+            self.replies
+                .send(QueryReply::ExecuteQuery { stream_id, part });
+        }
+        match script.end {
+            StreamEnd::Close => self
+                .replies
+                .send(QueryReply::ExecuteQueryClose { stream_id }),
+            StreamEnd::Fail(status) => self
+                .replies
+                .send(QueryReply::ExecuteQueryFail { stream_id, status }),
+        }
+        None
+    }
+}
+
+async fn make_client(
+    scripts: impl IntoIterator<Item = StreamScript>,
+) -> YdbResult<(Client, MockServer)> {
+    let (server, _replies) = MockServer::start(ScriptedStreamHandler::new(scripts)).await;
+    let client = ClientBuilder::new_from_connection_string(format!(
+        "{}{DATABASE}?use_discovery=false",
+        server.endpoint()
+    ))?
+    .build()
+    .await?
+    .with_session_pool(SessionPoolSettings::new().with_limit(1))
+    .await?;
+    Ok((client, server))
+}
+
+fn result_part(index: i64, column: Option<&str>, values: &[i64]) -> ExecuteQueryResponsePart {
+    let columns = column
+        .map(|name| {
+            vec![Column {
+                name: name.to_string(),
+                r#type: Some(Type {
+                    r#type: Some(r#type::Type::TypeId(r#type::PrimitiveTypeId::Int64 as i32)),
+                }),
+            }]
+        })
+        .unwrap_or_default();
+    ExecuteQueryResponsePart {
+        status: StatusCode::Success as i32,
+        issues: Vec::new(),
+        result_set_index: index,
+        result_set: Some(ResultSet {
+            columns,
+            rows: values
+                .iter()
+                .map(|value| ProtoValue {
+                    items: vec![ProtoValue {
+                        value: Some(value::Value::Int64Value(*value)),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }),
+        exec_stats: None,
+        tx_meta: None,
+    }
+}
+
+fn failed_part(status: StatusCode) -> ExecuteQueryResponsePart {
+    ExecuteQueryResponsePart {
+        status: status as i32,
+        issues: Vec::new(),
+        result_set_index: 0,
+        result_set: None,
+        exec_stats: None,
+        tx_meta: None,
+    }
+}
+
+fn result_values(result_set: ydb::ResultSet, column: &str) -> YdbResult<Vec<i64>> {
+    result_set
+        .rows()
+        .map(|mut row| match row.remove_field_by_name(column)? {
+            Value::Int64(value) => Ok(value),
+            value => Err(ydb::YdbError::Custom(format!(
+                "expected Int64 result value, got {value:?}"
+            ))),
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn query_materializes_all_result_sets() -> YdbResult<()> {
+    let (client, _server) = make_client([StreamScript::closed(vec![
+        result_part(0, Some("first"), &[10]),
+        result_part(1, Some("second"), &[20]),
+        result_part(0, None, &[11]),
+        result_part(1, None, &[21]),
+    ])])
+    .await?;
+    let mut query = client.query_client();
+
+    let mut result_sets = query.query("SELECT 1; SELECT 2").await?.into_iter();
+    let first = result_sets.next().expect("first result set");
+    let second = result_sets.next().expect("second result set");
+
+    assert_eq!(result_values(first, "first")?, vec![10, 11]);
+    assert_eq!(result_values(second, "second")?, vec![20, 21]);
+    assert!(result_sets.next().is_none());
+    assert_eq!(client.session_pool_stats().in_use, 0);
+    assert_eq!(client.session_pool_stats().idle, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_retries_after_response_stream_failure() -> YdbResult<()> {
+    let (client, _server) = make_client([
+        StreamScript::failed(
+            vec![result_part(0, Some("value"), &[1])],
+            tonic::Status::unavailable("response stream failed"),
+        ),
+        StreamScript::closed(vec![result_part(0, Some("value"), &[2])]),
+    ])
+    .await?;
+    let mut query = client.query_client();
+
+    let result_sets = query.query("SELECT 1").idempotent(true).await?;
+
+    assert_eq!(result_sets.len(), 1);
+    assert_eq!(
+        result_values(result_sets.into_iter().next().expect("result set"), "value")?,
+        vec![2]
+    );
+    assert_eq!(client.session_pool_stats().sessions_created, 2);
+    assert_eq!(client.session_pool_stats().idle, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_response_status_error_discards_the_pooled_session() -> YdbResult<()> {
+    let (client, _server) = make_client([
+        StreamScript::closed(vec![failed_part(StatusCode::BadRequest)]),
+        StreamScript::closed(Vec::new()),
+    ])
+    .await?;
+    let mut query = client.query_client();
+
+    assert!(query.query("SELECT broken").await.is_err());
+    assert_eq!(client.session_pool_stats().idle, 0);
+
+    query.exec("SELECT 2").await?;
+    assert_eq!(client.session_pool_stats().sessions_created, 2);
+    Ok(())
+}

--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -502,7 +502,7 @@ async fn commit_via_query_reports_committed() -> YdbResult<()> {
     Ok(())
 }
 
-async fn assert_dropped_transaction_stream_is_not_committed(drain: bool) -> YdbResult<()> {
+async fn assert_dropped_transaction_stream_is_not_committed() -> YdbResult<()> {
     let (handler, tx_lifecycle) = CountingHandler::new();
     let (server, _reply_tx) = MockServer::start(handler).await;
     let client = make_client(&server).await?;
@@ -510,10 +510,7 @@ async fn assert_dropped_transaction_stream_is_not_committed(drain: bool) -> YdbR
     let result = client
         .query_client()
         .retry_tx(closure!(async |tx: &mut Transaction| {
-            let mut stream = tx.query("SELECT 1; SELECT 2").await?;
-            if drain {
-                while stream.next_result_set().await?.is_some() {}
-            }
+            let stream = tx.query("SELECT 1; SELECT 2").await?;
             drop(stream);
             Ok(())
         }))
@@ -533,13 +530,7 @@ async fn assert_dropped_transaction_stream_is_not_committed(drain: bool) -> YdbR
 #[tracing_test::traced_test]
 async fn dropped_partially_consumed_transaction_stream_is_not_committed() -> YdbResult<()> {
     // Opening primes one response part; dropping now leaves the remaining stream unread.
-    assert_dropped_transaction_stream_is_not_committed(false).await
-}
-
-#[tokio::test]
-#[tracing_test::traced_test]
-async fn dropped_drained_transaction_stream_is_not_committed() -> YdbResult<()> {
-    assert_dropped_transaction_stream_is_not_committed(true).await
+    assert_dropped_transaction_stream_is_not_committed().await
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Query provides ResultSet streaming API. Each result set is accumulated in memory. Transport errors must be retried manually.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #618, closes #617

## What is the new behavior?

- Query without transaction provides only materialized API: method returns all ResultSets. Errors are retried internally. 
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Transaction provides partial result set streaming API, where each result set is lazily streamed.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
