### PR TITLE
refactor(errors): make status policies explicit

### DIFF
--- a/ydb/src/client_query/exec.rs
+++ b/ydb/src/client_query/exec.rs
@@ -764,11 +764,11 @@ mod unit_tests {
         ctx.tx_id = Some("tx-1".into());
         transaction_handle_query_error(
             &mut ctx,
-            &YdbError::YdbStatusError(crate::errors::YdbStatusError {
-                message: "bad".into(),
-                operation_status: StatusCode::GenericError as i32,
-                issues: vec![],
-            }),
+            &YdbError::YdbStatusError(crate::errors::YdbStatusError::new(
+                "bad",
+                StatusCode::GenericError as i32,
+                vec![],
+            )),
         );
         assert!(!ctx.state.is_active());
         assert!(ctx.tx_id.is_none());

--- a/ydb/src/client_query/mod.rs
+++ b/ydb/src/client_query/mod.rs
@@ -606,11 +606,11 @@ mod unit_tests {
         tx.ctx.pooled_lease = Some(lease);
         exec::transaction_handle_query_error(
             &mut tx.ctx,
-            &YdbError::YdbStatusError(YdbStatusError {
-                message: "transaction failed".to_string(),
-                operation_status: status as i32,
-                issues: Vec::new(),
-            }),
+            &YdbError::YdbStatusError(YdbStatusError::new(
+                "transaction failed",
+                status as i32,
+                Vec::new(),
+            )),
         );
         assert!(matches!(tx.ctx.state, TxState::Invalidated(_)));
         (tx, session_id)

--- a/ydb/src/errors.rs
+++ b/ydb/src/errors.rs
@@ -1,5 +1,3 @@
-use crate::errors::NeedRetry::IdempotentOnly;
-
 use crate::grpc_wrapper::raw_errors::RawError;
 use http::Uri;
 use std::fmt::{Debug, Display, Formatter};
@@ -86,11 +84,14 @@ impl From<YdbError> for YdbOrCustomerError {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum NeedRetry {
-    True,           // operation guarantee to not completed, error is temporary, need retry
-    IdempotentOnly, // operation in unknown state - it may be completed or not, error temporary. Operation may be auto retry for idempotent operations only.
-    False, // operation is completed or error is stable (for example yql syntax error) and no need retry
+    /// The operation is guaranteed not to have completed and may be retried.
+    True,
+    /// The operation may have completed and may only be retried when it is idempotent.
+    IdempotentOnly,
+    /// The error is stable or is not documented as safe to retry.
+    False,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -203,9 +204,34 @@ pub struct YdbStatusError {
     ///
     /// It describe internal errors, warnings, etc more detail then operation_status or message.
     pub issues: Vec<YdbIssue>,
+
+    /// Context-specific retry classification overriding the default status-code policy.
+    ///
+    /// `None` uses the documented YDB status-code policy.
+    pub(crate) need_retry: Option<NeedRetry>,
+
+    /// Context-specific session-discard decision overriding the default status-code policy.
+    ///
+    /// `None` uses the documented YDB status-code policy.
+    pub(crate) requires_session_discard: Option<bool>,
 }
 
 impl YdbStatusError {
+    /// Creates a status error using the documented retry and session-discard policies.
+    pub(crate) fn new(
+        message: impl Into<String>,
+        operation_status: i32,
+        issues: Vec<YdbIssue>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            operation_status,
+            issues,
+            need_retry: None,
+            requires_session_discard: None,
+        }
+    }
+
     /// Got typed operation status or error
     ///
     /// ```
@@ -344,92 +370,147 @@ impl YdbError {
             | Self::InternalError(_) => false,
             Self::TransportDial(_) | Self::Transport(_) | Self::DeadlineExceeded => true,
             Self::TransportGRPCStatus(status) => {
-                use tonic::Code;
+                use tonic::Code::*;
 
-                // Match go-sdk `xerrors.MustDeleteTableOrQuerySession`: these gRPC
-                // transport failures can leave server-side query or transaction work in
-                // flight, so the session must not be reused.
+                // Keep this match in the order of the YDB "Recreate session" table:
+                // https://ydb.tech/docs/en/reference/ydb-sdk/grpc-status-codes
                 match status.code() {
-                    Code::Ok | Code::ResourceExhausted | Code::OutOfRange => false,
-                    Code::Cancelled
-                    | Code::Unknown
-                    | Code::InvalidArgument
-                    | Code::DeadlineExceeded
-                    | Code::NotFound
-                    | Code::AlreadyExists
-                    | Code::PermissionDenied
-                    | Code::FailedPrecondition
-                    | Code::Aborted
-                    | Code::Unimplemented
-                    | Code::Internal
-                    | Code::Unavailable
-                    | Code::DataLoss
-                    | Code::Unauthenticated => true,
+                    Ok => false,
+                    Cancelled => true,
+                    Unknown => true,
+                    InvalidArgument => true,
+                    DeadlineExceeded => true,
+                    NotFound => true,
+                    AlreadyExists => true,
+                    PermissionDenied => true,
+                    ResourceExhausted => false,
+                    FailedPrecondition => true,
+                    Aborted => true,
+                    OutOfRange => false,
+                    Unimplemented => true,
+                    Internal => true,
+                    Unavailable => true,
+                    DataLoss => true,
+                    Unauthenticated => true,
                 }
             }
-            Self::YdbStatusError(status) => match StatusCode::try_from(status.operation_status) {
-                Ok(
-                    StatusCode::BadSession | StatusCode::SessionBusy | StatusCode::SessionExpired,
-                ) => true,
-                Ok(
-                    StatusCode::Unspecified
-                    | StatusCode::Success
-                    | StatusCode::BadRequest
-                    | StatusCode::Unauthorized
-                    | StatusCode::InternalError
-                    | StatusCode::Aborted
-                    | StatusCode::Unavailable
-                    | StatusCode::Overloaded
-                    | StatusCode::SchemeError
-                    | StatusCode::GenericError
-                    | StatusCode::Timeout
-                    | StatusCode::PreconditionFailed
-                    | StatusCode::AlreadyExists
-                    | StatusCode::NotFound
-                    | StatusCode::Cancelled
-                    | StatusCode::Undetermined
-                    | StatusCode::Unsupported
-                    | StatusCode::ExternalError,
-                ) => false,
-                // An unknown server status is not evidence that the session is reusable.
-                Err(_) => true,
-            },
+            Self::YdbStatusError(status) => {
+                if let Some(requires_discard) = status.requires_session_discard {
+                    return requires_discard;
+                }
+
+                let Ok(status) = StatusCode::try_from(status.operation_status) else {
+                    // An unknown server status is not evidence that the session is reusable.
+                    return true;
+                };
+                use StatusCode::*;
+
+                // Keep this match in the order of the YDB "Recreate session" table:
+                // https://ydb.tech/docs/en/reference/ydb-sdk/ydb-status-codes
+                match status {
+                    Success => false,
+                    BadRequest => false,
+                    Unauthorized => false,
+                    InternalError => false,
+                    Aborted => false,
+                    Unavailable => false,
+                    Overloaded => false,
+                    SchemeError => false,
+                    GenericError => false,
+                    Timeout => false,
+                    BadSession => true,
+                    PreconditionFailed => false,
+                    AlreadyExists => false,
+                    NotFound => false,
+                    SessionExpired => true,
+                    Cancelled => false,
+                    Undetermined => false,
+                    Unsupported => false,
+                    SessionBusy => true,
+                    ExternalError => false,
+                    Unspecified => false,
+                }
+            }
         }
     }
 
     pub(crate) fn need_retry(&self) -> NeedRetry {
+        use NeedRetry::*;
+
         match self {
             Self::Convert(_)
             | Self::Custom(_)
             | Self::InternalError(_)
             | Self::NoRows
-            | Self::EndpointHasNoHost(_) => NeedRetry::False,
-            Self::TransportDial(_) => NeedRetry::True,
-            Self::Transport(_) | Self::DeadlineExceeded => IdempotentOnly, // TODO: check when transport error created
+            | Self::EndpointHasNoHost(_) => False,
+            Self::TransportDial(_) => True,
+            Self::Transport(_) | Self::DeadlineExceeded => IdempotentOnly,
             Self::TransportGRPCStatus(status) => {
-                use tonic::Code;
+                use tonic::Code::*;
+
+                // Keep this match in the order of the YDB retry table:
+                // https://ydb.tech/docs/en/reference/ydb-sdk/grpc-status-codes
                 match status.code() {
-                    Code::Aborted | Code::ResourceExhausted => NeedRetry::True,
-                    Code::Internal | Code::Cancelled | Code::Unavailable | Code::Unknown => {
-                        NeedRetry::IdempotentOnly
-                    }
-                    _ => NeedRetry::False,
+                    Ok => False,
+                    Cancelled => IdempotentOnly,
+                    // tonic-generated clients create a new UNKNOWN status for `Service::ready()`
+                    // failures and retain only the formatted message, so the original failure
+                    // cannot be distinguished reliably from a server-returned UNKNOWN:
+                    // https://github.com/grpc/grpc-rust/blob/v0.14.2/tonic-build/src/client.rs#L239-L242
+                    // tonic deliberately retains UNKNOWN for transport failures:
+                    // https://github.com/grpc/grpc-rust/issues/2488
+                    Unknown => IdempotentOnly,
+                    InvalidArgument => False,
+                    DeadlineExceeded => IdempotentOnly,
+                    NotFound => False,
+                    AlreadyExists => False,
+                    PermissionDenied => False,
+                    ResourceExhausted => True,
+                    FailedPrecondition => False,
+                    Aborted => True,
+                    OutOfRange => False,
+                    Unimplemented => False,
+                    Internal => IdempotentOnly,
+                    Unavailable => IdempotentOnly,
+                    DataLoss => False,
+                    Unauthenticated => False,
                 }
             }
-            Self::YdbStatusError(ydb_err) => {
-                let Ok(status) = StatusCode::try_from(ydb_err.operation_status) else {
-                    return NeedRetry::False;
-                };
+            Self::YdbStatusError(status) => {
+                if let Some(need_retry) = status.need_retry {
+                    return need_retry;
+                }
 
+                let Ok(status) = StatusCode::try_from(status.operation_status) else {
+                    // An unknown server status is not documented as safe to retry.
+                    return False;
+                };
+                use StatusCode::*;
+
+                // Keep this match in the order of the YDB retry table:
+                // https://ydb.tech/docs/en/reference/ydb-sdk/ydb-status-codes
                 match status {
-                    StatusCode::Aborted
-                    | StatusCode::Unavailable
-                    | StatusCode::Overloaded
-                    | StatusCode::BadSession
-                    | StatusCode::SessionExpired
-                    | StatusCode::SessionBusy => NeedRetry::True,
-                    StatusCode::Undetermined => NeedRetry::IdempotentOnly,
-                    _ => NeedRetry::False,
+                    Success => False,
+                    BadRequest => False,
+                    Unauthorized => False,
+                    InternalError => False,
+                    Aborted => True,
+                    Unavailable => True,
+                    Overloaded => True,
+                    SchemeError => False,
+                    GenericError => False,
+                    Timeout => IdempotentOnly,
+                    BadSession => True,
+                    PreconditionFailed => False,
+                    AlreadyExists => False,
+                    NotFound => False,
+                    SessionExpired => True,
+                    Cancelled => False,
+                    Undetermined => IdempotentOnly,
+                    Unsupported => False,
+                    SessionBusy => True,
+                    ExternalError => False,
+                    Unspecified => False,
                 }
             }
         }
@@ -438,7 +519,7 @@ impl YdbError {
     pub(crate) fn is_retriable(&self, idempotency: Idempotency) -> bool {
         match self.need_retry() {
             NeedRetry::True => true,
-            IdempotentOnly => idempotency.is_idempotent(),
+            NeedRetry::IdempotentOnly => idempotency.is_idempotent(),
             NeedRetry::False => false,
         }
     }
@@ -483,11 +564,7 @@ mod error_classification_tests {
     use ydb_grpc::ydb_proto::status_ids::StatusCode;
 
     fn ydb_status(status: StatusCode) -> YdbError {
-        YdbError::YdbStatusError(YdbStatusError {
-            message: "test".into(),
-            operation_status: status as i32,
-            issues: vec![],
-        })
+        YdbError::YdbStatusError(YdbStatusError::new("test", status as i32, vec![]))
     }
 
     #[test]
@@ -513,11 +590,7 @@ mod error_classification_tests {
 
     #[test]
     fn unknown_status_code_does_not_invalidate() {
-        let err = YdbError::YdbStatusError(YdbStatusError {
-            message: "unknown".into(),
-            operation_status: -1,
-            issues: vec![],
-        });
+        let err = YdbError::YdbStatusError(YdbStatusError::new("unknown", -1, vec![]));
         assert!(!err.invalidates_server_transaction());
     }
 
@@ -555,11 +628,7 @@ mod error_classification_tests {
 
     #[test]
     fn unknown_operation_status_discards_session_conservatively() {
-        let err = YdbError::YdbStatusError(YdbStatusError {
-            message: "unknown".into(),
-            operation_status: -1,
-            issues: vec![],
-        });
+        let err = YdbError::YdbStatusError(YdbStatusError::new("unknown", -1, vec![]));
         assert!(err.requires_session_discard());
     }
 }

--- a/ydb/src/grpc_wrapper/grpc.rs
+++ b/ydb/src/grpc_wrapper/grpc.rs
@@ -11,11 +11,11 @@ pub(crate) fn grpc_check_status<T>(operation: &impl YdbGrpcStatus<T>) -> RawResu
         let issues = operation.issues()?;
         let issues = issues.to_vec();
 
-        Err(RawError::YdbStatus(crate::errors::YdbStatusError {
-            message: format!("{:?}", operation),
-            operation_status: status.into(),
-            issues: proto_issues_to_ydb_issues(issues),
-        }))
+        Err(RawError::YdbStatus(crate::errors::YdbStatusError::new(
+            format!("{:?}", operation),
+            status.into(),
+            proto_issues_to_ydb_issues(issues),
+        )))
     } else {
         Ok(())
     }
@@ -47,11 +47,11 @@ where
 }
 
 pub(crate) fn create_operation_error(op: ydb_grpc::ydb_proto::operations::Operation) -> RawError {
-    RawError::YdbStatus(crate::errors::YdbStatusError {
-        message: format!("{:?}", op),
-        operation_status: op.status,
-        issues: proto_issues_to_ydb_issues(op.issues),
-    })
+    RawError::YdbStatus(crate::errors::YdbStatusError::new(
+        format!("{:?}", op),
+        op.status,
+        proto_issues_to_ydb_issues(op.issues),
+    ))
 }
 
 pub(crate) fn proto_issues_to_ydb_issues(proto_issues: Vec<IssueMessage>) -> Vec<YdbIssue> {

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/acquire_semaphore.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/acquire_semaphore.rs
@@ -84,11 +84,11 @@ impl TryFrom<AcquireSemaphoreResult> for RawAcquireSemaphoreResult {
 
     fn try_from(value: AcquireSemaphoreResult) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
         Ok(RawAcquireSemaphoreResult {
             req_id: value.req_id,

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/create_semaphore.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/create_semaphore.rs
@@ -69,11 +69,11 @@ impl TryFrom<CreateSemaphoreResult> for RawCreateSemaphoreResult {
 
     fn try_from(value: CreateSemaphoreResult) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
         Ok(RawCreateSemaphoreResult {
             req_id: value.req_id,

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/delete_semaphore.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/delete_semaphore.rs
@@ -66,11 +66,11 @@ impl TryFrom<DeleteSemaphoreResult> for RawDeleteSemaphoreResult {
 
     fn try_from(value: DeleteSemaphoreResult) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
         Ok(RawDeleteSemaphoreResult {
             req_id: value.req_id,

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/describe_semaphore.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/describe_semaphore.rs
@@ -134,11 +134,11 @@ impl TryFrom<DescribeSemaphoreResult> for RawDescribeSemaphoreResult {
 
     fn try_from(value: DescribeSemaphoreResult) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
         let description = value
             .semaphore_description

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/mod.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/mod.rs
@@ -50,11 +50,13 @@ impl TryFrom<SessionResponse> for RawSessionResponse {
         match response {
             session_response::Response::Ping(ping) => Ok(RawSessionResponse::Ping(ping)),
             session_response::Response::Pong(pong) => Ok(RawSessionResponse::Pong(pong)),
-            session_response::Response::Failure(fail) => Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(), // TODO: what message?
-                operation_status: fail.status,
-                issues: proto_issues_to_ydb_issues(fail.issues),
-            })),
+            session_response::Response::Failure(fail) => {
+                Err(RawError::YdbStatus(YdbStatusError::new(
+                    "", // TODO: what message?
+                    fail.status,
+                    proto_issues_to_ydb_issues(fail.issues),
+                )))
+            }
             session_response::Response::SessionStarted(started) => {
                 Ok(RawSessionResponse::SessionStarted(started))
             }

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/release_semaphore.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/release_semaphore.rs
@@ -61,11 +61,11 @@ impl TryFrom<ReleaseSemaphoreResult> for RawReleaseSemaphoreResult {
 
     fn try_from(value: ReleaseSemaphoreResult) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
         Ok(RawReleaseSemaphoreResult {
             req_id: value.req_id,

--- a/ydb/src/grpc_wrapper/raw_coordination_service/session/update_semaphore.rs
+++ b/ydb/src/grpc_wrapper/raw_coordination_service/session/update_semaphore.rs
@@ -66,11 +66,11 @@ impl TryFrom<UpdateSemaphoreResult> for RawUpdateSemaphoreResult {
 
     fn try_from(value: UpdateSemaphoreResult) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
         Ok(RawUpdateSemaphoreResult {
             req_id: value.req_id,

--- a/ydb/src/grpc_wrapper/raw_operation_service/status.rs
+++ b/ydb/src/grpc_wrapper/raw_operation_service/status.rs
@@ -8,11 +8,11 @@ pub(crate) fn check_status(status: i32, issues: &[IssueMessage]) -> RawResult<()
     let code = StatusCode::try_from(status)
         .map_err(|e| RawError::custom(format!("unknown status code: {e}")))?;
     if code != StatusCode::Success {
-        return Err(RawError::YdbStatus(YdbStatusError {
-            message: format!("operation service status: {code:?}"),
-            operation_status: status,
-            issues: proto_issues_to_ydb_issues(issues.to_vec()),
-        }));
+        return Err(RawError::YdbStatus(YdbStatusError::new(
+            format!("operation service status: {code:?}"),
+            status,
+            proto_issues_to_ydb_issues(issues.to_vec()),
+        )));
     }
     Ok(())
 }

--- a/ydb/src/grpc_wrapper/raw_query_service/status.rs
+++ b/ydb/src/grpc_wrapper/raw_query_service/status.rs
@@ -8,11 +8,11 @@ pub(crate) fn check_status(status: i32, issues: &[IssueMessage]) -> RawResult<()
     let code = StatusCode::try_from(status)
         .map_err(|e| RawError::custom(format!("unknown status code: {e}")))?;
     if code != StatusCode::Success {
-        return Err(RawError::YdbStatus(YdbStatusError {
-            message: format!("query operation status: {code:?}"),
-            operation_status: status,
-            issues: proto_issues_to_ydb_issues(issues.to_vec()),
-        }));
+        return Err(RawError::YdbStatus(YdbStatusError::new(
+            format!("query operation status: {code:?}"),
+            status,
+            proto_issues_to_ydb_issues(issues.to_vec()),
+        )));
     }
     Ok(())
 }

--- a/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/stream_read/messages.rs
@@ -77,11 +77,11 @@ impl TryFrom<stream_read_message::FromServer> for RawFromServer {
 
     fn try_from(value: FromServer) -> Result<Self, Self::Error> {
         if value.status != StatusCode::Success as i32 {
-            return Err(RawError::YdbStatus(YdbStatusError {
-                message: "".to_string(),
-                operation_status: value.status,
-                issues: proto_issues_to_ydb_issues(value.issues),
-            }));
+            return Err(RawError::YdbStatus(YdbStatusError::new(
+                "",
+                value.status,
+                proto_issues_to_ydb_issues(value.issues),
+            )));
         }
 
         let message = value.server_message.ok_or(RawError::Custom(

--- a/ydb/src/grpc_wrapper/raw_topic_service/stream_write/mod.rs
+++ b/ydb/src/grpc_wrapper/raw_topic_service/stream_write/mod.rs
@@ -20,11 +20,11 @@ pub(crate) enum RawServerMessage {
 }
 
 pub(crate) fn create_server_status_error(message: FromServer) -> RawError {
-    RawError::YdbStatus(crate::errors::YdbStatusError {
-        message: "".to_string(), // TODO: what message?
-        operation_status: message.status,
-        issues: proto_issues_to_ydb_issues(message.issues),
-    })
+    RawError::YdbStatus(crate::errors::YdbStatusError::new(
+        "", // TODO: what message?
+        message.status,
+        proto_issues_to_ydb_issues(message.issues),
+    ))
 }
 
 impl TryFrom<FromServer> for RawServerMessage {

--- a/ydb/src/session_pool/session.rs
+++ b/ydb/src/session_pool/session.rs
@@ -106,14 +106,14 @@ impl AttachedSession {
         if self.is_healthy() {
             Ok(())
         } else {
-            Err(YdbError::YdbStatusError(YdbStatusError {
-                message: format!(
+            Err(YdbError::YdbStatusError(YdbStatusError::new(
+                format!(
                     "query session {} is not healthy",
                     self.resource.identity.session_id
                 ),
-                operation_status: StatusCode::BadSession as i32,
-                issues: Vec::new(),
-            }))
+                StatusCode::BadSession as i32,
+                Vec::new(),
+            )))
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Errors explicitly follows official YDB error code descriptions:
https://ydb.tech/docs/en/reference/ydb-sdk/ydb-status-codes?version=v26.1
https://ydb.tech/docs/en/reference/ydb-sdk/grpc-status-codes?version=v26.1

Added feature to overload the default policy of session discard/retry to Error containing YdbResultCode.
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
