### PR TITLE
test(query): remove the scheduling race from the cleanup session assertion

### DIFF
--- a/ydb/tests/query_tx.rs
+++ b/ydb/tests/query_tx.rs
@@ -21,8 +21,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use ydb::{
-    Client, ClientBuilder, Transaction, YdbError, YdbOrCustomerError, YdbResult, YdbStatusError,
-    closure,
+    Client, ClientBuilder, SessionPoolSettings, Transaction, YdbError, YdbOrCustomerError,
+    YdbResult, YdbStatusError, closure,
 };
 use ydb_grpc::ydb_proto::query::{
     CommitTransactionResponse, ExecuteQueryResponsePart, RollbackTransactionResponse,
@@ -43,6 +43,21 @@ async fn make_client(server: &MockServer) -> YdbResult<Client> {
     ))?
     .build()
     .await
+}
+
+/// A client whose session pool holds exactly one session.
+///
+/// Cleanup after a failed transaction runs in a detached task (`spawn_pool_release`) and returns
+/// the session only once the rollback RPC has answered, while `retry_tx` starts the next attempt
+/// straight away. With the default pool the next attempt simply creates a second session whenever
+/// it wins that race, so an assertion on session reuse depends on task scheduling. A pool of one
+/// removes the race: the next attempt has no permit to take and waits for the cleanup to hand the
+/// session back, which is the behaviour under test.
+async fn make_client_with_single_session(server: &MockServer) -> YdbResult<Client> {
+    make_client(server)
+        .await?
+        .with_session_pool(SessionPoolSettings::new().with_limit(1))
+        .await
 }
 
 fn success_part(tx_id: Option<&str>) -> ExecuteQueryResponsePart {
@@ -419,7 +434,7 @@ async fn definitive_commit_failure_retries_whole_transaction() -> YdbResult<()> 
     let (handler, tx_lifecycle) =
         ScriptedCommitHandler::new(vec![StatusCode::Aborted, StatusCode::Success]);
     let (server, _reply_tx) = MockServer::start(handler).await;
-    let client = make_client(&server).await?;
+    let client = make_client_with_single_session(&server).await?;
 
     let result = client
         .query_client()


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

`definitive_commit_failure_retries_whole_transaction`, added in #621 (`b7696b5`), is racy. It failed the `tests (RUST_VERSION_MODERN)` leg of #588, a PR that does not touch this code:

```
---- definitive_commit_failure_retries_whole_transaction stdout ----
thread 'definitive_commit_failure_retries_whole_transaction' panicked at ydb/tests/query_tx.rs:435:5:
assertion `left == right` failed: successful rollback cleanup must return the session for retry
  left: 2
 right: 1
```

In that run the MSRV (1.88) and the stable/latest-deps legs passed; only 1.96 failed. Reported in #621.

### Why it races

Cleanup after a failed commit is a detached task — `ydb/src/client_query/exec.rs`:

```rust
spawn_pool_release(async move {
    let rollback = client.rollback_transaction(&session_id, tx_id.as_str()).map_err(YdbError::from);
    finish_rollback_cleanup(lease, cleanup_timeout, rollback).await;
});
```

and the lease goes back only after the rollback RPC has answered:

```rust
if matches!(timeout(cleanup_timeout, rollback).await, Ok(Ok(()))) {
    lease.return_to_pool();
}
```

`retry_tx` does not wait for that task — the next attempt asks the pool for a session straight away. Two outcomes, both legal:

- the detached task returned the lease first → the attempt reuses the session → `create_session_count == 1`;
- the attempt got there first → the pool is empty → `CreateSession` → **2**.

`wait_for_rollback_count(&tx_lifecycle, 1)` does not order this. It runs after `retry_tx` has already returned, so the second attempt has long since taken or created its session, and it only observes that the mock received the rollback. The test uses `#[tokio::test]`, i.e. the current-thread runtime, so the outcome comes down to which ready task the scheduler polls first.

### Reproducing it

Deterministically, on master, by delaying the detached task in `handle_commit_error`:

```rust
spawn_pool_release(async move {
    tokio::time::sleep(Duration::from_millis(50)).await; // force the retry to win
    let rollback = client.rollback_transaction(&session_id, tx_id.as_str())
```

With that delay the test fails on every run with exactly `left: 2, right: 1`.

Without it, the failure needs a slow enough machine. It did not reproduce locally in 330 runs — 320 of the single test (8 concurrent workers), 25 of the whole `query_tx` binary, and 10 under `cargo llvm-cov` with the same instrumentation CI uses.

## What is the new behavior?

- The test takes a client whose session pool holds a single session, through a `make_client_with_single_session` helper that documents why the limit is there.
- The second attempt then has no permit to take and has to wait for the cleanup to hand the session back — which is exactly the behaviour the assertion is about, so `create_session_count == 1` holds regardless of how the tasks are scheduled.
- The assertion itself is unchanged: the intent of #621 is kept, only the race is removed. No production code is touched.

```rust
async fn make_client_with_single_session(server: &MockServer) -> YdbResult<Client> {
    make_client(server)
        .await?
        .with_session_pool(SessionPoolSettings::new().with_limit(1))
        .await
}
```

## Other information

Verification:

```
cargo test -p ydb --test query_tx     # 23 passed
cargo fmt --all
cargo clippy --workspace --all-targets --no-deps --exclude=ydb-grpc -- -D warnings
```

The fix was checked against the failure, not only against a green run: with the 50 ms delay above still in place, the test passes. That is what tells the race apart from a machine that happens to be fast enough.

An alternative would be to drop the `create_session_count` assertion from the integration test and cover the invariant next to `finish_rollback_cleanup`, where `rollback_cleanup_timeout_discards_session_and_releases_pool_permit` already covers the failure path. That trades an end-to-end assertion for a unit one; the single-session pool keeps both.
