### PR TITLE
feat: Graceful client resource lifetime

### DIFF
--- a/tests/slo/native/query/src/storage.rs
+++ b/tests/slo/native/query/src/storage.rs
@@ -20,15 +20,10 @@ pub struct Storage {
 
 impl Storage {
     pub async fn new(fw: &Framework, params: &Params) -> Result<Self, String> {
-        let client = ClientBuilder::new_from_connection_string(&fw.config.connection_string)
-            .map_err(|err| err.to_string())?
-            .build()
-            .await
-            .map_err(|err| err.to_string())?;
-
         let pool_limit = params.pool_size() as usize;
         let session_rpc_timeout = params.read_timeout.max(params.write_timeout);
-        let client = client
+        let client = ClientBuilder::new_from_connection_string(&fw.config.connection_string)
+            .map_err(|err| err.to_string())?
             .with_session_pool(
                 SessionPoolSettings::new()
                     .with_limit(pool_limit)
@@ -36,6 +31,7 @@ impl Storage {
                     .with_session_create_timeout(session_rpc_timeout)
                     .with_session_delete_timeout(session_rpc_timeout),
             )
+            .build()
             .await
             .map_err(|err| err.to_string())?;
 

--- a/tests/slo/native/topic-tx/src/storage.rs
+++ b/tests/slo/native/topic-tx/src/storage.rs
@@ -28,11 +28,6 @@ impl TopicTxStorage {
     pub(super) async fn connect(framework: &Framework, params: Params) -> Result<Self> {
         let client = ClientBuilder::new_from_connection_string(&framework.config.connection_string)
             .context("parse YDB connection string")?
-            .build()
-            .await
-            .context("create YDB client")?;
-
-        let client = client
             .with_session_pool(
                 SessionPoolSettings::new()
                     .with_limit(params.session_pool_size)
@@ -40,8 +35,9 @@ impl TopicTxStorage {
                     .with_session_create_timeout(params.operation_timeout)
                     .with_session_delete_timeout(params.operation_timeout),
             )
+            .build()
             .await
-            .context("initialize query session pool")?;
+            .context("create YDB client")?;
 
         Ok(Self {
             topic_client: client.topic_client(),

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -1,6 +1,7 @@
 use crate::RetrySettings;
 use crate::client_common::DBCredentials;
 use crate::client_coordination::client::CoordinationClient;
+use crate::client_lifetime::ClientLifetime;
 use crate::client_operation::OperationClient;
 use crate::client_query::QueryClient;
 use crate::client_scheme::client::SchemeClient;
@@ -37,6 +38,7 @@ pub struct Client {
     session_pool: SessionPool,
     retry_settings: RetrySettings,
     metrics_names: MetricsNames,
+    lifetime: ClientLifetime,
 }
 
 impl Client {
@@ -69,6 +71,7 @@ impl Client {
             session_pool,
             retry_settings,
             metrics_names,
+            lifetime: ClientLifetime::new(),
         };
         client.wait().await?;
 
@@ -89,6 +92,7 @@ impl Client {
             session_pool: self.session_pool.clone(),
             retry_settings,
             metrics_names: self.metrics_names.clone(),
+            lifetime: self.lifetime.clone(),
         }
     }
 
@@ -98,6 +102,7 @@ impl Client {
     ///
     #[instrument(name = "ydb.Driver.WithSessionPool", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
     pub async fn with_session_pool(self, settings: SessionPoolSettings) -> YdbResult<Self> {
+        self.lifetime.ensure_open()?;
         let session_pool = SessionPool::new_explicit(
             self.connection_manager.clone(),
             self.discovery.clone(),
@@ -106,6 +111,7 @@ impl Client {
         .await?;
         Ok(Self {
             session_pool,
+            lifetime: ClientLifetime::new(),
             ..self
         })
     }
@@ -123,6 +129,7 @@ impl Client {
     /// Shutdown must run while the Tokio runtime that created the driver is still alive.
     #[instrument(name = "ydb.Driver.Shutdown", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
     pub async fn shutdown(self) -> YdbResult<()> {
+        self.lifetime.close();
         self.session_pool.shutdown().await
     }
 
@@ -140,6 +147,7 @@ impl Client {
             self.connection_manager.clone(),
             self.session_pool.clone(),
             self.retry_settings.clone(),
+            self.lifetime.clone(),
         )
     }
 
@@ -154,6 +162,7 @@ impl Client {
             self.session_pool.clone(),
             self.retry_settings.clone(),
             self.metrics_names.clone(),
+            self.lifetime.clone(),
         )
     }
 
@@ -163,7 +172,7 @@ impl Client {
         self.metrics_names
             .client_new_scheme_client_counter
             .increment(1);
-        SchemeClient::new(self.connection_manager.clone())
+        SchemeClient::new(self.connection_manager.clone(), self.lifetime.clone())
     }
 
     /// Create instance of client for topic service
@@ -176,19 +185,24 @@ impl Client {
             self.connection_manager.clone(),
             self.credentials.token_cache.clone(),
             self.executor.clone(),
+            self.lifetime.clone(),
         )
     }
 
     /// Create instance of client for coordination service
     #[instrument(name = "ydb.Driver.CoordinationClient", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database))]
     pub fn coordination_client(&self) -> CoordinationClient {
-        CoordinationClient::new(self.connection_manager.clone())
+        CoordinationClient::new(self.connection_manager.clone(), self.lifetime.clone())
     }
 
     /// Create instance of client for operation service (list/get/forget long-running operations).
     #[instrument(name = "ydb.Driver.OperationClient", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database))]
     pub fn operation_client(&self) -> OperationClient {
-        OperationClient::new(self.connection_manager.clone(), self.retry_settings.clone())
+        OperationClient::new(
+            self.connection_manager.clone(),
+            self.retry_settings.clone(),
+            self.lifetime.clone(),
+        )
     }
 
     /// Wait initialization completed

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -1,7 +1,7 @@
 use crate::RetrySettings;
 use crate::client_common::DBCredentials;
 use crate::client_coordination::client::CoordinationClient;
-use crate::client_lifetime::{ClientLifetime, LiveClientResources};
+use crate::client_lifetime::ClientLifetime;
 use crate::client_operation::OperationClient;
 use crate::client_query::QueryClient;
 use crate::client_scheme::client::SchemeClient;
@@ -21,7 +21,7 @@ use crate::client_topic::client::TopicClient;
 use crate::client_topic::compression::{Executor, default_executor};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
-use tracing::{error, instrument, trace};
+use tracing::{instrument, trace};
 
 /// YDB client.
 ///
@@ -123,8 +123,16 @@ impl Client {
     #[instrument(name = "ydb.Driver.Shutdown", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
     pub async fn shutdown(self) -> YdbResult<()> {
         self.lifetime.close();
-        let session_pool_result = self.session_pool.shutdown().await;
-        finish_shutdown(session_pool_result, self.lifetime.live_resources())
+        self.session_pool.shutdown().await?;
+
+        let live_resources = self.lifetime.live_resources();
+        if live_resources.is_empty() {
+            Ok(())
+        } else {
+            Err(crate::YdbError::custom(format!(
+                "client shutdown completed with live resources: {live_resources}"
+            )))
+        }
     }
 
     pub fn database(&self) -> String {
@@ -214,24 +222,6 @@ impl Client {
         self.load_balancer.wait().await?;
         Ok(())
     }
-}
-
-fn finish_shutdown(
-    session_pool_result: YdbResult<()>,
-    live_resources: LiveClientResources,
-) -> YdbResult<()> {
-    if live_resources.is_empty() {
-        return session_pool_result;
-    }
-
-    if let Err(err) = session_pool_result {
-        error!(%live_resources, "client shutdown failed with live resources");
-        return Err(err);
-    }
-
-    Err(crate::YdbError::custom(format!(
-        "client shutdown completed with live resources: {live_resources}"
-    )))
 }
 
 #[cfg(test)]

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -1,12 +1,12 @@
 use crate::RetrySettings;
 use crate::client_common::DBCredentials;
 use crate::client_coordination::client::CoordinationClient;
-use crate::client_lifetime::ClientLifetime;
 use crate::client_operation::OperationClient;
 use crate::client_query::QueryClient;
 use crate::client_scheme::client::SchemeClient;
 use crate::client_table::TableClient;
 use crate::discovery::Discovery;
+use crate::driver_lifecycle::DriverLifecycle;
 use crate::errors::YdbResult;
 use crate::load_balancer::SharedLoadBalancer;
 use crate::session_pool::SessionPool;
@@ -31,14 +31,12 @@ use tracing::{instrument, trace};
 /// high-concurrency workloads.
 pub struct Client {
     credentials: DBCredentials,
-    load_balancer: SharedLoadBalancer,
-    discovery: Arc<dyn Discovery>,
     connection_manager: GrpcConnectionManager,
     executor: Arc<dyn Executor>,
     session_pool: SessionPool,
     retry_settings: RetrySettings,
     metrics_names: MetricsNames,
-    lifetime: ClientLifetime,
+    lifecycle: DriverLifecycle,
 }
 
 impl Client {
@@ -63,21 +61,18 @@ impl Client {
             session_pool_settings,
         );
 
-        let client = Client {
+        Self::wait_until_ready(&credentials, &discovery, &load_balancer).await?;
+        session_pool.warm_up().await?;
+
+        Ok(Client {
             credentials,
-            load_balancer,
-            discovery,
             connection_manager,
             executor,
             session_pool,
             retry_settings,
             metrics_names,
-            lifetime: ClientLifetime::new(),
-        };
-        client.wait().await?;
-        client.session_pool.warm_up().await?;
-
-        Ok(client)
+            lifecycle: DriverLifecycle::new(),
+        })
     }
 
     /// Replace the driver-wide retry budget.
@@ -103,11 +98,12 @@ impl Client {
     /// shutdown reports their final counts if they remain.
     /// Shutdown must run while the Tokio runtime that created the driver is still alive.
     #[instrument(name = "ydb.Driver.Shutdown", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
-    pub async fn shutdown(self) -> YdbResult<()> {
-        self.lifetime.close();
+    pub async fn shutdown(mut self) -> YdbResult<()> {
+        self.lifecycle.start_shutdown();
         self.session_pool.shutdown().await?;
+        self.lifecycle.complete_shutdown();
 
-        let live_resources = self.lifetime.live_resources();
+        let live_resources = self.lifecycle.live_resources();
         if live_resources.is_empty() {
             Ok(())
         } else {
@@ -131,7 +127,7 @@ impl Client {
             self.connection_manager.clone(),
             self.session_pool.clone(),
             self.retry_settings.clone(),
-            self.lifetime.clone(),
+            &self.lifecycle,
         )
     }
 
@@ -146,7 +142,7 @@ impl Client {
             self.session_pool.clone(),
             self.retry_settings.clone(),
             self.metrics_names.clone(),
-            self.lifetime.clone(),
+            &self.lifecycle,
         )
     }
 
@@ -156,7 +152,7 @@ impl Client {
         self.metrics_names
             .client_new_scheme_client_counter
             .increment(1);
-        SchemeClient::new(self.connection_manager.clone(), self.lifetime.clone())
+        SchemeClient::new(self.connection_manager.clone(), &self.lifecycle)
     }
 
     /// Create instance of client for topic service
@@ -169,14 +165,14 @@ impl Client {
             self.connection_manager.clone(),
             self.credentials.token_cache.clone(),
             self.executor.clone(),
-            self.lifetime.clone(),
+            &self.lifecycle,
         )
     }
 
     /// Create instance of client for coordination service
     #[instrument(name = "ydb.Driver.CoordinationClient", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database))]
     pub fn coordination_client(&self) -> CoordinationClient {
-        CoordinationClient::new(self.connection_manager.clone(), self.lifetime.clone())
+        CoordinationClient::new(self.connection_manager.clone(), &self.lifecycle)
     }
 
     /// Create instance of client for operation service (list/get/forget long-running operations).
@@ -185,7 +181,7 @@ impl Client {
         OperationClient::new(
             self.connection_manager.clone(),
             self.retry_settings.clone(),
-            self.lifetime.clone(),
+            &self.lifecycle,
         )
     }
 
@@ -193,15 +189,19 @@ impl Client {
     ///
     /// Wait all background process get first successfully result and client fully
     /// available to work.
-    #[instrument(name = "ydb.Driver.Initialize", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
-    async fn wait(&self) -> YdbResult<()> {
+    #[instrument(name = "ydb.Driver.Initialize", skip_all, fields(db.system.name = "ydb", db.namespace = %credentials.database), err)]
+    async fn wait_until_ready(
+        credentials: &DBCredentials,
+        discovery: &Arc<dyn Discovery>,
+        load_balancer: &SharedLoadBalancer,
+    ) -> YdbResult<()> {
         trace!("waiting_token");
-        self.credentials.token_cache.wait().await?;
+        credentials.token_cache.wait().await?;
         trace!("wait discovery");
-        self.discovery.wait().await?;
+        discovery.wait().await?;
 
         trace!("wait balancer");
-        self.load_balancer.wait().await?;
+        load_balancer.wait().await?;
         Ok(())
     }
 }

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -1,7 +1,7 @@
 use crate::RetrySettings;
 use crate::client_common::DBCredentials;
 use crate::client_coordination::client::CoordinationClient;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, LiveClientResources};
 use crate::client_operation::OperationClient;
 use crate::client_query::QueryClient;
 use crate::client_scheme::client::SchemeClient;
@@ -21,8 +21,7 @@ use crate::client_topic::client::TopicClient;
 use crate::client_topic::compression::{Executor, default_executor};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_ydb_operation::RawOperationParams;
-use tracing::instrument;
-use tracing::trace;
+use tracing::{error, instrument, trace};
 
 /// YDB client.
 ///
@@ -78,7 +77,8 @@ impl Client {
         Ok(client)
     }
 
-    /// Return a child driver that shares sessions and connections but uses a different retry budget.
+    /// Return a child driver that shares sessions, connections, and shutdown state but uses a
+    /// different retry budget.
     ///
     /// All service clients created from the returned [`Client`] consult `budget` before each retry
     /// (table, query one-shot, [`crate::QueryClient::retry_tx`], operation service, and similar).
@@ -98,7 +98,8 @@ impl Client {
 
     /// Replace the driver session pool (CreateSession + AttachSession) and optionally warm it up.
     ///
-    /// Table and query clients created from this driver share the same pool.
+    /// The returned driver starts a new shutdown lifetime because it owns a different pool. Service
+    /// clients derived before this call remain attached to the previous pool and lifetime.
     ///
     #[instrument(name = "ydb.Driver.WithSessionPool", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
     pub async fn with_session_pool(self, settings: SessionPoolSettings) -> YdbResult<Self> {
@@ -123,14 +124,17 @@ impl Client {
 
     /// Stop the shared session pool and wait for accepted session cleanup attempts to finish.
     ///
-    /// This consumes the driver and stops new session acquisition. Existing session leases may
-    /// finish; shutdown waits for them before deleting idle sessions. Do not use clients,
-    /// sessions, transactions, or streams derived from this driver after shutdown begins.
+    /// This consumes the driver and rejects new work through service clients sharing its shutdown
+    /// state. Existing sessions, transactions, streams, readers, writers, and coordination
+    /// sessions remain usable so they can finish or stop. Shutdown waits for session leases before
+    /// deleting idle sessions. Topic readers, writers, and coordination sessions are not awaited;
+    /// shutdown reports their final counts if they remain.
     /// Shutdown must run while the Tokio runtime that created the driver is still alive.
     #[instrument(name = "ydb.Driver.Shutdown", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
     pub async fn shutdown(self) -> YdbResult<()> {
         self.lifetime.close();
-        self.session_pool.shutdown().await
+        let session_pool_result = self.session_pool.shutdown().await;
+        finish_shutdown(session_pool_result, self.lifetime.live_resources())
     }
 
     pub fn database(&self) -> String {
@@ -220,6 +224,24 @@ impl Client {
         self.load_balancer.wait().await?;
         Ok(())
     }
+}
+
+fn finish_shutdown(
+    session_pool_result: YdbResult<()>,
+    live_resources: LiveClientResources,
+) -> YdbResult<()> {
+    if live_resources.is_empty() {
+        return session_pool_result;
+    }
+
+    if let Err(err) = session_pool_result {
+        error!(%live_resources, "client shutdown failed with live resources");
+        return Err(err);
+    }
+
+    Err(crate::YdbError::custom(format!(
+        "client shutdown completed with live resources: {live_resources}"
+    )))
 }
 
 #[cfg(test)]

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -77,23 +77,13 @@ impl Client {
         Ok(client)
     }
 
-    /// Return a child driver that shares sessions, connections, and shutdown state but uses a
-    /// different retry budget.
+    /// Replace the driver-wide retry budget.
     ///
-    /// All service clients created from the returned [`Client`] consult `budget` before each retry
-    /// (table, query one-shot, [`crate::QueryClient::retry_tx`], operation service, and similar).
-    pub fn clone_with_retry_settings(&self, retry_settings: RetrySettings) -> Self {
-        Self {
-            credentials: self.credentials.clone(),
-            load_balancer: self.load_balancer.clone(),
-            discovery: self.discovery.clone(),
-            connection_manager: self.connection_manager.clone(),
-            executor: self.executor.clone(),
-            session_pool: self.session_pool.clone(),
-            retry_settings,
-            metrics_names: self.metrics_names.clone(),
-            lifetime: self.lifetime.clone(),
-        }
+    /// Service clients created afterward use these settings for table, query, operation, and
+    /// similar retries.
+    pub fn with_retry_settings(mut self, retry_settings: RetrySettings) -> Self {
+        self.retry_settings = retry_settings;
+        self
     }
 
     /// Replace the driver session pool (CreateSession + AttachSession) and optionally warm it up.

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -9,7 +9,7 @@ use crate::client_table::TableClient;
 use crate::discovery::Discovery;
 use crate::errors::YdbResult;
 use crate::load_balancer::SharedLoadBalancer;
-use crate::session_pool::{SessionPool, default_session_pool_settings};
+use crate::session_pool::SessionPool;
 pub use crate::session_pool::{SessionPoolSettings, SessionPoolStats};
 use crate::waiter::Waiter;
 
@@ -27,7 +27,8 @@ use tracing::{instrument, trace};
 ///
 /// The built-in session pool defaults to a limit of **50** concurrent sessions (shared by
 /// table and query clients). The legacy table-only pool used **1000**; use
-/// [`Self::with_session_pool`] with an explicit limit when migrating high-concurrency workloads.
+/// [`crate::ClientBuilder::with_session_pool`] with an explicit limit when migrating
+/// high-concurrency workloads.
 pub struct Client {
     credentials: DBCredentials,
     load_balancer: SharedLoadBalancer,
@@ -49,6 +50,7 @@ impl Client {
         executor: Option<Arc<dyn Executor>>,
         retry_settings: RetrySettings,
         metrics_names: MetricsNames,
+        session_pool_settings: SessionPoolSettings,
     ) -> YdbResult<Self> {
         let executor = match executor {
             Some(e) => e,
@@ -58,7 +60,7 @@ impl Client {
         let session_pool = SessionPool::new_explicit_sync(
             connection_manager.clone(),
             discovery.clone(),
-            default_session_pool_settings(),
+            session_pool_settings,
         );
 
         let client = Client {
@@ -73,6 +75,7 @@ impl Client {
             lifetime: ClientLifetime::new(),
         };
         client.wait().await?;
+        client.session_pool.warm_up().await?;
 
         Ok(client)
     }
@@ -84,27 +87,6 @@ impl Client {
     pub fn with_retry_settings(mut self, retry_settings: RetrySettings) -> Self {
         self.retry_settings = retry_settings;
         self
-    }
-
-    /// Replace the driver session pool (CreateSession + AttachSession) and optionally warm it up.
-    ///
-    /// The returned driver starts a new shutdown lifetime because it owns a different pool. Service
-    /// clients derived before this call remain attached to the previous pool and lifetime.
-    ///
-    #[instrument(name = "ydb.Driver.WithSessionPool", skip_all, fields(db.system.name = "ydb", db.namespace = %self.credentials.database), err)]
-    pub async fn with_session_pool(self, settings: SessionPoolSettings) -> YdbResult<Self> {
-        self.lifetime.ensure_open()?;
-        let session_pool = SessionPool::new_explicit(
-            self.connection_manager.clone(),
-            self.discovery.clone(),
-            settings,
-        )
-        .await?;
-        Ok(Self {
-            session_pool,
-            lifetime: ClientLifetime::new(),
-            ..self
-        })
     }
 
     /// Session pool counters for the driver (shared by table and query clients).

--- a/ydb/src/client.rs
+++ b/ydb/src/client.rs
@@ -39,18 +39,22 @@ pub struct Client {
     lifecycle: DriverLifecycle,
 }
 
+pub(crate) struct ClientInitSettings {
+    pub executor: Option<Arc<dyn Executor>>,
+    pub retry_settings: RetrySettings,
+    pub metrics_names: MetricsNames,
+    pub session_pool_settings: SessionPoolSettings,
+}
+
 impl Client {
     pub(crate) async fn init(
         credentials: DBCredentials,
         discovery: Arc<dyn Discovery>,
         connection_manager: GrpcConnectionManager,
         load_balancer: SharedLoadBalancer,
-        executor: Option<Arc<dyn Executor>>,
-        retry_settings: RetrySettings,
-        metrics_names: MetricsNames,
-        session_pool_settings: SessionPoolSettings,
+        settings: ClientInitSettings,
     ) -> YdbResult<Self> {
-        let executor = match executor {
+        let executor = match settings.executor {
             Some(e) => e,
             None => default_executor()?,
         };
@@ -58,7 +62,7 @@ impl Client {
         let session_pool = SessionPool::new_explicit_sync(
             connection_manager.clone(),
             discovery.clone(),
-            session_pool_settings,
+            settings.session_pool_settings,
         );
 
         Self::wait_until_ready(&credentials, &discovery, &load_balancer).await?;
@@ -69,8 +73,8 @@ impl Client {
             connection_manager,
             executor,
             session_pool,
-            retry_settings,
-            metrics_names,
+            retry_settings: settings.retry_settings,
+            metrics_names: settings.metrics_names,
             lifecycle: DriverLifecycle::new(),
         })
     }

--- a/ydb/src/client_builder.rs
+++ b/ydb/src/client_builder.rs
@@ -14,7 +14,7 @@ use crate::grpc_connection_manager::{
 use crate::grpc_wrapper::auth::AuthGrpcInterceptor;
 use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
 use crate::load_balancer::SharedLoadBalancer;
-use crate::{Client, Credentials, GrpcOptions, HasGrpcOptions, RetrySettings};
+use crate::{Client, Credentials, GrpcOptions, HasGrpcOptions, RetrySettings, SessionPoolSettings};
 use http::Uri;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -237,6 +237,7 @@ pub struct ClientBuilder {
     executor: Option<Arc<dyn Executor>>,
     retry_settings: Option<RetrySettings>,
     driver_name: Option<String>,
+    session_pool_settings: SessionPoolSettings,
 }
 
 impl ClientBuilder {
@@ -330,6 +331,7 @@ impl ClientBuilder {
             self.executor,
             retry_settings,
             metrics_names,
+            self.session_pool_settings,
         )
         .await
     }
@@ -390,6 +392,12 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure the session pool shared by table and query clients.
+    pub fn with_session_pool(mut self, settings: SessionPoolSettings) -> Self {
+        self.session_pool_settings = settings;
+        self
+    }
+
     fn new() -> Self {
         Self {
             credentials: credentials_ref(AccessTokenCredentials::from("")),
@@ -402,6 +410,7 @@ impl ClientBuilder {
             executor: None,
             retry_settings: None,
             driver_name: None,
+            session_pool_settings: SessionPoolSettings::default(),
         }
     }
 }

--- a/ydb/src/client_builder.rs
+++ b/ydb/src/client_builder.rs
@@ -1,3 +1,4 @@
+use crate::client::ClientInitSettings;
 use crate::client_common::{DBCredentials, TokenCache};
 use crate::client_metrics::names::MetricsNames;
 use crate::client_topic::compression::Executor;
@@ -328,10 +329,12 @@ impl ClientBuilder {
             discovery,
             connection_manager,
             load_balancer,
-            self.executor,
-            retry_settings,
-            metrics_names,
-            self.session_pool_settings,
+            ClientInitSettings {
+                executor: self.executor,
+                retry_settings,
+                metrics_names,
+                session_pool_settings: self.session_pool_settings,
+            },
         )
         .await
     }

--- a/ydb/src/client_coordination/client.rs
+++ b/ydb/src/client_coordination/client.rs
@@ -1,4 +1,5 @@
 use crate::client::TimeoutSettings;
+use crate::client_lifetime::ClientLifetime;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_coordination_service::alter_node::RawAlterNodeRequest;
 use crate::grpc_wrapper::raw_coordination_service::config::RawCoordinationNodeConfig;
@@ -18,14 +19,16 @@ pub struct CoordinationClient {
     session_seq_no: u64,
 
     connection_manager: GrpcConnectionManager,
+    lifetime: ClientLifetime,
 }
 
 impl CoordinationClient {
-    pub(crate) fn new(connection_manager: GrpcConnectionManager) -> Self {
+    pub(crate) fn new(connection_manager: GrpcConnectionManager, lifetime: ClientLifetime) -> Self {
         Self {
             timeouts: TimeoutSettings::default(),
             session_seq_no: 0,
             connection_manager,
+            lifetime,
         }
     }
 
@@ -35,6 +38,7 @@ impl CoordinationClient {
         path: String,
         options: SessionOptions,
     ) -> YdbResult<CoordinationSession> {
+        self.lifetime.ensure_open()?;
         let seq_no = self.session_seq_no;
         self.session_seq_no += 1;
 
@@ -99,6 +103,7 @@ impl CoordinationClient {
     pub(crate) async fn raw_client_connection(
         &self,
     ) -> YdbResult<grpc_wrapper::raw_coordination_service::client::RawCoordinationClient> {
+        self.lifetime.ensure_open()?;
         self.connection_manager
             .get_auth_service(
                 grpc_wrapper::raw_coordination_service::client::RawCoordinationClient::new,

--- a/ydb/src/client_coordination/client.rs
+++ b/ydb/src/client_coordination/client.rs
@@ -38,11 +38,18 @@ impl CoordinationClient {
         path: String,
         options: SessionOptions,
     ) -> YdbResult<CoordinationSession> {
-        self.lifetime.ensure_open()?;
+        let resource = self.lifetime.register_coordination_session()?;
         let seq_no = self.session_seq_no;
         self.session_seq_no += 1;
 
-        CoordinationSession::new(path, seq_no, options, self.connection_manager.clone()).await
+        CoordinationSession::new(
+            path,
+            seq_no,
+            options,
+            self.connection_manager.clone(),
+            resource,
+        )
+        .await
     }
 
     #[instrument(name = "ydb.CoordinationClient.CreateNode", skip_all, fields(db.system.name = "ydb", ydb.coordination.path = %path))]

--- a/ydb/src/client_coordination/client.rs
+++ b/ydb/src/client_coordination/client.rs
@@ -1,5 +1,5 @@
 use crate::client::TimeoutSettings;
-use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
+use crate::driver_lifecycle::{DriverGuarded, DriverLifecycle};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_coordination_service::alter_node::RawAlterNodeRequest;
 use crate::grpc_wrapper::raw_coordination_service::config::RawCoordinationNodeConfig;
@@ -14,7 +14,7 @@ use super::list_types::{NodeConfig, NodeDescription};
 
 #[derive(Clone)]
 pub struct CoordinationClient {
-    inner: ShutdownGuarded<CoordinationClientInner>,
+    inner: DriverGuarded<CoordinationClientInner>,
 }
 
 #[derive(Clone)]
@@ -25,9 +25,12 @@ struct CoordinationClientInner {
 }
 
 impl CoordinationClient {
-    pub(crate) fn new(connection_manager: GrpcConnectionManager, lifetime: ClientLifetime) -> Self {
+    pub(crate) fn new(
+        connection_manager: GrpcConnectionManager,
+        lifecycle: &DriverLifecycle,
+    ) -> Self {
         Self {
-            inner: lifetime.guard(CoordinationClientInner {
+            inner: lifecycle.guard(CoordinationClientInner {
                 timeouts: TimeoutSettings::default(),
                 session_seq_no: 0,
                 connection_manager,

--- a/ydb/src/client_coordination/client.rs
+++ b/ydb/src/client_coordination/client.rs
@@ -1,5 +1,5 @@
 use crate::client::TimeoutSettings;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_coordination_service::alter_node::RawAlterNodeRequest;
 use crate::grpc_wrapper::raw_coordination_service::config::RawCoordinationNodeConfig;
@@ -14,21 +14,24 @@ use super::list_types::{NodeConfig, NodeDescription};
 
 #[derive(Clone)]
 pub struct CoordinationClient {
+    inner: ShutdownGuarded<CoordinationClientInner>,
+}
+
+#[derive(Clone)]
+struct CoordinationClientInner {
     timeouts: TimeoutSettings,
-
     session_seq_no: u64,
-
     connection_manager: GrpcConnectionManager,
-    lifetime: ClientLifetime,
 }
 
 impl CoordinationClient {
     pub(crate) fn new(connection_manager: GrpcConnectionManager, lifetime: ClientLifetime) -> Self {
         Self {
-            timeouts: TimeoutSettings::default(),
-            session_seq_no: 0,
-            connection_manager,
-            lifetime,
+            inner: lifetime.guard(CoordinationClientInner {
+                timeouts: TimeoutSettings::default(),
+                session_seq_no: 0,
+                connection_manager,
+            }),
         }
     }
 
@@ -38,15 +41,16 @@ impl CoordinationClient {
         path: String,
         options: SessionOptions,
     ) -> YdbResult<CoordinationSession> {
-        let resource = self.lifetime.register_coordination_session()?;
-        let seq_no = self.session_seq_no;
-        self.session_seq_no += 1;
+        let resource = self.inner.register_coordination_session()?;
+        let inner = self.inner.access_mut()?;
+        let seq_no = inner.session_seq_no;
+        inner.session_seq_no += 1;
 
         CoordinationSession::new(
             path,
             seq_no,
             options,
-            self.connection_manager.clone(),
+            inner.connection_manager.clone(),
             resource,
         )
         .await
@@ -54,13 +58,14 @@ impl CoordinationClient {
 
     #[instrument(name = "ydb.CoordinationClient.CreateNode", skip_all, fields(db.system.name = "ydb", ydb.coordination.path = %path))]
     pub async fn create_node(&mut self, path: String, config: NodeConfig) -> YdbResult<()> {
+        let inner = self.inner.access()?;
         let req = RawCreateNodeRequest {
             config: RawCoordinationNodeConfig::from(config),
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         service.create_node(req).await?;
 
         Ok(())
@@ -68,13 +73,14 @@ impl CoordinationClient {
 
     #[instrument(name = "ydb.CoordinationClient.AlterNode", skip_all, fields(db.system.name = "ydb", ydb.coordination.path = %path))]
     pub async fn alter_node(&mut self, path: String, config: NodeConfig) -> YdbResult<()> {
+        let inner = self.inner.access()?;
         let req = RawAlterNodeRequest {
             config: RawCoordinationNodeConfig::from(config),
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         service.alter_node(req).await?;
 
         Ok(())
@@ -82,12 +88,13 @@ impl CoordinationClient {
 
     #[instrument(name = "ydb.CoordinationClient.DescribeNode", skip_all, fields(db.system.name = "ydb", ydb.coordination.path = %path))]
     pub async fn describe_node(&mut self, path: String) -> YdbResult<NodeDescription> {
+        let inner = self.inner.access()?;
         let req = RawDescribeNodeRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         let result = service.describe_node(req).await?;
         let description = NodeDescription::from(result);
 
@@ -96,21 +103,23 @@ impl CoordinationClient {
 
     #[instrument(name = "ydb.CoordinationClient.DropNode", skip_all, fields(db.system.name = "ydb", ydb.coordination.path = %path))]
     pub async fn drop_node(&mut self, path: String) -> YdbResult<()> {
+        let inner = self.inner.access()?;
         let req = RawDropNodeRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         service.drop_node(req).await?;
 
         Ok(())
     }
+}
 
-    pub(crate) async fn raw_client_connection(
+impl CoordinationClientInner {
+    async fn raw_client_connection(
         &self,
     ) -> YdbResult<grpc_wrapper::raw_coordination_service::client::RawCoordinationClient> {
-        self.lifetime.ensure_open()?;
         self.connection_manager
             .get_auth_service(
                 grpc_wrapper::raw_coordination_service::client::RawCoordinationClient::new,

--- a/ydb/src/client_coordination/session/coordination_session.rs
+++ b/ydb/src/client_coordination/session/coordination_session.rs
@@ -13,6 +13,7 @@ use ydb_grpc::ydb_proto::coordination::{
     session_response::SessionStarted,
 };
 
+use crate::client_lifetime::ClientResourceGuard;
 use crate::{
     AcquireOptions, AcquireOptionsBuilder, DescribeOptions, DescribeOptionsBuilder, SessionOptions,
     YdbError, YdbResult,
@@ -60,6 +61,7 @@ pub struct CoordinationSession {
     protection_key: Vec<u8>,
 
     connection_manager: GrpcConnectionManager,
+    _client_resource: ClientResourceGuard,
 }
 
 #[allow(dead_code)]
@@ -69,6 +71,7 @@ impl CoordinationSession {
         seq_no: u64,
         options: SessionOptions,
         connection_manager: GrpcConnectionManager,
+        client_resource: ClientResourceGuard,
     ) -> YdbResult<Self> {
         let mut coordination_service = connection_manager
             .get_auth_service(
@@ -148,6 +151,7 @@ impl CoordinationSession {
             protection_key,
 
             connection_manager,
+            _client_resource: client_resource,
         })
     }
 
@@ -366,5 +370,12 @@ impl CoordinationSession {
             }
         }
         Ok(())
+    }
+}
+
+impl Drop for CoordinationSession {
+    fn drop(&mut self) {
+        self.cancellation_token.cancel();
+        self.receiver_loop.abort();
     }
 }

--- a/ydb/src/client_coordination/session/coordination_session.rs
+++ b/ydb/src/client_coordination/session/coordination_session.rs
@@ -13,7 +13,7 @@ use ydb_grpc::ydb_proto::coordination::{
     session_response::SessionStarted,
 };
 
-use crate::client_lifetime::ClientResourceGuard;
+use crate::driver_lifecycle::DriverResourceGuard;
 use crate::{
     AcquireOptions, AcquireOptionsBuilder, DescribeOptions, DescribeOptionsBuilder, SessionOptions,
     YdbError, YdbResult,
@@ -61,7 +61,7 @@ pub struct CoordinationSession {
     protection_key: Vec<u8>,
 
     connection_manager: GrpcConnectionManager,
-    _client_resource: ClientResourceGuard,
+    _driver_resource: DriverResourceGuard,
 }
 
 #[allow(dead_code)]
@@ -71,7 +71,7 @@ impl CoordinationSession {
         seq_no: u64,
         options: SessionOptions,
         connection_manager: GrpcConnectionManager,
-        client_resource: ClientResourceGuard,
+        driver_resource: DriverResourceGuard,
     ) -> YdbResult<Self> {
         let mut coordination_service = connection_manager
             .get_auth_service(
@@ -151,7 +151,7 @@ impl CoordinationSession {
             protection_key,
 
             connection_manager,
-            _client_resource: client_resource,
+            _driver_resource: driver_resource,
         })
     }
 

--- a/ydb/src/client_lifetime.rs
+++ b/ydb/src/client_lifetime.rs
@@ -14,6 +14,13 @@ pub(crate) struct ClientLifetime {
     inner: Arc<ClientLifetimeInner>,
 }
 
+/// A value that can only be accessed while its driver accepts new work.
+#[derive(Clone)]
+pub(crate) struct ShutdownGuarded<T> {
+    lifetime: ClientLifetime,
+    value: T,
+}
+
 struct ClientLifetimeInner {
     closed: AtomicBool,
     topic_readers: ResourceCounter,
@@ -44,8 +51,11 @@ impl Display for LiveClientResources {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             formatter,
-            "topic readers={}, topic writers={}, coordination sessions={}",
-            self.topic_readers, self.topic_writers, self.coordination_sessions
+            "topic readers={topic_readers}, topic writers={topic_writers}, \
+             coordination sessions={coordination_sessions}",
+            topic_readers = self.topic_readers,
+            topic_writers = self.topic_writers,
+            coordination_sessions = self.coordination_sessions,
         )
     }
 }
@@ -104,6 +114,13 @@ impl ClientLifetime {
         }
     }
 
+    pub(crate) fn guard<T>(&self, value: T) -> ShutdownGuarded<T> {
+        ShutdownGuarded {
+            lifetime: self.clone(),
+            value,
+        }
+    }
+
     pub(crate) fn close(&self) {
         self.inner.closed.store(true, Ordering::Relaxed);
         self.inner.topic_readers.close();
@@ -129,5 +146,29 @@ impl ClientLifetime {
             topic_writers: self.inner.topic_writers.active(),
             coordination_sessions: self.inner.coordination_sessions.active(),
         }
+    }
+}
+
+impl<T> ShutdownGuarded<T> {
+    pub(crate) fn access(&self) -> YdbResult<&T> {
+        self.lifetime.ensure_open()?;
+        Ok(&self.value)
+    }
+
+    pub(crate) fn access_mut(&mut self) -> YdbResult<&mut T> {
+        self.lifetime.ensure_open()?;
+        Ok(&mut self.value)
+    }
+
+    pub(crate) fn register_topic_reader(&self) -> YdbResult<ClientResourceGuard> {
+        self.lifetime.register_topic_reader()
+    }
+
+    pub(crate) fn register_topic_writer(&self) -> YdbResult<ClientResourceGuard> {
+        self.lifetime.register_topic_writer()
+    }
+
+    pub(crate) fn register_coordination_session(&self) -> YdbResult<ClientResourceGuard> {
+        self.lifetime.register_coordination_session()
     }
 }

--- a/ydb/src/client_lifetime.rs
+++ b/ydb/src/client_lifetime.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::{YdbError, YdbResult};
+
+/// Shared shutdown state for a driver and every service client derived from it.
+#[derive(Clone)]
+pub(crate) struct ClientLifetime {
+    inner: Arc<ClientLifetimeInner>,
+}
+
+struct ClientLifetimeInner {
+    closed: AtomicBool,
+}
+
+impl ClientLifetime {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(ClientLifetimeInner {
+                closed: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    pub(crate) fn ensure_open(&self) -> YdbResult<()> {
+        if self.inner.closed.load(Ordering::Relaxed) {
+            Err(YdbError::custom("client shutdown has started"))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn close(&self) {
+        self.inner.closed.store(true, Ordering::Relaxed);
+    }
+}

--- a/ydb/src/client_lifetime.rs
+++ b/ydb/src/client_lifetime.rs
@@ -1,7 +1,12 @@
+use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+
 use crate::{YdbError, YdbResult};
+
+const RESOURCE_COUNTER_CAPACITY: usize = Semaphore::MAX_PERMITS;
 
 /// Shared shutdown state for a driver and every service client derived from it.
 #[derive(Clone)]
@@ -11,6 +16,72 @@ pub(crate) struct ClientLifetime {
 
 struct ClientLifetimeInner {
     closed: AtomicBool,
+    topic_readers: ResourceCounter,
+    topic_writers: ResourceCounter,
+    coordination_sessions: ResourceCounter,
+}
+
+/// Opaque ownership token held by one live client resource.
+pub(crate) struct ClientResourceGuard {
+    _permit: OwnedSemaphorePermit,
+}
+
+/// Final snapshot of resources that still depend on a shutting-down client.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LiveClientResources {
+    pub(crate) topic_readers: usize,
+    pub(crate) topic_writers: usize,
+    pub(crate) coordination_sessions: usize,
+}
+
+impl LiveClientResources {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.topic_readers == 0 && self.topic_writers == 0 && self.coordination_sessions == 0
+    }
+}
+
+impl Display for LiveClientResources {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "topic readers={}, topic writers={}, coordination sessions={}",
+            self.topic_readers, self.topic_writers, self.coordination_sessions
+        )
+    }
+}
+
+/// A closeable RAII counter. Permits represent live resources, not concurrency capacity.
+struct ResourceCounter {
+    name: &'static str,
+    permits: Arc<Semaphore>,
+}
+
+impl ResourceCounter {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            permits: Arc::new(Semaphore::new(RESOURCE_COUNTER_CAPACITY)),
+        }
+    }
+
+    fn register(&self) -> YdbResult<ClientResourceGuard> {
+        match self.permits.clone().try_acquire_owned() {
+            Ok(permit) => Ok(ClientResourceGuard { _permit: permit }),
+            Err(TryAcquireError::Closed) => Err(YdbError::custom("client shutdown has started")),
+            Err(TryAcquireError::NoPermits) => Err(YdbError::InternalError(format!(
+                "{} resource counter exhausted",
+                self.name
+            ))),
+        }
+    }
+
+    fn close(&self) {
+        self.permits.close();
+    }
+
+    fn active(&self) -> usize {
+        RESOURCE_COUNTER_CAPACITY - self.permits.available_permits()
+    }
 }
 
 impl ClientLifetime {
@@ -18,6 +89,9 @@ impl ClientLifetime {
         Self {
             inner: Arc::new(ClientLifetimeInner {
                 closed: AtomicBool::new(false),
+                topic_readers: ResourceCounter::new("topic reader"),
+                topic_writers: ResourceCounter::new("topic writer"),
+                coordination_sessions: ResourceCounter::new("coordination session"),
             }),
         }
     }
@@ -32,5 +106,28 @@ impl ClientLifetime {
 
     pub(crate) fn close(&self) {
         self.inner.closed.store(true, Ordering::Relaxed);
+        self.inner.topic_readers.close();
+        self.inner.topic_writers.close();
+        self.inner.coordination_sessions.close();
+    }
+
+    pub(crate) fn register_topic_reader(&self) -> YdbResult<ClientResourceGuard> {
+        self.inner.topic_readers.register()
+    }
+
+    pub(crate) fn register_topic_writer(&self) -> YdbResult<ClientResourceGuard> {
+        self.inner.topic_writers.register()
+    }
+
+    pub(crate) fn register_coordination_session(&self) -> YdbResult<ClientResourceGuard> {
+        self.inner.coordination_sessions.register()
+    }
+
+    pub(crate) fn live_resources(&self) -> LiveClientResources {
+        LiveClientResources {
+            topic_readers: self.inner.topic_readers.active(),
+            topic_writers: self.inner.topic_writers.active(),
+            coordination_sessions: self.inner.coordination_sessions.active(),
+        }
     }
 }

--- a/ydb/src/client_operation/client.rs
+++ b/ydb/src/client_operation/client.rs
@@ -2,7 +2,7 @@ use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
 use crate::RefWithLifetime;
 use crate::async_closure::AsyncFnMut;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::closure;
 use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
@@ -19,9 +19,13 @@ use tracing::instrument;
 
 #[derive(Clone)]
 pub struct OperationClient {
+    inner: ShutdownGuarded<OperationClientInner>,
+}
+
+#[derive(Clone)]
+struct OperationClientInner {
     connection_manager: GrpcConnectionManager,
     retry_settings: RetrySettings,
-    lifetime: ClientLifetime,
 }
 
 impl OperationClient {
@@ -31,9 +35,10 @@ impl OperationClient {
         lifetime: ClientLifetime,
     ) -> Self {
         Self {
-            connection_manager,
-            retry_settings,
-            lifetime,
+            inner: lifetime.guard(OperationClientInner {
+                connection_manager,
+                retry_settings,
+            }),
         }
     }
 
@@ -54,8 +59,9 @@ impl OperationClient {
     where
         F: AsyncFnMut<RefWithLifetime<RetryState>, Output = YdbResult<T>>,
     {
-        self.lifetime.ensure_open()?;
-        self.retry_settings
+        self.inner
+            .access()?
+            .retry_settings
             .clone()
             .with_deadline(opts.timeout)
             .retry_on_retriable_errors(Idempotency::Idempotent, attempt_fn)
@@ -174,7 +180,9 @@ impl OperationClient {
     }
 
     async fn raw_client(&self) -> YdbResult<RawOperationClient> {
-        self.connection_manager
+        self.inner
+            .access()?
+            .connection_manager
             .get_auth_service(RawOperationClient::new)
             .await
     }

--- a/ydb/src/client_operation/client.rs
+++ b/ydb/src/client_operation/client.rs
@@ -2,6 +2,7 @@ use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
 use crate::RefWithLifetime;
 use crate::async_closure::AsyncFnMut;
+use crate::client_lifetime::ClientLifetime;
 use crate::closure;
 use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
@@ -20,16 +21,19 @@ use tracing::instrument;
 pub struct OperationClient {
     connection_manager: GrpcConnectionManager,
     retry_settings: RetrySettings,
+    lifetime: ClientLifetime,
 }
 
 impl OperationClient {
     pub(crate) fn new(
         connection_manager: GrpcConnectionManager,
         retry_settings: RetrySettings,
+        lifetime: ClientLifetime,
     ) -> Self {
         Self {
             connection_manager,
             retry_settings,
+            lifetime,
         }
     }
 
@@ -50,6 +54,7 @@ impl OperationClient {
     where
         F: AsyncFnMut<RefWithLifetime<RetryState>, Output = YdbResult<T>>,
     {
+        self.lifetime.ensure_open()?;
         self.retry_settings
             .clone()
             .with_deadline(opts.timeout)

--- a/ydb/src/client_operation/client.rs
+++ b/ydb/src/client_operation/client.rs
@@ -2,8 +2,8 @@ use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
 use crate::RefWithLifetime;
 use crate::async_closure::AsyncFnMut;
-use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::closure;
+use crate::driver_lifecycle::{DriverGuarded, DriverLifecycle};
 use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_operation_service::client::RawOperationClient;
@@ -19,7 +19,7 @@ use tracing::instrument;
 
 #[derive(Clone)]
 pub struct OperationClient {
-    inner: ShutdownGuarded<OperationClientInner>,
+    inner: DriverGuarded<OperationClientInner>,
 }
 
 #[derive(Clone)]
@@ -32,10 +32,10 @@ impl OperationClient {
     pub(crate) fn new(
         connection_manager: GrpcConnectionManager,
         retry_settings: RetrySettings,
-        lifetime: ClientLifetime,
+        lifecycle: &DriverLifecycle,
     ) -> Self {
         Self {
-            inner: lifetime.guard(OperationClientInner {
+            inner: lifecycle.guard(OperationClientInner {
                 connection_manager,
                 retry_settings,
             }),

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -49,6 +49,7 @@ impl CallOptions {
 #[derive(Clone)]
 pub(crate) struct ClientExecContext {
     inner: DriverGuarded<ClientExecContextInner>,
+    pub metrics_names: MetricsNames,
 }
 
 #[derive(Clone)]
@@ -56,7 +57,6 @@ pub(crate) struct ClientExecContextInner {
     pub connection_manager: GrpcConnectionManager,
     pub session_pool: SessionPool,
     pub retry_settings: RetrySettings,
-    pub metrics_names: MetricsNames,
 }
 
 impl ClientExecContext {
@@ -72,8 +72,8 @@ impl ClientExecContext {
                 connection_manager,
                 session_pool,
                 retry_settings,
-                metrics_names,
             }),
+            metrics_names,
         }
     }
 

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -6,7 +6,7 @@ use futures_util::TryFutureExt;
 use tokio::time::timeout;
 
 use crate::client_metrics::names::MetricsNames;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
@@ -48,11 +48,38 @@ impl CallOptions {
 
 #[derive(Clone)]
 pub(crate) struct ClientExecContext {
+    inner: ShutdownGuarded<ClientExecContextInner>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ClientExecContextInner {
     pub connection_manager: GrpcConnectionManager,
     pub session_pool: SessionPool,
     pub retry_settings: RetrySettings,
     pub metrics_names: MetricsNames,
-    pub lifetime: ClientLifetime,
+}
+
+impl ClientExecContext {
+    pub(crate) fn new(
+        connection_manager: GrpcConnectionManager,
+        session_pool: SessionPool,
+        retry_settings: RetrySettings,
+        metrics_names: MetricsNames,
+        lifetime: ClientLifetime,
+    ) -> Self {
+        Self {
+            inner: lifetime.guard(ClientExecContextInner {
+                connection_manager,
+                session_pool,
+                retry_settings,
+                metrics_names,
+            }),
+        }
+    }
+
+    pub(crate) fn access(&self) -> YdbResult<&ClientExecContextInner> {
+        self.inner.access()
+    }
 }
 
 /// Opened client stream and its explicit session ownership mode.
@@ -479,6 +506,7 @@ async fn client_implicit_session_request(
     concurrent_result_sets: bool,
 ) -> YdbResult<(RawQueryClient, RawExecuteQueryRequest)> {
     let client = ctx
+        .access()?
         .connection_manager
         .get_auth_service(RawQueryClient::new)
         .await?;
@@ -523,10 +551,11 @@ async fn open_pooled_query_stream(
     concurrent_result_sets: bool,
 ) -> YdbResult<OpenedClientQueryStream> {
     let tx_control = tx_control_for_client(opts)?;
-    let lease = ctx.session_pool.acquire_explicit().await?;
+    let lease = ctx.access()?.session_pool.acquire_explicit().await?;
     let result = async {
         lease.ensure_healthy()?;
         let mut client = ctx
+            .access()?
             .connection_manager
             .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
             .await?;
@@ -560,8 +589,8 @@ pub(crate) async fn client_begin_stream(
     opts: CallOptions,
     concurrent_result_sets: bool,
 ) -> YdbResult<OpenedClientQueryStream> {
-    ctx.lifetime.ensure_open()?;
-    ctx.retry_settings
+    ctx.access()?
+        .retry_settings
         .clone()
         .with_deadline(opts.timeout)
         .retry_on_retriable_errors(

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -6,7 +6,7 @@ use futures_util::TryFutureExt;
 use tokio::time::timeout;
 
 use crate::client_metrics::names::MetricsNames;
-use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
+use crate::driver_lifecycle::{DriverGuarded, DriverLifecycle};
 use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
@@ -48,7 +48,7 @@ impl CallOptions {
 
 #[derive(Clone)]
 pub(crate) struct ClientExecContext {
-    inner: ShutdownGuarded<ClientExecContextInner>,
+    inner: DriverGuarded<ClientExecContextInner>,
 }
 
 #[derive(Clone)]
@@ -65,10 +65,10 @@ impl ClientExecContext {
         session_pool: SessionPool,
         retry_settings: RetrySettings,
         metrics_names: MetricsNames,
-        lifetime: ClientLifetime,
+        lifecycle: &DriverLifecycle,
     ) -> Self {
         Self {
-            inner: lifetime.guard(ClientExecContextInner {
+            inner: lifecycle.guard(ClientExecContextInner {
                 connection_manager,
                 session_pool,
                 retry_settings,

--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -6,6 +6,7 @@ use futures_util::TryFutureExt;
 use tokio::time::timeout;
 
 use crate::client_metrics::names::MetricsNames;
+use crate::client_lifetime::ClientLifetime;
 use crate::errors::{Idempotency, YdbError, YdbResult};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_query_service::client::RawQueryClient;
@@ -51,6 +52,7 @@ pub(crate) struct ClientExecContext {
     pub session_pool: SessionPool,
     pub retry_settings: RetrySettings,
     pub metrics_names: MetricsNames,
+    pub lifetime: ClientLifetime,
 }
 
 /// Opened client stream and its explicit session ownership mode.
@@ -558,6 +560,7 @@ pub(crate) async fn client_begin_stream(
     opts: CallOptions,
     concurrent_result_sets: bool,
 ) -> YdbResult<OpenedClientQueryStream> {
+    ctx.lifetime.ensure_open()?;
     ctx.retry_settings
         .clone()
         .with_deadline(opts.timeout)

--- a/ydb/src/client_query/explain_query.rs
+++ b/ydb/src/client_query/explain_query.rs
@@ -76,6 +76,7 @@ async fn explain_query_once(
     text: &str,
 ) -> YdbResult<Option<RawQueryStatsPlan>> {
     let mut client = ctx
+        .access()?
         .connection_manager
         .get_auth_service(RawQueryClient::new)
         .await?;
@@ -97,9 +98,9 @@ async fn explain_query(
     text: String,
     timeout: Option<Duration>,
 ) -> YdbResult<ExplainResult> {
-    ctx.lifetime.ensure_open()?;
     // EXPLAIN never executes the query, so retrying is always safe.
     let plan = ctx
+        .access()?
         .retry_settings
         .clone()
         .with_deadline(timeout)
@@ -149,8 +150,8 @@ mod unit_tests {
     /// Context pointing at a closed port: every attempt fails with a retriable transport error,
     /// so the only thing that can end the retry loop is the deadline.
     fn unreachable_ctx() -> ClientExecContext {
-        ClientExecContext {
-            connection_manager: GrpcConnectionManager::new(
+        ClientExecContext::new(
+            GrpcConnectionManager::new(
                 SharedLoadBalancer::new_with_balancer(Box::new(StaticLoadBalancer::new(
                     Uri::from_static("http://127.0.0.1:1"),
                 ))),
@@ -158,11 +159,11 @@ mod unit_tests {
                 MultiInterceptor::new(),
                 GrpcOptions::default(),
             ),
-            session_pool: SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1)),
-            retry_settings: RetrySettings::with_default_backoff(),
-            metrics_names: MetricsNames::new(None),
-            lifetime: ClientLifetime::new(),
-        }
+            SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1)),
+            RetrySettings::with_default_backoff(),
+            MetricsNames::new(None),
+            ClientLifetime::new(),
+        )
     }
 
     #[tokio::test]

--- a/ydb/src/client_query/explain_query.rs
+++ b/ydb/src/client_query/explain_query.rs
@@ -97,6 +97,7 @@ async fn explain_query(
     text: String,
     timeout: Option<Duration>,
 ) -> YdbResult<ExplainResult> {
+    ctx.lifetime.ensure_open()?;
     // EXPLAIN never executes the query, so retrying is always safe.
     let plan = ctx
         .retry_settings
@@ -137,6 +138,7 @@ mod unit_tests {
     use super::*;
     use crate::GrpcOptions;
     use crate::client_metrics::names::MetricsNames;
+    use crate::client_lifetime::ClientLifetime;
     use crate::grpc_connection_manager::GrpcConnectionManager;
     use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
     use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
@@ -159,6 +161,7 @@ mod unit_tests {
             session_pool: SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1)),
             retry_settings: RetrySettings::with_default_backoff(),
             metrics_names: MetricsNames::new(None),
+            lifetime: ClientLifetime::new(),
         }
     }
 

--- a/ydb/src/client_query/explain_query.rs
+++ b/ydb/src/client_query/explain_query.rs
@@ -139,13 +139,19 @@ mod unit_tests {
     use super::*;
     use crate::GrpcOptions;
     use crate::client_metrics::names::MetricsNames;
-    use crate::client_lifetime::ClientLifetime;
+    use crate::driver_lifecycle::DriverLifecycle;
     use crate::grpc_connection_manager::GrpcConnectionManager;
     use crate::grpc_wrapper::runtime_interceptors::MultiInterceptor;
     use crate::load_balancer::{SharedLoadBalancer, StaticLoadBalancer};
     use crate::retry_settings::RetrySettings;
     use crate::session_pool::{SessionPool, SessionPoolSettings};
     use http::Uri;
+
+    fn test_driver_lifecycle() -> DriverLifecycle {
+        let mut lifecycle = DriverLifecycle::new();
+        lifecycle.complete_shutdown();
+        lifecycle
+    }
 
     /// Context pointing at a closed port: every attempt fails with a retriable transport error,
     /// so the only thing that can end the retry loop is the deadline.
@@ -162,7 +168,7 @@ mod unit_tests {
             SessionPool::new_explicit_bench(SessionPoolSettings::new().with_limit(1)),
             RetrySettings::with_default_backoff(),
             MetricsNames::new(None),
-            ClientLifetime::new(),
+            &test_driver_lifecycle(),
         )
     }
 

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -168,6 +168,7 @@ impl QueryClient {
         session_pool: SessionPool,
         retry_settings: RetrySettings,
         metrics_names: MetricsNames,
+        lifetime: crate::client_lifetime::ClientLifetime,
     ) -> Self {
         Self {
             ctx: ClientExecContext {
@@ -175,6 +176,7 @@ impl QueryClient {
                 session_pool,
                 retry_settings,
                 metrics_names,
+                lifetime,
             },
         }
     }
@@ -293,6 +295,10 @@ impl QueryClient {
         T: Send,
     {
         ensure_interactive_tx_mode(options.mode())?;
+        self.ctx
+            .lifetime
+            .ensure_open()
+            .map_err(YdbOrCustomerError::from)?;
         let result = self
             .ctx
             .retry_settings
@@ -585,6 +591,7 @@ mod unit_tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use crate::GrpcOptions;
+    use crate::client_lifetime::ClientLifetime;
     use crate::errors::YdbStatusError;
     use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
     use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
@@ -691,6 +698,7 @@ mod unit_tests {
             pool.clone(),
             RetrySettings::dont_retry(),
             MetricsNames::new(None),
+            ClientLifetime::new(),
         );
         let observed_pool = pool.clone();
 
@@ -716,6 +724,7 @@ mod unit_tests {
             pool,
             RetrySettings::dont_retry(),
             MetricsNames::new(None),
+            ClientLifetime::new(),
         );
         let callback_called = Arc::new(AtomicBool::new(false));
         let observed_called = callback_called.clone();
@@ -742,6 +751,7 @@ mod unit_tests {
             pool,
             RetrySettings::dont_retry(),
             MetricsNames::new(None),
+            ClientLifetime::new(),
         );
         let callback_called = Arc::new(AtomicBool::new(false));
 
@@ -781,6 +791,7 @@ mod unit_tests {
             pool,
             RetrySettings::with_default_backoff(),
             MetricsNames::new(None),
+            ClientLifetime::new(),
         );
         let callback_calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = callback_calls.clone();

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -171,13 +171,13 @@ impl QueryClient {
         lifetime: crate::client_lifetime::ClientLifetime,
     ) -> Self {
         Self {
-            ctx: ClientExecContext {
+            ctx: ClientExecContext::new(
                 connection_manager,
                 session_pool,
                 retry_settings,
                 metrics_names,
                 lifetime,
-            },
+            ),
         }
     }
 
@@ -295,14 +295,8 @@ impl QueryClient {
         T: Send,
     {
         ensure_interactive_tx_mode(options.mode())?;
-        self.ctx
-            .lifetime
-            .ensure_open()
-            .map_err(YdbOrCustomerError::from)?;
-        let result = self
-            .ctx
-            .retry_settings
-            .clone()
+        let retry_settings = self.ctx.access()?.retry_settings.clone();
+        let result = retry_settings
             .with_deadline(wall_timeout)
             .retry(closure!(
                 [&client = self, callback, &options],
@@ -338,9 +332,10 @@ impl QueryClient {
         options: TransactionOptions,
         retry_deadline: Option<Instant>,
     ) -> YdbResult<Transaction> {
-        let lease = self.ctx.session_pool.acquire_explicit().await?;
+        let lease = self.ctx.access()?.session_pool.acquire_explicit().await?;
         let query_client = match self
             .ctx
+            .access()?
             .connection_manager
             .get_auth_service_to_node(RawQueryClient::new, lease.node_uri())
             .await

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -168,7 +168,7 @@ impl QueryClient {
         session_pool: SessionPool,
         retry_settings: RetrySettings,
         metrics_names: MetricsNames,
-        lifetime: crate::client_lifetime::ClientLifetime,
+        lifecycle: &crate::driver_lifecycle::DriverLifecycle,
     ) -> Self {
         Self {
             ctx: ClientExecContext::new(
@@ -176,7 +176,7 @@ impl QueryClient {
                 session_pool,
                 retry_settings,
                 metrics_names,
-                lifetime,
+                lifecycle,
             ),
         }
     }
@@ -586,7 +586,7 @@ mod unit_tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use crate::GrpcOptions;
-    use crate::client_lifetime::ClientLifetime;
+    use crate::driver_lifecycle::DriverLifecycle;
     use crate::errors::YdbStatusError;
     use crate::grpc_wrapper::raw_query_service::stream::ExecuteQueryStream;
     use crate::grpc_wrapper::raw_table_service::value::r#type::RawType;
@@ -599,6 +599,12 @@ mod unit_tests {
     use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
     use builders::{exactly_one_set, take_single_row};
+
+    fn test_driver_lifecycle() -> DriverLifecycle {
+        let mut lifecycle = DriverLifecycle::new();
+        lifecycle.complete_shutdown();
+        lifecycle
+    }
 
     struct AbortCounterHook(Arc<AtomicUsize>);
 
@@ -693,7 +699,7 @@ mod unit_tests {
             pool.clone(),
             RetrySettings::dont_retry(),
             MetricsNames::new(None),
-            ClientLifetime::new(),
+            &test_driver_lifecycle(),
         );
         let observed_pool = pool.clone();
 
@@ -719,7 +725,7 @@ mod unit_tests {
             pool,
             RetrySettings::dont_retry(),
             MetricsNames::new(None),
-            ClientLifetime::new(),
+            &test_driver_lifecycle(),
         );
         let callback_called = Arc::new(AtomicBool::new(false));
         let observed_called = callback_called.clone();
@@ -746,7 +752,7 @@ mod unit_tests {
             pool,
             RetrySettings::dont_retry(),
             MetricsNames::new(None),
-            ClientLifetime::new(),
+            &test_driver_lifecycle(),
         );
         let callback_called = Arc::new(AtomicBool::new(false));
 
@@ -786,7 +792,7 @@ mod unit_tests {
             pool,
             RetrySettings::with_default_backoff(),
             MetricsNames::new(None),
-            ClientLifetime::new(),
+            &test_driver_lifecycle(),
         );
         let callback_calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = callback_calls.clone();

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -156,6 +156,7 @@ async fn client_execute_script(
     opts: CallOptions,
     results_ttl: Duration,
 ) -> YdbResult<ExecuteScriptOperation> {
+    ctx.lifetime.ensure_open()?;
     // Unlike FetchScriptResults, ExecuteScript is not retried: a server-side start
     // followed by a client transport error would spawn duplicate long-running ops.
     client_execute_script_once(ctx, &text, &params, &opts, results_ttl).await
@@ -211,6 +212,7 @@ async fn client_fetch_script_results(
     rows_limit: i64,
     opts: CallOptions,
 ) -> YdbResult<FetchScriptResult> {
+    ctx.lifetime.ensure_open()?;
     // FetchScriptResults is always safe to retry (aligned with Go SDK).
     ctx.retry_settings
         .clone()

--- a/ydb/src/client_query/script.rs
+++ b/ydb/src/client_query/script.rs
@@ -149,6 +149,9 @@ impl<'a> IntoFuture for FetchScriptResultsBuilder<'a> {
     }
 }
 
+// Unlike FetchScriptResults, ExecuteScript is not retried: a server-side start followed by a
+// client transport error would spawn duplicate long-running operations.
+#[instrument(name = "ydb.ExecuteScript", skip_all, fields(db.system.name = "ydb", ydb.Query.text = %crate::traces::helpers::ensure_len_string(&text)), err)]
 async fn client_execute_script(
     ctx: &ClientExecContext,
     text: String,
@@ -156,24 +159,10 @@ async fn client_execute_script(
     opts: CallOptions,
     results_ttl: Duration,
 ) -> YdbResult<ExecuteScriptOperation> {
-    ctx.lifetime.ensure_open()?;
-    // Unlike FetchScriptResults, ExecuteScript is not retried: a server-side start
-    // followed by a client transport error would spawn duplicate long-running ops.
-    client_execute_script_once(ctx, &text, &params, &opts, results_ttl).await
-}
-
-#[instrument(name = "ydb.ExecuteScript", skip_all, fields(db.system.name = "ydb", ydb.Query.text = %crate::traces::helpers::ensure_len_string(text)), err)]
-async fn client_execute_script_once(
-    ctx: &ClientExecContext,
-    text: &str,
-    params: &HashMap<String, Value>,
-    opts: &CallOptions,
-    results_ttl: Duration,
-) -> YdbResult<ExecuteScriptOperation> {
     let timeout = opts.timeout;
     let req = RawExecuteScriptRequest {
-        yql_text: text.to_string(),
-        parameters: params.clone(),
+        yql_text: text,
+        parameters: params,
         results_ttl,
         operation_params: TimeoutSettings {
             operation_timeout: timeout,
@@ -182,6 +171,7 @@ async fn client_execute_script_once(
         collect_stats: false,
     };
     let mut client = ctx
+        .access()?
         .connection_manager
         .get_auth_service(RawQueryClient::new)
         .await?;
@@ -212,10 +202,9 @@ async fn client_fetch_script_results(
     rows_limit: i64,
     opts: CallOptions,
 ) -> YdbResult<FetchScriptResult> {
-    ctx.lifetime.ensure_open()?;
+    let retry_settings = ctx.access()?.retry_settings.clone();
     // FetchScriptResults is always safe to retry (aligned with Go SDK).
-    ctx.retry_settings
-        .clone()
+    retry_settings
         .with_deadline(opts.timeout)
         .retry_on_retriable_errors(
             Idempotency::Idempotent,
@@ -250,6 +239,7 @@ async fn client_fetch_script_results_once(
         rows_limit,
     };
     let mut client = ctx
+        .access()?
         .connection_manager
         .get_auth_service(RawQueryClient::new)
         .await?;

--- a/ydb/src/client_query/session_pool_integration_test.rs
+++ b/ydb/src/client_query/session_pool_integration_test.rs
@@ -117,15 +117,11 @@ async fn create_client_with_short_pool_acquire_timeout(
 ) -> Arc<Client> {
     let client = test_client_builder()
         .with_executor(Arc::new(crate::test_integration_helper::InplaceExecutor))
+        .with_session_pool(settings.with_acquire_timeout(Duration::from_millis(300)))
         .build()
         .await
         .expect("client builder");
-    Arc::new(
-        client
-            .with_session_pool(settings.with_acquire_timeout(Duration::from_millis(300)))
-            .await
-            .expect("session pool"),
-    )
+    Arc::new(client)
 }
 
 #[tokio::test]

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -187,6 +187,7 @@ pub(crate) async fn materialize_query(
     let commit_at_end = resolve_commit_tx(core, &opts);
     match core {
         ExecTarget::Client(ctx) => {
+            ctx.lifetime.ensure_open()?;
             ctx.retry_settings
                 .clone()
                 .with_deadline(opts.timeout)

--- a/ydb/src/client_query/stream_facade.rs
+++ b/ydb/src/client_query/stream_facade.rs
@@ -187,8 +187,8 @@ pub(crate) async fn materialize_query(
     let commit_at_end = resolve_commit_tx(core, &opts);
     match core {
         ExecTarget::Client(ctx) => {
-            ctx.lifetime.ensure_open()?;
-            ctx.retry_settings
+            ctx.access()?
+                .retry_settings
                 .clone()
                 .with_deadline(opts.timeout)
                 .retry_on_retriable_errors(

--- a/ydb/src/client_scheme/client.rs
+++ b/ydb/src/client_scheme/client.rs
@@ -1,6 +1,6 @@
 use crate::client::TimeoutSettings;
-use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::client_scheme::list_types::SchemeEntry;
+use crate::driver_lifecycle::{DriverGuarded, DriverLifecycle};
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_scheme_client::client::{
     RawMakeDirectoryRequest, RawRemoveDirectoryRequest,
@@ -13,7 +13,7 @@ use tracing::instrument;
 
 #[derive(Clone)]
 pub struct SchemeClient {
-    inner: ShutdownGuarded<SchemeClientInner>,
+    inner: DriverGuarded<SchemeClientInner>,
 }
 
 #[derive(Clone)]
@@ -23,9 +23,12 @@ struct SchemeClientInner {
 }
 
 impl SchemeClient {
-    pub(crate) fn new(connection_manager: GrpcConnectionManager, lifetime: ClientLifetime) -> Self {
+    pub(crate) fn new(
+        connection_manager: GrpcConnectionManager,
+        lifecycle: &DriverLifecycle,
+    ) -> Self {
         Self {
-            inner: lifetime.guard(SchemeClientInner {
+            inner: lifecycle.guard(SchemeClientInner {
                 timeouts: TimeoutSettings::default(),
                 connection_manager,
             }),

--- a/ydb/src/client_scheme/client.rs
+++ b/ydb/src/client_scheme/client.rs
@@ -1,5 +1,5 @@
 use crate::client::TimeoutSettings;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::client_scheme::list_types::SchemeEntry;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_scheme_client::client::{
@@ -13,39 +13,46 @@ use tracing::instrument;
 
 #[derive(Clone)]
 pub struct SchemeClient {
+    inner: ShutdownGuarded<SchemeClientInner>,
+}
+
+#[derive(Clone)]
+struct SchemeClientInner {
     timeouts: TimeoutSettings,
     connection_manager: GrpcConnectionManager,
-    lifetime: ClientLifetime,
 }
 
 impl SchemeClient {
     pub(crate) fn new(connection_manager: GrpcConnectionManager, lifetime: ClientLifetime) -> Self {
         Self {
-            timeouts: TimeoutSettings::default(),
-            connection_manager,
-            lifetime,
+            inner: lifetime.guard(SchemeClientInner {
+                timeouts: TimeoutSettings::default(),
+                connection_manager,
+            }),
         }
     }
 
     #[instrument(name = "ydb.SchemeClient.MakeDirectory", skip_all, fields(db.system.name = "ydb", ydb.path = %path))]
     pub async fn make_directory(&mut self, path: String) -> YdbResult<()> {
+        let inner = self.inner.access()?;
         let req = RawMakeDirectoryRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
-        let mut service = self.connection().await?;
+        let mut service = inner.connection().await?;
         service.make_directory(req).await?;
         Ok(())
     }
 
     #[instrument(name = "ydb.SchemeClient.DescribePath", skip_all, fields(db.system.name = "ydb", ydb.path = %path))]
     pub async fn describe_path(&mut self, path: String) -> YdbResult<SchemeEntry> {
+        let inner = self.inner.access()?;
         let req = RawDescribePathRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.connection().await?;
+        let mut service = inner.connection().await?;
         let res = service.describe_path(req).await?;
 
         Ok(res.entry)
@@ -53,12 +60,13 @@ impl SchemeClient {
 
     #[instrument(name = "ydb.SchemeClient.ListDirectory", skip_all, fields(db.system.name = "ydb", ydb.path = %path))]
     pub async fn list_directory(&mut self, path: String) -> YdbResult<Vec<SchemeEntry>> {
+        let inner = self.inner.access()?;
         let req = RawListDirectoryRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.connection().await?;
+        let mut service = inner.connection().await?;
         let res = service.list_directory(req).await?;
 
         Ok(res.children.into_iter().collect())
@@ -66,19 +74,21 @@ impl SchemeClient {
 
     #[instrument(name = "ydb.SchemeClient.RemoveDirectory", skip_all, fields(db.system.name = "ydb", ydb.path = %path))]
     pub async fn remove_directory(&mut self, path: String) -> YdbResult<()> {
+        let inner = self.inner.access()?;
         let req = RawRemoveDirectoryRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
-        let mut service = self.connection().await?;
+        let mut service = inner.connection().await?;
         service.remove_directory(req).await?;
         Ok(())
     }
+}
 
+impl SchemeClientInner {
     async fn connection(
         &self,
     ) -> YdbResult<grpc_wrapper::raw_scheme_client::client::RawSchemeClient> {
-        self.lifetime.ensure_open()?;
         self.connection_manager
             .get_auth_service(grpc_wrapper::raw_scheme_client::client::RawSchemeClient::new)
             .await

--- a/ydb/src/client_scheme/client.rs
+++ b/ydb/src/client_scheme/client.rs
@@ -1,4 +1,5 @@
 use crate::client::TimeoutSettings;
+use crate::client_lifetime::ClientLifetime;
 use crate::client_scheme::list_types::SchemeEntry;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_scheme_client::client::{
@@ -14,13 +15,15 @@ use tracing::instrument;
 pub struct SchemeClient {
     timeouts: TimeoutSettings,
     connection_manager: GrpcConnectionManager,
+    lifetime: ClientLifetime,
 }
 
 impl SchemeClient {
-    pub(crate) fn new(connection_manager: GrpcConnectionManager) -> Self {
+    pub(crate) fn new(connection_manager: GrpcConnectionManager, lifetime: ClientLifetime) -> Self {
         Self {
             timeouts: TimeoutSettings::default(),
             connection_manager,
+            lifetime,
         }
     }
 
@@ -75,6 +78,7 @@ impl SchemeClient {
     async fn connection(
         &self,
     ) -> YdbResult<grpc_wrapper::raw_scheme_client::client::RawSchemeClient> {
+        self.lifetime.ensure_open()?;
         self.connection_manager
             .get_auth_service(grpc_wrapper::raw_scheme_client::client::RawSchemeClient::new)
             .await

--- a/ydb/src/client_table/builders.rs
+++ b/ydb/src/client_table/builders.rs
@@ -28,7 +28,7 @@ macro_rules! impl_table_call_builder {
             /// Default depends on the operation: `true` for `read_rows` and `bulk_upsert`,
             /// `false` for DDL and describe calls.
             pub fn idempotent(mut self, idempotent: bool) -> Self {
-                self.opts.idempotent = Some(idempotent);
+                self.opts.idempotency = Some(idempotent.into());
                 self
             }
         }

--- a/ydb/src/client_table/call_options.rs
+++ b/ydb/src/client_table/call_options.rs
@@ -1,11 +1,12 @@
 use std::time::Duration;
 
 use crate::client::TimeoutSettings;
+use crate::errors::Idempotency;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TableCallOptions {
     pub timeout: Option<Duration>,
-    pub idempotent: Option<bool>,
+    pub idempotency: Option<Idempotency>,
 }
 
 pub(crate) fn resolve_timeouts(opts: &TableCallOptions) -> TimeoutSettings {

--- a/ydb/src/client_table/mod.rs
+++ b/ydb/src/client_table/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod call_options;
 
 use crate::RefWithLifetime;
 use crate::async_closure::AsyncFnMut;
-use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
+use crate::driver_lifecycle::{DriverGuarded, DriverLifecycle};
 use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session::TableSession;
 use crate::session_pool::{SessionPool, TableSessionPool};
@@ -66,7 +66,7 @@ impl WithGrpcMaxMessageSize for TableServiceClientType {
 /// `table_client.read_rows(path, keys, None).timeout(Duration::from_secs(1)).idempotent(true).await`.
 #[derive(Clone)]
 pub struct TableClient {
-    session_pool: ShutdownGuarded<TableSessionPool>,
+    session_pool: DriverGuarded<TableSessionPool>,
 }
 
 impl TableClient {
@@ -74,10 +74,10 @@ impl TableClient {
         connection_manager: GrpcConnectionManager,
         session_pool: SessionPool,
         retry_settings: RetrySettings,
-        lifetime: ClientLifetime,
+        lifecycle: &DriverLifecycle,
     ) -> Self {
         Self {
-            session_pool: lifetime.guard(TableSessionPool::from_shared(
+            session_pool: lifecycle.guard(TableSessionPool::from_shared(
                 session_pool,
                 connection_manager,
                 retry_settings,

--- a/ydb/src/client_table/mod.rs
+++ b/ydb/src/client_table/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod call_options;
 
 use crate::RefWithLifetime;
 use crate::async_closure::AsyncFnMut;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session::TableSession;
 use crate::session_pool::{SessionPool, TableSessionPool};
@@ -66,8 +66,7 @@ impl WithGrpcMaxMessageSize for TableServiceClientType {
 /// `table_client.read_rows(path, keys, None).timeout(Duration::from_secs(1)).idempotent(true).await`.
 #[derive(Clone)]
 pub struct TableClient {
-    session_pool: TableSessionPool,
-    lifetime: ClientLifetime,
+    session_pool: ShutdownGuarded<TableSessionPool>,
 }
 
 impl TableClient {
@@ -78,12 +77,11 @@ impl TableClient {
         lifetime: ClientLifetime,
     ) -> Self {
         Self {
-            session_pool: TableSessionPool::from_shared(
+            session_pool: lifetime.guard(TableSessionPool::from_shared(
                 session_pool,
                 connection_manager,
                 retry_settings,
-            ),
-            lifetime,
+            )),
         }
     }
 
@@ -92,11 +90,17 @@ impl TableClient {
         opts: &TableCallOptions,
     ) -> YdbResult<TableSession> {
         let timeouts = resolve_timeouts(opts);
-        Ok(self.session_pool.session().await?.with_timeouts(timeouts))
+        Ok(self
+            .session_pool
+            .access()?
+            .session()
+            .await?
+            .with_timeouts(timeouts))
     }
 
     async fn sessionless_table_client(&self, opts: &TableCallOptions) -> YdbResult<RawTableClient> {
         self.session_pool
+            .access()?
             .connection_manager()
             .get_auth_service(RawTableClient::new)
             .await
@@ -161,16 +165,12 @@ impl TableClient {
     where
         F: AsyncFnMut<RefWithLifetime<RetryState>, Output = YdbResult<T>>,
     {
-        self.session_pool
-            .retry_settings()
-            .clone()
+        let retry_settings = self.session_pool.access()?.retry_settings().clone();
+        let idempotency = opts.idempotency.unwrap_or(default_idempotency);
+
+        retry_settings
             .with_deadline(opts.timeout)
-            .retry_on_retriable_errors(
-                opts.idempotent
-                    .map(Idempotency::from)
-                    .unwrap_or(default_idempotency),
-                attempt_fn,
-            )
+            .retry_on_retriable_errors(idempotency, attempt_fn)
             .await
     }
 
@@ -182,7 +182,7 @@ impl TableClient {
         columns: Option<Vec<String>>,
         opts: TableCallOptions,
     ) -> YdbResult<crate::ResultSet> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         if keys.is_empty() {
             return Ok(crate::ResultSet::default());
         }
@@ -223,7 +223,7 @@ impl TableClient {
         rows: Vec<Value>,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         let Some(value) = try_vec_to_list_of_structs(rows)? else {
             return Ok(());
         };
@@ -259,7 +259,7 @@ impl TableClient {
         destination_path: String,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -301,7 +301,7 @@ impl TableClient {
         tables: Vec<CopyTableItem>,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -348,7 +348,7 @@ impl TableClient {
         replace_destination: bool,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -393,7 +393,7 @@ impl TableClient {
         tables: Vec<RenameTableItem>,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -431,7 +431,7 @@ impl TableClient {
         path: String,
         opts: TableCallOptions,
     ) -> YdbResult<TableDescription> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -471,7 +471,7 @@ impl TableClient {
         request: CreateTableRequest,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -510,7 +510,7 @@ impl TableClient {
         request: DropTableRequest,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -544,7 +544,7 @@ impl TableClient {
         request: AlterTableRequest,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -581,7 +581,7 @@ impl TableClient {
         &self,
         opts: TableCallOptions,
     ) -> YdbResult<TableOptionsDescription> {
-        self.lifetime.ensure_open()?;
+        self.session_pool.access()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,

--- a/ydb/src/client_table/mod.rs
+++ b/ydb/src/client_table/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod call_options;
 
 use crate::RefWithLifetime;
 use crate::async_closure::AsyncFnMut;
+use crate::client_lifetime::ClientLifetime;
 use crate::retry_settings::{RetrySettings, RetryState};
 use crate::session::TableSession;
 use crate::session_pool::{SessionPool, TableSessionPool};
@@ -66,6 +67,7 @@ impl WithGrpcMaxMessageSize for TableServiceClientType {
 #[derive(Clone)]
 pub struct TableClient {
     session_pool: TableSessionPool,
+    lifetime: ClientLifetime,
 }
 
 impl TableClient {
@@ -73,6 +75,7 @@ impl TableClient {
         connection_manager: GrpcConnectionManager,
         session_pool: SessionPool,
         retry_settings: RetrySettings,
+        lifetime: ClientLifetime,
     ) -> Self {
         Self {
             session_pool: TableSessionPool::from_shared(
@@ -80,6 +83,7 @@ impl TableClient {
                 connection_manager,
                 retry_settings,
             ),
+            lifetime,
         }
     }
 
@@ -178,6 +182,7 @@ impl TableClient {
         columns: Option<Vec<String>>,
         opts: TableCallOptions,
     ) -> YdbResult<crate::ResultSet> {
+        self.lifetime.ensure_open()?;
         if keys.is_empty() {
             return Ok(crate::ResultSet::default());
         }
@@ -218,6 +223,7 @@ impl TableClient {
         rows: Vec<Value>,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         let Some(value) = try_vec_to_list_of_structs(rows)? else {
             return Ok(());
         };
@@ -253,6 +259,7 @@ impl TableClient {
         destination_path: String,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -294,6 +301,7 @@ impl TableClient {
         tables: Vec<CopyTableItem>,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -340,6 +348,7 @@ impl TableClient {
         replace_destination: bool,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -384,6 +393,7 @@ impl TableClient {
         tables: Vec<RenameTableItem>,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -421,6 +431,7 @@ impl TableClient {
         path: String,
         opts: TableCallOptions,
     ) -> YdbResult<TableDescription> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -460,6 +471,7 @@ impl TableClient {
         request: CreateTableRequest,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -498,6 +510,7 @@ impl TableClient {
         request: DropTableRequest,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -531,6 +544,7 @@ impl TableClient {
         request: AlterTableRequest,
         opts: TableCallOptions,
     ) -> YdbResult<()> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,
@@ -567,6 +581,7 @@ impl TableClient {
         &self,
         opts: TableCallOptions,
     ) -> YdbResult<TableOptionsDescription> {
+        self.lifetime.ensure_open()?;
         self.retry_table_operation(
             &opts,
             Idempotency::NonIdempotent,

--- a/ydb/src/client_topic/client.rs
+++ b/ydb/src/client_topic/client.rs
@@ -223,7 +223,7 @@ impl TopicClient {
         consumer: impl Into<String>,
         topic: impl Into<TopicSelectors>,
     ) -> YdbResult<TopicReader> {
-        self.lifetime.ensure_open()?;
+        let resource = self.lifetime.register_topic_reader()?;
         let options = TopicReaderOptions::builder()
             .consumer(consumer)
             .topic(topic)
@@ -233,6 +233,7 @@ impl TopicClient {
             self.connection_manager.clone(),
             self.token_cache.clone(),
             self.executor.clone(),
+            resource,
         )
         .await
     }
@@ -242,12 +243,13 @@ impl TopicClient {
         &mut self,
         options: TopicReaderOptions,
     ) -> YdbResult<TopicReader> {
-        self.lifetime.ensure_open()?;
+        let resource = self.lifetime.register_topic_reader()?;
         TopicReader::new(
             options,
             self.connection_manager.clone(),
             self.token_cache.clone(),
             self.executor.clone(),
+            resource,
         )
         .await
     }
@@ -257,11 +259,12 @@ impl TopicClient {
         &mut self,
         writer_options: TopicWriterOptions,
     ) -> YdbResult<TopicWriter> {
-        self.lifetime.ensure_open()?;
+        let resource = self.lifetime.register_topic_writer()?;
         TopicWriter::new(
             writer_options,
             self.connection_manager.clone(),
             self.executor.clone(),
+            resource,
         )
         .await
     }
@@ -282,23 +285,25 @@ impl TopicClient {
         writer_tx_options: TopicWriterTxOptions,
         tx: &mut Transaction,
     ) -> YdbResult<TopicWriterTx> {
-        self.lifetime.ensure_open()?;
+        let resource = self.lifetime.register_topic_writer()?;
         TopicWriterTx::new(
             writer_tx_options,
             self.connection_manager.clone(),
             self.executor.clone(),
             tx,
+            resource,
         )
         .await
     }
 
     #[instrument(name = "ydb.TopicClient.CreateWriter", skip_all)]
     pub async fn create_writer(&mut self, path: impl Into<String>) -> YdbResult<TopicWriter> {
-        self.lifetime.ensure_open()?;
+        let resource = self.lifetime.register_topic_writer()?;
         TopicWriter::new(
             TopicWriterOptions::builder().topic_path(path).build(),
             self.connection_manager.clone(),
             self.executor.clone(),
+            resource,
         )
         .await
     }

--- a/ydb/src/client_topic/client.rs
+++ b/ydb/src/client_topic/client.rs
@@ -4,6 +4,7 @@ use super::topicwriter::writer_tx_options::{TopicWriterTxOptions, TopicWriterTxO
 use crate::YdbError::InternalError;
 use crate::client::TimeoutSettings;
 use crate::client_common::TokenCache;
+use crate::client_lifetime::ClientLifetime;
 use crate::client_query::Transaction;
 use crate::client_topic::list_types::{AlterConsumer, Consumer, MeteringMode};
 use crate::client_topic::topicreader::reader::{TopicReader, TopicSelectors};
@@ -124,6 +125,7 @@ pub struct TopicClient {
     connection_manager: GrpcConnectionManager,
     token_cache: TokenCache,
     executor: Arc<dyn Executor>,
+    lifetime: ClientLifetime,
 }
 
 impl TopicClient {
@@ -131,12 +133,14 @@ impl TopicClient {
         connection_manager: GrpcConnectionManager,
         token_cache: TokenCache,
         executor: Arc<dyn Executor>,
+        lifetime: ClientLifetime,
     ) -> Self {
         Self {
             timeouts: TimeoutSettings::default(),
             connection_manager,
             token_cache,
             executor,
+            lifetime,
         }
     }
 
@@ -219,6 +223,7 @@ impl TopicClient {
         consumer: impl Into<String>,
         topic: impl Into<TopicSelectors>,
     ) -> YdbResult<TopicReader> {
+        self.lifetime.ensure_open()?;
         let options = TopicReaderOptions::builder()
             .consumer(consumer)
             .topic(topic)
@@ -237,6 +242,7 @@ impl TopicClient {
         &mut self,
         options: TopicReaderOptions,
     ) -> YdbResult<TopicReader> {
+        self.lifetime.ensure_open()?;
         TopicReader::new(
             options,
             self.connection_manager.clone(),
@@ -251,6 +257,7 @@ impl TopicClient {
         &mut self,
         writer_options: TopicWriterOptions,
     ) -> YdbResult<TopicWriter> {
+        self.lifetime.ensure_open()?;
         TopicWriter::new(
             writer_options,
             self.connection_manager.clone(),
@@ -275,6 +282,7 @@ impl TopicClient {
         writer_tx_options: TopicWriterTxOptions,
         tx: &mut Transaction,
     ) -> YdbResult<TopicWriterTx> {
+        self.lifetime.ensure_open()?;
         TopicWriterTx::new(
             writer_tx_options,
             self.connection_manager.clone(),
@@ -286,6 +294,7 @@ impl TopicClient {
 
     #[instrument(name = "ydb.TopicClient.CreateWriter", skip_all)]
     pub async fn create_writer(&mut self, path: impl Into<String>) -> YdbResult<TopicWriter> {
+        self.lifetime.ensure_open()?;
         TopicWriter::new(
             TopicWriterOptions::builder().topic_path(path).build(),
             self.connection_manager.clone(),
@@ -297,6 +306,7 @@ impl TopicClient {
     pub(crate) async fn raw_client_connection(
         &self,
     ) -> YdbResult<grpc_wrapper::raw_topic_service::client::RawTopicClient> {
+        self.lifetime.ensure_open()?;
         self.connection_manager
             .get_auth_service(grpc_wrapper::raw_topic_service::client::RawTopicClient::new)
             .await

--- a/ydb/src/client_topic/client.rs
+++ b/ydb/src/client_topic/client.rs
@@ -4,7 +4,6 @@ use super::topicwriter::writer_tx_options::{TopicWriterTxOptions, TopicWriterTxO
 use crate::YdbError::InternalError;
 use crate::client::TimeoutSettings;
 use crate::client_common::TokenCache;
-use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::client_query::Transaction;
 use crate::client_topic::list_types::{AlterConsumer, Consumer, MeteringMode};
 use crate::client_topic::topicreader::reader::{TopicReader, TopicSelectors};
@@ -12,6 +11,7 @@ use crate::client_topic::topicreader::reader_options::TopicReaderOptions;
 use crate::client_topic::topicwriter::writer::TopicWriter;
 use crate::client_topic::topicwriter::writer_options::TopicWriterOptions;
 use crate::client_topic::topicwriter::writer_tx::TopicWriterTx;
+use crate::driver_lifecycle::{DriverGuarded, DriverLifecycle};
 use crate::errors;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_topic_service::alter_topic::RawAlterTopicRequest;
@@ -121,7 +121,7 @@ impl From<UninitializedFieldError> for errors::YdbError {
 
 #[derive(Clone)]
 pub struct TopicClient {
-    inner: ShutdownGuarded<TopicClientInner>,
+    inner: DriverGuarded<TopicClientInner>,
 }
 
 #[derive(Clone)]
@@ -137,10 +137,10 @@ impl TopicClient {
         connection_manager: GrpcConnectionManager,
         token_cache: TokenCache,
         executor: Arc<dyn Executor>,
-        lifetime: ClientLifetime,
+        lifecycle: &DriverLifecycle,
     ) -> Self {
         Self {
-            inner: lifetime.guard(TopicClientInner {
+            inner: lifecycle.guard(TopicClientInner {
                 timeouts: TimeoutSettings::default(),
                 connection_manager,
                 token_cache,

--- a/ydb/src/client_topic/client.rs
+++ b/ydb/src/client_topic/client.rs
@@ -4,7 +4,7 @@ use super::topicwriter::writer_tx_options::{TopicWriterTxOptions, TopicWriterTxO
 use crate::YdbError::InternalError;
 use crate::client::TimeoutSettings;
 use crate::client_common::TokenCache;
-use crate::client_lifetime::ClientLifetime;
+use crate::client_lifetime::{ClientLifetime, ShutdownGuarded};
 use crate::client_query::Transaction;
 use crate::client_topic::list_types::{AlterConsumer, Consumer, MeteringMode};
 use crate::client_topic::topicreader::reader::{TopicReader, TopicSelectors};
@@ -121,11 +121,15 @@ impl From<UninitializedFieldError> for errors::YdbError {
 
 #[derive(Clone)]
 pub struct TopicClient {
+    inner: ShutdownGuarded<TopicClientInner>,
+}
+
+#[derive(Clone)]
+struct TopicClientInner {
     timeouts: TimeoutSettings,
     connection_manager: GrpcConnectionManager,
     token_cache: TokenCache,
     executor: Arc<dyn Executor>,
-    lifetime: ClientLifetime,
 }
 
 impl TopicClient {
@@ -136,11 +140,12 @@ impl TopicClient {
         lifetime: ClientLifetime,
     ) -> Self {
         Self {
-            timeouts: TimeoutSettings::default(),
-            connection_manager,
-            token_cache,
-            executor,
-            lifetime,
+            inner: lifetime.guard(TopicClientInner {
+                timeouts: TimeoutSettings::default(),
+                connection_manager,
+                token_cache,
+                executor,
+            }),
         }
     }
 
@@ -150,9 +155,10 @@ impl TopicClient {
         path: String,
         options: CreateTopicOptions,
     ) -> YdbResult<()> {
-        let req = RawCreateTopicRequest::new(path, self.timeouts.operation_params(), options);
+        let inner = self.inner.access()?;
+        let req = RawCreateTopicRequest::new(path, inner.timeouts.operation_params(), options);
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         service.create_topic(req).await?;
 
         Ok(())
@@ -160,9 +166,10 @@ impl TopicClient {
 
     #[instrument(name = "ydb.TopicClient.AlterTopic", skip_all, fields(db.system.name = "ydb", ydb.topic.path = %path))]
     pub async fn alter_topic(&mut self, path: String, options: AlterTopicOptions) -> YdbResult<()> {
-        let req = RawAlterTopicRequest::new(path, self.timeouts.operation_params(), options);
+        let inner = self.inner.access()?;
+        let req = RawAlterTopicRequest::new(path, inner.timeouts.operation_params(), options);
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         service.alter_topic(req).await?;
 
         Ok(())
@@ -175,14 +182,15 @@ impl TopicClient {
         consumer: String,
         options: DescribeConsumerOptions,
     ) -> YdbResult<super::list_types::ConsumerDescription> {
+        let inner = self.inner.access()?;
         let req = RawDescribeConsumerRequest::new(
             path,
             consumer,
-            self.timeouts.operation_params(),
+            inner.timeouts.operation_params(),
             options,
         );
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         let result = service.describe_consumer(req).await?;
         let description = super::list_types::ConsumerDescription::from(result);
 
@@ -195,9 +203,10 @@ impl TopicClient {
         path: String,
         options: DescribeTopicOptions,
     ) -> YdbResult<TopicDescription> {
-        let req = RawDescribeTopicRequest::new(path, self.timeouts.operation_params(), options);
+        let inner = self.inner.access()?;
+        let req = RawDescribeTopicRequest::new(path, inner.timeouts.operation_params(), options);
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         let result = service.describe_topic(req).await?;
         let description = TopicDescription::from(result);
 
@@ -206,12 +215,13 @@ impl TopicClient {
 
     #[instrument(name = "ydb.TopicClient.DropTopic", skip_all, fields(db.system.name = "ydb", ydb.topic.path = %path))]
     pub async fn drop_topic(&mut self, path: String) -> YdbResult<()> {
+        let inner = self.inner.access()?;
         let req = RawDropTopicRequest {
-            operation_params: self.timeouts.operation_params(),
+            operation_params: inner.timeouts.operation_params(),
             path,
         };
 
-        let mut service = self.raw_client_connection().await?;
+        let mut service = inner.raw_client_connection().await?;
         service.delete_topic(req).await?;
 
         Ok(())
@@ -223,16 +233,17 @@ impl TopicClient {
         consumer: impl Into<String>,
         topic: impl Into<TopicSelectors>,
     ) -> YdbResult<TopicReader> {
-        let resource = self.lifetime.register_topic_reader()?;
+        let resource = self.inner.register_topic_reader()?;
+        let inner = self.inner.access()?;
         let options = TopicReaderOptions::builder()
             .consumer(consumer)
             .topic(topic)
             .build();
         TopicReader::new(
             options,
-            self.connection_manager.clone(),
-            self.token_cache.clone(),
-            self.executor.clone(),
+            inner.connection_manager.clone(),
+            inner.token_cache.clone(),
+            inner.executor.clone(),
             resource,
         )
         .await
@@ -243,12 +254,13 @@ impl TopicClient {
         &mut self,
         options: TopicReaderOptions,
     ) -> YdbResult<TopicReader> {
-        let resource = self.lifetime.register_topic_reader()?;
+        let resource = self.inner.register_topic_reader()?;
+        let inner = self.inner.access()?;
         TopicReader::new(
             options,
-            self.connection_manager.clone(),
-            self.token_cache.clone(),
-            self.executor.clone(),
+            inner.connection_manager.clone(),
+            inner.token_cache.clone(),
+            inner.executor.clone(),
             resource,
         )
         .await
@@ -259,11 +271,12 @@ impl TopicClient {
         &mut self,
         writer_options: TopicWriterOptions,
     ) -> YdbResult<TopicWriter> {
-        let resource = self.lifetime.register_topic_writer()?;
+        let resource = self.inner.register_topic_writer()?;
+        let inner = self.inner.access()?;
         TopicWriter::new(
             writer_options,
-            self.connection_manager.clone(),
-            self.executor.clone(),
+            inner.connection_manager.clone(),
+            inner.executor.clone(),
             resource,
         )
         .await
@@ -285,11 +298,12 @@ impl TopicClient {
         writer_tx_options: TopicWriterTxOptions,
         tx: &mut Transaction,
     ) -> YdbResult<TopicWriterTx> {
-        let resource = self.lifetime.register_topic_writer()?;
+        let resource = self.inner.register_topic_writer()?;
+        let inner = self.inner.access()?;
         TopicWriterTx::new(
             writer_tx_options,
-            self.connection_manager.clone(),
-            self.executor.clone(),
+            inner.connection_manager.clone(),
+            inner.executor.clone(),
             tx,
             resource,
         )
@@ -298,20 +312,29 @@ impl TopicClient {
 
     #[instrument(name = "ydb.TopicClient.CreateWriter", skip_all)]
     pub async fn create_writer(&mut self, path: impl Into<String>) -> YdbResult<TopicWriter> {
-        let resource = self.lifetime.register_topic_writer()?;
+        let resource = self.inner.register_topic_writer()?;
+        let inner = self.inner.access()?;
         TopicWriter::new(
             TopicWriterOptions::builder().topic_path(path).build(),
-            self.connection_manager.clone(),
-            self.executor.clone(),
+            inner.connection_manager.clone(),
+            inner.executor.clone(),
             resource,
         )
         .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn raw_client_connection(
         &self,
     ) -> YdbResult<grpc_wrapper::raw_topic_service::client::RawTopicClient> {
-        self.lifetime.ensure_open()?;
+        self.inner.access()?.raw_client_connection().await
+    }
+}
+
+impl TopicClientInner {
+    async fn raw_client_connection(
+        &self,
+    ) -> YdbResult<grpc_wrapper::raw_topic_service::client::RawTopicClient> {
         self.connection_manager
             .get_auth_service(grpc_wrapper::raw_topic_service::client::RawTopicClient::new)
             .await

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -9,6 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::client_common::TokenCache;
+use crate::client_lifetime::ClientResourceGuard;
 use crate::client_query::Transaction;
 use crate::client_topic::compression::Executor;
 use crate::client_topic::topicreader::ids::{PartitionId, PartitionSessionId};
@@ -35,6 +36,7 @@ pub struct TopicReader {
     reconnect_handle: JoinHandle<YdbResult<()>>,
     runtime: RuntimeHandle,
     cancellation: CancellationToken,
+    _client_resource: ClientResourceGuard,
 }
 
 static READER_ID: AtomicUsize = AtomicUsize::new(0);
@@ -49,6 +51,7 @@ impl TopicReader {
         manager: GrpcConnectionManager,
         token_cache: TokenCache,
         compression_executor: Arc<dyn Executor>,
+        client_resource: ClientResourceGuard,
     ) -> YdbResult<Self> {
         let cancellation = CancellationToken::new();
         let ReconnectorTask {
@@ -71,6 +74,7 @@ impl TopicReader {
             reconnect_handle: join_handle,
             runtime,
             cancellation: cancellation_token,
+            _client_resource: client_resource,
         })
     }
 

--- a/ydb/src/client_topic/topicreader/reader.rs
+++ b/ydb/src/client_topic/topicreader/reader.rs
@@ -9,12 +9,12 @@ use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
 use crate::client_common::TokenCache;
-use crate::client_lifetime::ClientResourceGuard;
 use crate::client_query::Transaction;
 use crate::client_topic::compression::Executor;
 use crate::client_topic::topicreader::ids::{PartitionId, PartitionSessionId};
 use crate::client_topic::topicreader::messages::TopicReaderBatch;
 use crate::client_topic::topicreader::reader_options::TopicReaderOptions;
+use crate::driver_lifecycle::DriverResourceGuard;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::grpc_wrapper::raw_topic_service::client::RawTopicClient;
 use crate::grpc_wrapper::raw_topic_service::common::partition::RawOffsetsRange;
@@ -36,7 +36,7 @@ pub struct TopicReader {
     reconnect_handle: JoinHandle<YdbResult<()>>,
     runtime: RuntimeHandle,
     cancellation: CancellationToken,
-    _client_resource: ClientResourceGuard,
+    _driver_resource: DriverResourceGuard,
 }
 
 static READER_ID: AtomicUsize = AtomicUsize::new(0);
@@ -51,7 +51,7 @@ impl TopicReader {
         manager: GrpcConnectionManager,
         token_cache: TokenCache,
         compression_executor: Arc<dyn Executor>,
-        client_resource: ClientResourceGuard,
+        driver_resource: DriverResourceGuard,
     ) -> YdbResult<Self> {
         let cancellation = CancellationToken::new();
         let ReconnectorTask {
@@ -74,7 +74,7 @@ impl TopicReader {
             reconnect_handle: join_handle,
             runtime,
             cancellation: cancellation_token,
-            _client_resource: client_resource,
+            _driver_resource: driver_resource,
         })
     }
 

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -8,6 +8,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::{instrument, trace};
 
+use crate::client_lifetime::ClientResourceGuard;
 use crate::client_topic::compression::Executor;
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::client_topic::topicwriter::message_write_status::{
@@ -26,6 +27,7 @@ pub struct TopicWriter {
     wait_for_fatal_error_handle: JoinHandle<()>,
     reconnector: Reconnector,
     _cancel_on_drop: DropGuard,
+    _client_resource: ClientResourceGuard,
 }
 
 pub struct AckFuture {
@@ -50,8 +52,16 @@ impl TopicWriter {
         writer_options: TopicWriterOptions,
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
+        client_resource: ClientResourceGuard,
     ) -> YdbResult<Self> {
-        Self::new_inner(writer_options, connection_manager, executor, None).await
+        Self::new_inner(
+            writer_options,
+            connection_manager,
+            executor,
+            None,
+            client_resource,
+        )
+        .await
     }
 
     pub(crate) async fn with_tx_identity(
@@ -59,12 +69,14 @@ impl TopicWriter {
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
         tx_identity: TransactionIdentity,
+        client_resource: ClientResourceGuard,
     ) -> YdbResult<Self> {
         Self::new_inner(
             writer_options,
             connection_manager,
             executor,
             Some(tx_identity),
+            client_resource,
         )
         .await
     }
@@ -74,6 +86,7 @@ impl TopicWriter {
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
         tx_identity: Option<TransactionIdentity>,
+        client_resource: ClientResourceGuard,
     ) -> YdbResult<Self> {
         let producer_id = writer_options
             .producer_id
@@ -117,6 +130,7 @@ impl TopicWriter {
             wait_for_fatal_error_handle,
             reconnector,
             _cancel_on_drop: cancel_on_drop,
+            _client_resource: client_resource,
         })
     }
 

--- a/ydb/src/client_topic/topicwriter/writer.rs
+++ b/ydb/src/client_topic/topicwriter/writer.rs
@@ -8,7 +8,6 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::{instrument, trace};
 
-use crate::client_lifetime::ClientResourceGuard;
 use crate::client_topic::compression::Executor;
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::client_topic::topicwriter::message_write_status::{
@@ -16,6 +15,7 @@ use crate::client_topic::topicwriter::message_write_status::{
 };
 use crate::client_topic::topicwriter::reconnector::{Reconnector, ReconnectorParams};
 use crate::client_topic::topicwriter::writer_options::TopicWriterOptions;
+use crate::driver_lifecycle::DriverResourceGuard;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 use crate::{YdbError, YdbResult};
 use ydb_grpc::ydb_proto::topic::TransactionIdentity;
@@ -27,7 +27,7 @@ pub struct TopicWriter {
     wait_for_fatal_error_handle: JoinHandle<()>,
     reconnector: Reconnector,
     _cancel_on_drop: DropGuard,
-    _client_resource: ClientResourceGuard,
+    _driver_resource: DriverResourceGuard,
 }
 
 pub struct AckFuture {
@@ -52,14 +52,14 @@ impl TopicWriter {
         writer_options: TopicWriterOptions,
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
-        client_resource: ClientResourceGuard,
+        driver_resource: DriverResourceGuard,
     ) -> YdbResult<Self> {
         Self::new_inner(
             writer_options,
             connection_manager,
             executor,
             None,
-            client_resource,
+            driver_resource,
         )
         .await
     }
@@ -69,14 +69,14 @@ impl TopicWriter {
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
         tx_identity: TransactionIdentity,
-        client_resource: ClientResourceGuard,
+        driver_resource: DriverResourceGuard,
     ) -> YdbResult<Self> {
         Self::new_inner(
             writer_options,
             connection_manager,
             executor,
             Some(tx_identity),
-            client_resource,
+            driver_resource,
         )
         .await
     }
@@ -86,7 +86,7 @@ impl TopicWriter {
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
         tx_identity: Option<TransactionIdentity>,
-        client_resource: ClientResourceGuard,
+        driver_resource: DriverResourceGuard,
     ) -> YdbResult<Self> {
         let producer_id = writer_options
             .producer_id
@@ -130,7 +130,7 @@ impl TopicWriter {
             wait_for_fatal_error_handle,
             reconnector,
             _cancel_on_drop: cancel_on_drop,
-            _client_resource: client_resource,
+            _driver_resource: driver_resource,
         })
     }
 

--- a/ydb/src/client_topic/topicwriter/writer_tx.rs
+++ b/ydb/src/client_topic/topicwriter/writer_tx.rs
@@ -5,6 +5,7 @@ use ydb_grpc::ydb_proto::topic::TransactionIdentity;
 use tracing::instrument;
 
 use crate::YdbResult;
+use crate::client_lifetime::ClientResourceGuard;
 use crate::client_query::Transaction;
 use crate::client_query::hooks::{QueryTxCommitStatus, QueryTxHook};
 use crate::client_topic::compression::Executor;
@@ -48,6 +49,7 @@ impl TopicWriterTx {
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
         tx: &mut Transaction,
+        client_resource: ClientResourceGuard,
     ) -> YdbResult<Self> {
         let (session_id, transaction_id) = tx.identity().await?;
 
@@ -60,9 +62,14 @@ impl TopicWriterTx {
         // options construction and conversion.
         let options = options.into_non_tx_options();
 
-        let writer =
-            TopicWriter::with_tx_identity(options, connection_manager, executor, tx_identity)
-                .await?;
+        let writer = TopicWriter::with_tx_identity(
+            options,
+            connection_manager,
+            executor,
+            tx_identity,
+            client_resource,
+        )
+        .await?;
 
         let inner = Arc::new(writer);
         tx.register_hook(WriterTxHook {

--- a/ydb/src/client_topic/topicwriter/writer_tx.rs
+++ b/ydb/src/client_topic/topicwriter/writer_tx.rs
@@ -5,12 +5,12 @@ use ydb_grpc::ydb_proto::topic::TransactionIdentity;
 use tracing::instrument;
 
 use crate::YdbResult;
-use crate::client_lifetime::ClientResourceGuard;
 use crate::client_query::Transaction;
 use crate::client_query::hooks::{QueryTxCommitStatus, QueryTxHook};
 use crate::client_topic::compression::Executor;
 use crate::client_topic::topicwriter::message::TopicWriterMessage;
 use crate::client_topic::topicwriter::writer::TopicWriter;
+use crate::driver_lifecycle::DriverResourceGuard;
 use crate::grpc_connection_manager::GrpcConnectionManager;
 
 use super::writer_tx_options::TopicWriterTxOptions;
@@ -49,7 +49,7 @@ impl TopicWriterTx {
         connection_manager: GrpcConnectionManager,
         executor: Arc<dyn Executor>,
         tx: &mut Transaction,
-        client_resource: ClientResourceGuard,
+        driver_resource: DriverResourceGuard,
     ) -> YdbResult<Self> {
         let (session_id, transaction_id) = tx.identity().await?;
 
@@ -67,7 +67,7 @@ impl TopicWriterTx {
             connection_manager,
             executor,
             tx_identity,
-            client_resource,
+            driver_resource,
         )
         .await?;
 

--- a/ydb/src/driver_lifecycle.rs
+++ b/ydb/src/driver_lifecycle.rs
@@ -130,7 +130,6 @@ impl DriverLifecycle {
 impl Drop for DriverLifecycle {
     fn drop(&mut self) {
         if !self.shutdown_completed {
-        if !self.shutdown_completed {
             self.state.start_shutdown();
             tracing::warn!(
                 "YDB driver dropped without completing graceful shutdown; call Client::shutdown().await before dropping it"

--- a/ydb/src/driver_lifecycle.rs
+++ b/ydb/src/driver_lifecycle.rs
@@ -8,46 +8,46 @@ use crate::{YdbError, YdbResult};
 
 const RESOURCE_COUNTER_CAPACITY: usize = Semaphore::MAX_PERMITS;
 
-/// Shared shutdown state for a driver and every service client derived from it.
-#[derive(Clone)]
-pub(crate) struct ClientLifetime {
-    inner: Arc<ClientLifetimeInner>,
+/// Root driver lifecycle and the shared state observed by its derived clients.
+pub(crate) struct DriverLifecycle {
+    state: Arc<DriverLifecycleState>,
+    shutdown_completed: bool,
 }
 
 /// A value that can only be accessed while its driver accepts new work.
 #[derive(Clone)]
-pub(crate) struct ShutdownGuarded<T> {
-    lifetime: ClientLifetime,
+pub(crate) struct DriverGuarded<T> {
+    state: Arc<DriverLifecycleState>,
     value: T,
 }
 
-struct ClientLifetimeInner {
-    closed: AtomicBool,
+struct DriverLifecycleState {
+    shutdown_started: AtomicBool,
     topic_readers: ResourceCounter,
     topic_writers: ResourceCounter,
     coordination_sessions: ResourceCounter,
 }
 
 /// Opaque ownership token held by one live client resource.
-pub(crate) struct ClientResourceGuard {
+pub(crate) struct DriverResourceGuard {
     _permit: OwnedSemaphorePermit,
 }
 
-/// Final snapshot of resources that still depend on a shutting-down client.
+/// Final snapshot of resources that still depend on a shutting-down driver.
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) struct LiveClientResources {
+pub(crate) struct LiveDriverResources {
     pub(crate) topic_readers: usize,
     pub(crate) topic_writers: usize,
     pub(crate) coordination_sessions: usize,
 }
 
-impl LiveClientResources {
+impl LiveDriverResources {
     pub(crate) fn is_empty(&self) -> bool {
         self.topic_readers == 0 && self.topic_writers == 0 && self.coordination_sessions == 0
     }
 }
 
-impl Display for LiveClientResources {
+impl Display for LiveDriverResources {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             formatter,
@@ -74,9 +74,9 @@ impl ResourceCounter {
         }
     }
 
-    fn register(&self) -> YdbResult<ClientResourceGuard> {
+    fn register(&self) -> YdbResult<DriverResourceGuard> {
         match self.permits.clone().try_acquire_owned() {
-            Ok(permit) => Ok(ClientResourceGuard { _permit: permit }),
+            Ok(permit) => Ok(DriverResourceGuard { _permit: permit }),
             Err(TryAcquireError::Closed) => Err(YdbError::custom("client shutdown has started")),
             Err(TryAcquireError::NoPermits) => Err(YdbError::InternalError(format!(
                 "{} resource counter exhausted",
@@ -94,81 +94,94 @@ impl ResourceCounter {
     }
 }
 
-impl ClientLifetime {
+impl DriverLifecycle {
     pub(crate) fn new() -> Self {
         Self {
-            inner: Arc::new(ClientLifetimeInner {
-                closed: AtomicBool::new(false),
+            state: Arc::new(DriverLifecycleState {
+                shutdown_started: AtomicBool::new(false),
                 topic_readers: ResourceCounter::new("topic reader"),
                 topic_writers: ResourceCounter::new("topic writer"),
                 coordination_sessions: ResourceCounter::new("coordination session"),
             }),
+            shutdown_completed: false,
         }
     }
 
-    pub(crate) fn ensure_open(&self) -> YdbResult<()> {
-        if self.inner.closed.load(Ordering::Relaxed) {
+    pub(crate) fn guard<T>(&self, value: T) -> DriverGuarded<T> {
+        DriverGuarded {
+            state: self.state.clone(),
+            value,
+        }
+    }
+
+    pub(crate) fn start_shutdown(&self) {
+        self.state.start_shutdown();
+    }
+
+    pub(crate) fn complete_shutdown(&mut self) {
+        self.shutdown_completed = true;
+    }
+
+    pub(crate) fn live_resources(&self) -> LiveDriverResources {
+        self.state.live_resources()
+    }
+}
+
+impl Drop for DriverLifecycle {
+    fn drop(&mut self) {
+        if !self.shutdown_completed {
+            tracing::warn!(
+                "YDB driver dropped without completing graceful shutdown; call Client::shutdown().await before dropping it"
+            );
+        }
+    }
+}
+
+impl DriverLifecycleState {
+    fn ensure_open(&self) -> YdbResult<()> {
+        if self.shutdown_started.load(Ordering::Relaxed) {
             Err(YdbError::custom("client shutdown has started"))
         } else {
             Ok(())
         }
     }
 
-    pub(crate) fn guard<T>(&self, value: T) -> ShutdownGuarded<T> {
-        ShutdownGuarded {
-            lifetime: self.clone(),
-            value,
-        }
+    fn start_shutdown(&self) {
+        self.shutdown_started.store(true, Ordering::Relaxed);
+        self.topic_readers.close();
+        self.topic_writers.close();
+        self.coordination_sessions.close();
     }
 
-    pub(crate) fn close(&self) {
-        self.inner.closed.store(true, Ordering::Relaxed);
-        self.inner.topic_readers.close();
-        self.inner.topic_writers.close();
-        self.inner.coordination_sessions.close();
-    }
-
-    pub(crate) fn register_topic_reader(&self) -> YdbResult<ClientResourceGuard> {
-        self.inner.topic_readers.register()
-    }
-
-    pub(crate) fn register_topic_writer(&self) -> YdbResult<ClientResourceGuard> {
-        self.inner.topic_writers.register()
-    }
-
-    pub(crate) fn register_coordination_session(&self) -> YdbResult<ClientResourceGuard> {
-        self.inner.coordination_sessions.register()
-    }
-
-    pub(crate) fn live_resources(&self) -> LiveClientResources {
-        LiveClientResources {
-            topic_readers: self.inner.topic_readers.active(),
-            topic_writers: self.inner.topic_writers.active(),
-            coordination_sessions: self.inner.coordination_sessions.active(),
+    fn live_resources(&self) -> LiveDriverResources {
+        LiveDriverResources {
+            topic_readers: self.topic_readers.active(),
+            topic_writers: self.topic_writers.active(),
+            coordination_sessions: self.coordination_sessions.active(),
         }
     }
 }
 
-impl<T> ShutdownGuarded<T> {
+impl<T> DriverGuarded<T> {
     pub(crate) fn access(&self) -> YdbResult<&T> {
-        self.lifetime.ensure_open()?;
+        self.state.ensure_open()?;
         Ok(&self.value)
     }
 
     pub(crate) fn access_mut(&mut self) -> YdbResult<&mut T> {
-        self.lifetime.ensure_open()?;
+        self.state.ensure_open()?;
         Ok(&mut self.value)
     }
 
-    pub(crate) fn register_topic_reader(&self) -> YdbResult<ClientResourceGuard> {
-        self.lifetime.register_topic_reader()
+    pub(crate) fn register_topic_reader(&self) -> YdbResult<DriverResourceGuard> {
+        self.state.topic_readers.register()
     }
 
-    pub(crate) fn register_topic_writer(&self) -> YdbResult<ClientResourceGuard> {
-        self.lifetime.register_topic_writer()
+    pub(crate) fn register_topic_writer(&self) -> YdbResult<DriverResourceGuard> {
+        self.state.topic_writers.register()
     }
 
-    pub(crate) fn register_coordination_session(&self) -> YdbResult<ClientResourceGuard> {
-        self.lifetime.register_coordination_session()
+    pub(crate) fn register_coordination_session(&self) -> YdbResult<DriverResourceGuard> {
+        self.state.coordination_sessions.register()
     }
 }

--- a/ydb/src/driver_lifecycle.rs
+++ b/ydb/src/driver_lifecycle.rs
@@ -130,6 +130,7 @@ impl DriverLifecycle {
 impl Drop for DriverLifecycle {
     fn drop(&mut self) {
         if !self.shutdown_completed {
+        if !self.shutdown_completed {
             self.state.start_shutdown();
             tracing::warn!(
                 "YDB driver dropped without completing graceful shutdown; call Client::shutdown().await before dropping it"

--- a/ydb/src/driver_lifecycle.rs
+++ b/ydb/src/driver_lifecycle.rs
@@ -130,6 +130,7 @@ impl DriverLifecycle {
 impl Drop for DriverLifecycle {
     fn drop(&mut self) {
         if !self.shutdown_completed {
+            self.state.start_shutdown();
             tracing::warn!(
                 "YDB driver dropped without completing graceful shutdown; call Client::shutdown().await before dropping it"
             );

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -39,7 +39,6 @@ pub(crate) mod client_common;
 pub(crate) mod client_coordination;
 #[cfg(test)]
 mod client_directory_test_integration;
-mod client_lifetime;
 pub(crate) mod client_operation;
 pub(crate) mod client_query;
 pub(crate) mod client_scheme;
@@ -50,6 +49,7 @@ pub(crate) mod client_topic;
 pub(crate) mod connection_pool;
 mod credentials;
 pub(crate) mod discovery;
+mod driver_lifecycle;
 mod errors;
 mod grpc;
 pub(crate) mod grpc_connection_manager;

--- a/ydb/src/lib.rs
+++ b/ydb/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) mod client_common;
 pub(crate) mod client_coordination;
 #[cfg(test)]
 mod client_directory_test_integration;
+mod client_lifetime;
 pub(crate) mod client_operation;
 pub(crate) mod client_query;
 pub(crate) mod client_scheme;

--- a/ydb/src/session_pool/mod.rs
+++ b/ydb/src/session_pool/mod.rs
@@ -11,8 +11,3 @@ pub use pool::{SessionPoolSettings, SessionPoolStats};
 pub(crate) use pool::{SessionPool, SessionPoolLease};
 
 pub(crate) use table_pool::TableSessionPool;
-
-/// Default session pool settings for a newly created [`crate::Client`].
-pub fn default_session_pool_settings() -> SessionPoolSettings {
-    SessionPoolSettings::default()
-}

--- a/ydb/src/session_pool/pool.rs
+++ b/ydb/src/session_pool/pool.rs
@@ -51,7 +51,7 @@ pub struct SessionPoolSettings {
     /// Default is **50** (ydb-go-sdk parity). The legacy table-only pool defaulted to **1000**;
     /// after upgrading, callers that relied on the old default should set
     /// `SessionPoolSettings::new().with_limit(1000)` explicitly or tune via
-    /// [`crate::Client::with_session_pool`].
+    /// [`crate::ClientBuilder::with_session_pool`].
     ///
     /// Normalized to at least 1 when a pool is created (`with_limit` and pool constructors
     /// apply the same rule).
@@ -331,21 +331,12 @@ impl SessionPool {
         Self { inner }
     }
 
-    #[instrument(name = "ydb.SessionPool.Initialize", skip_all, fields(db.system.name = "ydb"), err)]
-    pub async fn new_explicit(
-        connection_manager: GrpcConnectionManager,
-        discovery: Arc<dyn Discovery>,
-        settings: SessionPoolSettings,
-    ) -> YdbResult<Self> {
-        let settings = normalize_pool_settings(settings);
-        let warm_up = settings.warm_up;
-        let pool = Self::new_explicit_sync(connection_manager, discovery, settings);
-
+    pub(crate) async fn warm_up(&self) -> YdbResult<()> {
+        let warm_up = self.inner.settings.warm_up;
         if warm_up > 0 {
-            SessionPoolInner::warm_up_parallel(pool.inner.clone(), warm_up).await?;
+            SessionPoolInner::warm_up_parallel(self.inner.clone(), warm_up).await?;
         }
-
-        Ok(pool)
+        Ok(())
     }
 
     pub fn stats(&self) -> SessionPoolStats {
@@ -782,15 +773,6 @@ mod unit_tests {
         });
         assert_eq!(settings.limit, 1);
         assert_eq!(settings.warm_up, 1);
-    }
-
-    #[test]
-    fn default_session_pool_settings_matches_driver() {
-        use crate::session_pool::default_session_pool_settings;
-        assert_eq!(
-            default_session_pool_settings().limit,
-            SessionPoolSettings::default().limit
-        );
     }
 
     #[test]

--- a/ydb/src/test_integration_helper.rs
+++ b/ydb/src/test_integration_helper.rs
@@ -56,9 +56,10 @@ pub(crate) async fn create_client_with_session_pool(
 ) -> YdbResult<Arc<Client>> {
     let client = test_client_builder()
         .with_executor(Arc::new(InplaceExecutor))
+        .with_session_pool(settings)
         .build()
         .await?;
-    Ok(Arc::new(client.with_session_pool(settings).await?))
+    Ok(Arc::new(client))
 }
 
 async fn connect(executor: Arc<dyn Executor>) -> YdbResult<Arc<Client>> {

--- a/ydb/src/topics_compression_test.rs
+++ b/ydb/src/topics_compression_test.rs
@@ -133,7 +133,7 @@ where
     W: FnOnce(String) -> TopicWriterOptions,
     R: FnOnce(String, String) -> TopicReaderOptions,
 {
-    let (mut topic_client, topic_path, consumer_name) =
+    let (_client, mut topic_client, topic_path, consumer_name) =
         topic_setup(test_name, supported_codecs).await?;
 
     let writer = topic_client
@@ -167,7 +167,10 @@ where
     Ok(())
 }
 
-async fn topic_setup(name: &str, codecs: &[Codec]) -> YdbResult<(TopicClient, String, String)> {
+async fn topic_setup(
+    name: &str,
+    codecs: &[Codec],
+) -> YdbResult<(Arc<Client>, TopicClient, String, String)> {
     let client = create_client().await?;
     setup_topic(name, codecs, client).await
 }
@@ -176,7 +179,7 @@ async fn setup_topic(
     name: &str,
     codecs: &[Codec],
     client: Arc<Client>,
-) -> YdbResult<(TopicClient, String, String)> {
+) -> YdbResult<(Arc<Client>, TopicClient, String, String)> {
     let topic_path = format!("{}/{name}", client.database());
     let consumer_name = format!("test-consumer-{name}");
 
@@ -202,14 +205,14 @@ async fn setup_topic(
 
     trace!("topic created");
 
-    Ok((topic_client, topic_path, consumer_name))
+    Ok((client, topic_client, topic_path, consumer_name))
 }
 
 #[tokio::test]
 #[traced_test]
 #[ignore] // need YDB access
 async fn codec_fail_fast() -> YdbResult<()> {
-    let (mut topic_client, topic_path, consumer_name) =
+    let (_client, mut topic_client, topic_path, consumer_name) =
         topic_setup("codec_fail_fast_write", &[Codec::RAW, Codec::INV]).await?;
 
     let success_count = 10;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
- Client have API to clone himself
- Client have API to change SessionPool in runtime
- CoordinationSession does not stop work on Drop
- Even if Driver (root Client) is dropped, other factories (TopicClient, TableClient, ...) can produce new resource-acquiring entities. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #560

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Client API is changed: settings of SessionPool are moved to ClientBuilder, changing RetrySettings does not clone Client
- CoordinationSession implements Drop to stop background workers
- Implemented safe-way ClientLifetime. Each client factory is stored inside wrapper, which allows obtain inner factory object only with checking the Driver lifetime status. 
- Each resource-aware entity (Topic Writer/Reader, CoordinationSessions) is counter. Shutting down the Driver while any of them is alive ends with descriptive error -- which resources are still alive. 
- Dropping driver without shutting down emits warning.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
